### PR TITLE
feat(mainnav): allow nav items to be added from far right and include…

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             --sgds-masthead-text-color: red;
         }
         sgds-mainnav-item {
-            --sgds-mainnav-item-theme-color:red;
+            --mainnav-item-theme-color:red;
         }
 
         body {
@@ -69,11 +69,16 @@
 </head>
 
 <body class="d-flex flex-column min-vh-100">
-    <sgds-mainnav expand="never" mode="offcanvas">
+    <sgds-mainnav>
         <img width="130" src="https://www.designsystem.tech.gov.sg/assets/img/logo-sgds.svg" slot="brand" />
 
         <sgds-mainnav-item href="#">Home</sgds-mainnav-item>
         <sgds-mainnav-item href="#">About</sgds-mainnav-item>
+        <sgds-mainnav-item href="#" slot="end">Info</sgds-mainnav-item>
+        <sgds-mainnav-item href="#" slot="end">Contact Us</sgds-mainnav-item>
+        <sgds-mainnav-item href="#" slot="end">
+            <sgds-button>Login</sgds-button>
+        </sgds-mainnav-item>
         <dev-console-widget slot="non-collapsible" iconColor="black" iconWidth="28px" iconHeight="28px"></dev-console-widget>
     </sgds-mainnav>
 

--- a/index.html
+++ b/index.html
@@ -76,9 +76,7 @@
         <sgds-mainnav-item href="#">About</sgds-mainnav-item>
         <sgds-mainnav-item href="#" slot="end">Info</sgds-mainnav-item>
         <sgds-mainnav-item href="#" slot="end">Contact Us</sgds-mainnav-item>
-        <sgds-mainnav-item href="#" slot="end">
-            <sgds-button>Login</sgds-button>
-        </sgds-mainnav-item>
+            <sgds-button slot="end">Login</sgds-button>
         <dev-console-widget slot="non-collapsible" iconColor="black" iconWidth="28px" iconHeight="28px"></dev-console-widget>
     </sgds-mainnav>
 

--- a/src/Mainnav/sgds-mainnav.scss
+++ b/src/Mainnav/sgds-mainnav.scss
@@ -2,14 +2,16 @@
 @import "~@govtechsg/sgds/sass/navbar";
 @import "~@govtechsg/sgds/sass/transitions";
 @import "~@govtechsg/sgds/sass/offcanvas";
-
 .navbar-nav {
   display: flex;
   align-self: center;
-  gap: 1rem;
+  gap: 1rem; 
+  padding-left: 1rem;
+  padding-right: 1rem;
   height: 100%;
-  margin-left: 1rem;
+  width:100%;
 }
+
 .navbar-toggler {
   border: none;
 }
@@ -21,4 +23,11 @@ slot[name="non-collapsible"] {
   display: flex;
   gap: 1rem;
   align-items: center;
+}
+
+.slot-end {
+  display: flex;
+  margin-left: auto;
+  align-items: center;
+  gap: 1rem;
 }

--- a/src/Mainnav/sgds-mainnav.scss
+++ b/src/Mainnav/sgds-mainnav.scss
@@ -5,11 +5,11 @@
 .navbar-nav {
   display: flex;
   align-self: center;
-  gap: 1rem; 
+  gap: 1rem;
   padding-left: 1rem;
   padding-right: 1rem;
   height: 100%;
-  width:100%;
+  width: 100%;
 }
 
 .navbar-toggler {
@@ -26,8 +26,13 @@ slot[name="non-collapsible"] {
 }
 
 .slot-end {
-  display: flex;
-  margin-left: auto;
-  align-items: center;
-  gap: 1rem;
+    display: flex;
+    margin-left: auto;
+    align-items: stretch;
+    gap: 1rem;
+
+}
+
+.slot-end::slotted(:not(sgds-mainnav-item)){
+  align-self: center;
 }

--- a/src/Mainnav/sgds-mainnav.ts
+++ b/src/Mainnav/sgds-mainnav.ts
@@ -12,6 +12,7 @@ import {
   XL_BREAKPOINT,
   XXL_BREAKPOINT,
 } from "../utils/breakpoints";
+import { classMap } from "lit/directives/class-map.js";
 
 export type MainnavExpandSize =
   | "sm"
@@ -154,6 +155,7 @@ export class SgdsMainnav extends SgdsElement {
         >
           <ul class="navbar-nav">
             <slot></slot>
+            <slot name="end" class=${classMap({"slot-end": !this.breakpointReached})}></slot>
           </ul>
         </div>
       </nav>

--- a/stories/MainNav.stories.mdx
+++ b/stories/MainNav.stories.mdx
@@ -52,14 +52,20 @@ import { partDescription } from "./common";
       },
     },
     brand: {
-      description:
-        "Brand slot of SgdsMainnav. Pass in brand logo or img here",
+      description: "Brand slot of SgdsMainnav. Pass in brand logo or img here",
       table: {
         category: "slot: SgdsMainnav",
       },
     },
     "non-collapsible": {
       description: "Elements in this slot will not be collapsed",
+      table: {
+        category: "slot: SgdsMainnav",
+      },
+    },
+    end: {
+      description:
+        "Elements in this slot will be positioned to the right end of .navbar-nav. Elements in this slot will also be included in collapsed menu",
       table: {
         category: "slot: SgdsMainnav",
       },
@@ -113,6 +119,8 @@ export const Template = ({ expand, brandHref, collapseId, active, href }) => {
         >Home (argsTable controlled)
       </sgds-mainnav-item>
       <sgds-mainnav-item href="#">About</sgds-mainnav-item>
+      <sgds-mainnav-item href="#" slot="end">Contact Us</sgds-mainnav-item>
+        <sgds-button slot="end">Login</sgds-button>
       <dev-console-widget
         slot="non-collapsible"
         iconColor="black"
@@ -129,14 +137,13 @@ export const Template = ({ expand, brandHref, collapseId, active, href }) => {
   <Story name="Basic">{Template.bind({})}</Story>
 </Canvas>
 
-
 ## API
 
 ```jsx
 import {
   SgdsMainnav,
   SgdsMainnavItem,
-  MainNavExpandSize
+  MainNavExpandSize,
 } from "@govtechsg/sgds-web-component/MainNav";
 ```
 
@@ -144,6 +151,6 @@ import {
 
 ## CSS Custom Properties
 
-| Name                         | Description                                                                                                      |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Name                         | Description                                                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--mainnav-item-theme-color` | Sets color of hovered/active text and bottom-border of`<sgds-mainnav-item/>` Default to sgds primary color (#5925DC). |

--- a/stories/MainNav.stories.mdx
+++ b/stories/MainNav.stories.mdx
@@ -120,7 +120,7 @@ export const Template = ({ expand, brandHref, collapseId, active, href }) => {
       </sgds-mainnav-item>
       <sgds-mainnav-item href="#">About</sgds-mainnav-item>
       <sgds-mainnav-item href="#" slot="end">Contact Us</sgds-mainnav-item>
-        <sgds-button slot="end">Login</sgds-button>
+      <sgds-button slot="end">Login</sgds-button>
       <dev-console-widget
         slot="non-collapsible"
         iconColor="black"

--- a/test/mainnav.test.ts
+++ b/test/mainnav.test.ts
@@ -62,6 +62,8 @@ describe("sgds-mainnav", () => {
          <ul class="navbar-nav">
            <slot>
            </slot>
+          <slot name="end">
+          </slot>
          </ul>
        </div>
     `
@@ -142,11 +144,12 @@ describe("sgds-mainnav", () => {
   // initial window.innerWidth = 800 
   // LG_BREAKPOINT = 992 
   // since window.innerWidth < LG_BREAKPOINT --> expect non-collapsible slot to be .order-2 (see first test)
-  it('when expand=lg and window resize event occurs to above breakpoint, it changes order of non-collapsible slot, ', async() => {
+  it('when expand=lg and window resize event occurs to above breakpoint, it changes order of non-collapsible slot, and end slot has class .slot-end', async() => {
     const el = await fixture<SgdsMainnav>(
       html`<sgds-mainnav expand="lg"></sgds-mainnav>`
     );
     expect(el.shadowRoot?.querySelector("slot[name='non-collapsible']")).to.have.class('order-2')
+    expect(el.shadowRoot?.querySelector("slot[name='end']")).not.to.have.class('slot-end')
     Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -155,14 +158,17 @@ describe("sgds-mainnav", () => {
    window.dispatchEvent(new Event('resize'));
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-5')
+   expect(el.shadowRoot?.querySelector("slot[name='end']")).to.have.class('slot-end')
+
   })
   //SM_BREAKPOINT = 576
   // now window.innerWidth = 1000
-  it('when expand=sm and window resize event occurs to above breakpoint, it changes order of non-collapsible slot, ', async() => {
+  it('when expand=sm and window resize event occurs to above breakpoint, it changes order of non-collapsible slot and end slot has class slot-end ', async() => {
     const el = await fixture<SgdsMainnav>(
       html`<sgds-mainnav expand="sm"></sgds-mainnav>`
     );
     expect(el.shadowRoot?.querySelector("slot[name='non-collapsible']")).to.have.class('order-5')
+    expect(el.shadowRoot?.querySelector("slot[name='end']")).to.have.class('slot-end')
     Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -171,13 +177,17 @@ describe("sgds-mainnav", () => {
    window.dispatchEvent(new Event('resize'));
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-2')
+   expect(el.shadowRoot?.querySelector("slot[name='end']")).not.to.have.class('slot-end')
+
   })
   // now window.innerWidth = 575
-  it('when expand=always and window resize event occurs, it NEVER changes order of non-collapsible slot, ', async() => {
+  it('when expand=always and window resize event occurs, it NEVER changes order of non-collapsible slot and end slot ALWAYS have slot-end ', async() => {
     const el = await fixture<SgdsMainnav>(
       html`<sgds-mainnav expand="always"></sgds-mainnav>`
     );
     expect(el.shadowRoot?.querySelector("slot[name='non-collapsible']")).to.have.class('order-5')
+    expect(el.shadowRoot?.querySelector("slot[name='end']")).to.have.class('slot-end')
+
     Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -186,6 +196,8 @@ describe("sgds-mainnav", () => {
    window.dispatchEvent(new Event('resize'));
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-5')
+   expect(el.shadowRoot?.querySelector("slot[name='end']")).to.have.class('slot-end')
+
 
    Object.defineProperty(window, 'innerWidth', {
     writable: true,
@@ -196,11 +208,13 @@ describe("sgds-mainnav", () => {
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-5')
   })
-  it('when expand=never and window resize event occurs, it NEVER changes order of non-collapsible slot, ', async() => {
+  it('when expand=never and window resize event occurs, it NEVER changes order of non-collapsible slot,  and end slot NEVER has class slot-end', async() => {
     const el = await fixture<SgdsMainnav>(
       html`<sgds-mainnav expand="never"></sgds-mainnav>`
     );
     expect(el.shadowRoot?.querySelector("slot[name='non-collapsible']")).to.have.class('order-2')
+    expect(el.shadowRoot?.querySelector("slot[name='end']")).not.to.have.class('slot-end')
+
     Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -209,6 +223,7 @@ describe("sgds-mainnav", () => {
    window.dispatchEvent(new Event('resize'));
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-2')
+   expect(el.shadowRoot?.querySelector("slot[name='end']")).not.to.have.class('slot-end')
 
    Object.defineProperty(window, 'innerWidth', {
     writable: true,
@@ -218,6 +233,8 @@ describe("sgds-mainnav", () => {
    window.dispatchEvent(new Event('resize'));
    await el.updateComplete
    expect(el.shadowRoot?.querySelector('slot[name="non-collapsible"]')).to.have.class('order-2')
+   expect(el.shadowRoot?.querySelector("slot[name='end']")).not.to.have.class('slot-end')
+
   })
 
   it('keyboard esc to exit offcanvas works', async() => {


### PR DESCRIPTION
Add new feature for MainNav
- to allow nav items to be added from far right of navbar and also be included in the collapsed menu 

new slot name "end" introduced, updated in storybook and UT
