### PR TITLE
sgds-504-sidenav

### DIFF
--- a/src/components/Sidenav/sgds-sidenav-item.scss
+++ b/src/components/Sidenav/sgds-sidenav-item.scss
@@ -1,19 +1,23 @@
-
-:host   {
-  --sidenav-theme-color: #5925DC;
+:host{
+  --sidenav-item-button-border-left-width: 0.125rem;
+  --sidenav-item-padding-x: 1rem;
+  --sidenav-item-padding-y: 0.5rem;
+  --sidenav-item-icon-title-gap: 1rem;
 }
+
 
 .sidenav-btn {
   width: 100%;
   text-align: initial;
   line-height: 1.5rem;
-  font-size: 1rem;
+  font-size: var(--sgds-body-font-size);
   border: 0;
   background: 0;
   padding: 0.5rem 1rem;
-  border-left: 0.125rem solid transparent;
+  border-left: var(--sidenav-item-button-border-left-width) solid transparent;
   border-radius: 0;
   display: flex;
+  gap: var(--sidenav-item-icon-title-gap);
   align-items: center;
 
   &.active,
@@ -61,10 +65,4 @@ a.sidenav-btn {
 .collapse.show,
 .collapsing {
   margin-top: 1rem;
-}
-
-::slotted(*[slot="title"]) {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
 }

--- a/src/components/Sidenav/sgds-sidenav-item.ts
+++ b/src/components/Sidenav/sgds-sidenav-item.ts
@@ -13,33 +13,54 @@ import { classMap } from "lit/directives/class-map.js";
  *
  * @slot - default slot for SgdsSidenavLink element.
  * @slot title - title slot for the content of SgdsSidenavItem's button / anchor element.
+ * @slot icon - icon slot for the content of SgdsSidenavItem's button / anchor element.
+ *
+ * @cssproperty --sidenav-item-button-border-left-width - sidenav item left border width
+ * @cssproperty --sidenav-item-padding-x - sidenav item padding left and right
+ * @cssproperty --sidenav-item-padding-y - sidenav item padding top and bottom
+ * @cssproperty --sidenav-item-icon-title-gap - the flex gap between sidenav item icon and title
  */
 
 @customElement("sgds-sidenav-item")
 export class SgdsSidenavItem extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
 
+  /** @internal */
   private myCollapse: Ref<HTMLElement> = createRef();
+  /** @internal */
   private bsCollapse: Collapse = null;
 
-  /**  when true, toggles the sidenav-item to open on first load and
-   * set the active stylings.
+  /**
+   *  when true, toggles the sidenav-item to open on first load and set the active stylings.
    */
   @property({ type: Boolean })
   active = false;
 
+  /**
+   *  When defined, converts SgdsSidenavItem from a button element to an Anchor element
+   */
   @property({ type: String })
   href = "";
 
+  /**
+   * Forwards to id attribute of div.collapse and aria-controls attribute of button in SgdsSidenavItem. By default, SgdsSidenavItem auto-generates a unique id. Override the default id by specifiying your own
+   */
   @property({ type: String })
-  collapseId = genId("sidenav", "collapse");
+  collapseId: string = genId("sidenav", "collapse");
 
+  /**
+   * Forwards to id attribute of button and aria-labelledby attribute of ul.sidenav-list in SgdsSidenavItem. By default, SgdsSidenavItem auto-generates a unique id. Override the default id by specifiying your own
+   */
   @property({ type: String })
-  buttonId = genId("sidenav", "button");
+  buttonId: string = genId("sidenav", "button");
 
+  /**
+   * Disables the SgdsSidenavItem
+   */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
+  /** @internal */
   private index = "-1";
 
   private _onClick() {
@@ -58,14 +79,14 @@ export class SgdsSidenavItem extends SgdsElement {
   }
 
   /**
-   * closeItem - closes sidenav and inactivates it
+   * When invoked, closes the SgdsSidenavItem
    */
   public closeItem() {
     this.active = false;
     if (this.bsCollapse) this.bsCollapse.hide();
   }
   /**
-   * openItem
+   * When invoked, opens the SgdsSidenavItem
    */
   public openItem() {
     this.active = true;
@@ -142,6 +163,7 @@ export class SgdsSidenavItem extends SgdsElement {
         ?disabled=${this.disabled}
         aria-disabled=${this.disabled ? "true" : "false"}
       >
+        <slot name="icon"></slot>
         <slot name="title"></slot>
       </a>
     `;

--- a/src/components/Sidenav/sgds-sidenav-link.scss
+++ b/src/components/Sidenav/sgds-sidenav-link.scss
@@ -1,21 +1,20 @@
 
 :host {
-  //Sidenav
---sidenav-fontsize: 1rem;
---sidenav-item-spacing: 1rem;
---sidenav-btn-border-width: 0.125rem;
---nav-link-disabled-color: #344054;
+  --sidenav-link-font-size: var(--sgds-body-font-size);
+  --sidenav-link-padding-x: 1rem;
+  --sidenav-link-padding-y: 0.5rem;
+  --sidenav-link-disabled-color: var(--sgds-gray-600);
 }
+
+
 
 a.nav-link {
   display: block;
   color: inherit;
-  font-size: var(--sidenav-fontsize);
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: calc(
-    var(--sidenav-item-spacing) * 4 + var(--sidenav-btn-border-width)
-  );
+  font-size: var(--sidenav-link-font-size);
+  padding-top: var(--sidenav-link-padding-y);
+  padding-bottom: var(--sidenav-link-padding-y);
+  padding-left: calc(var(--sidenav-link-padding-y) * 4 + var(--sidenav-item-button-border-left-width));
   padding-right: 0;
   text-decoration: none;
 
@@ -23,9 +22,9 @@ a.nav-link {
   &:hover {
     color: var(--sidenav-theme-color);
   }
-  // Disabled state lightens text
+
   &.disabled {
-    color: var(--nav-link-disabled-color);
+    color: var(--sidenav-link-disabled-color);
     pointer-events: none;
     cursor: default;
   }

--- a/src/components/Sidenav/sgds-sidenav-link.ts
+++ b/src/components/Sidenav/sgds-sidenav-link.ts
@@ -4,6 +4,11 @@ import styles from "./sgds-sidenav-link.scss";
 
 /**
  * @slot - default slot for label of anchor tag.
+ *
+ * @cssproperty --sidenav-link-font-size - sidenav link font size, default to `--sgds-body-font-size`
+ * @cssproperty --sidenav-link-padding-x - sidenav link padding left and right
+ * @cssproperty --sidenav-link-padding-y - sidenav link padding top and bottom
+ * @cssproperty --sidenav-link-disabled-color - sidenav link disabled color, default to `--sgds-gray-600`
  */
 @customElement("sgds-sidenav-link")
 export class SgdsSidenavLink extends LinkElement {

--- a/src/components/Sidenav/sgds-sidenav.scss
+++ b/src/components/Sidenav/sgds-sidenav.scss
@@ -1,3 +1,7 @@
+:host   {
+    --sidenav-theme-color: #5925DC;
+  }
+
 ul {
     display: flex;
     flex-direction: column;

--- a/src/components/Sidenav/sgds-sidenav.ts
+++ b/src/components/Sidenav/sgds-sidenav.ts
@@ -5,12 +5,16 @@ import styles from "./sgds-sidenav.scss";
 import SgdsSidenavItem from "./sgds-sidenav-item";
 
 /**
+ * @summary The side navigation is used to display a list of links to move between pages within a related category. It is used as a secondary form of navigation where the primary navigation is located hierachically above the page frame.
  * @slot - default slot for SgdsSidenavItem element.
+ *
+ * @cssproperty --sidenav-theme-color - overall sidenav theme color
  */
 @customElement("sgds-sidenav")
 export class SgdsSidenav extends SgdsElement {
   static styles = styles;
 
+  /** Allow sidenav items to stay open when another item is opened */
   @property({ type: Boolean, attribute: true })
   alwaysOpen = false;
 

--- a/stories/templates/Sidenav/basic.js
+++ b/stories/templates/Sidenav/basic.js
@@ -11,29 +11,63 @@ export const Template = ({
   disabledSNI
 }) => {
   return html`
-    <sgds-sidenav .alwaysOpen=${alwaysOpen}>
+    <sgds-sidenav ?alwaysOpen=${alwaysOpen}>
       <sgds-sidenav-item
-        .active=${active}
-        .href=${href}
-        .collapseId=${collapseId}
-        .buttonId=${buttonId}
-        .disabled=${disabledSNI}
+        ?active=${active}
+        href=${href}
+        collapseId=${collapseId}
+        buttonId=${buttonId}
+        ?disabled=${disabledSNI}
       >
-        <span slot="title"> <sl-icon name="stack"></sl-icon> SideNav Item #1 (control by Argstable) </span>
-        <sgds-sidenav-link .href=${hrefSNL} .active=${activeSNL} .disabled=${disabledSNL}
+        <span slot="title">SideNav Item #1 (control by Argstable) </span>
+        <sgds-sidenav-link href=${hrefSNL} ?active=${activeSNL} ?disabled=${disabledSNL}
           >sgds-sidenav-link (control by Argstable)</sgds-sidenav-link
         >
         <sgds-sidenav-link href="#" disabled>sgds-sidenav-link</sgds-sidenav-link>
         <sgds-sidenav-link href="#">sgds-sidenav-link</sgds-sidenav-link>
       </sgds-sidenav-item>
       <sgds-sidenav-item>
-        <span slot="title"> <sl-icon name="stack"></sl-icon>SideNav Item #2</span>
+        <span slot="title">SideNav Item #2</span>
+        <span slot="icon">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-layers-fill"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M7.765 1.559a.5.5 0 0 1 .47 0l7.5 4a.5.5 0 0 1 0 .882l-7.5 4a.5.5 0 0 1-.47 0l-7.5-4a.5.5 0 0 1 0-.882l7.5-4z"
+            />
+            <path
+              d="m2.125 8.567-1.86.992a.5.5 0 0 0 0 .882l7.5 4a.5.5 0 0 0 .47 0l7.5-4a.5.5 0 0 0 0-.882l-1.86-.992-5.17 2.756a1.5 1.5 0 0 1-1.41 0l-5.17-2.756z"
+            />
+          </svg>
+        </span>
         <sgds-sidenav-link href="#">sgds-sidenav-link</sgds-sidenav-link>
         <sgds-sidenav-link href="#">sgds-sidenav-link</sgds-sidenav-link>
         <sgds-sidenav-link href="#">sgds-sidenav-link</sgds-sidenav-link>
       </sgds-sidenav-item>
       <sgds-sidenav-item href="#">
         <span slot="title">SideNav Item #3</span>
+        <span slot="icon">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-layers-fill"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M7.765 1.559a.5.5 0 0 1 .47 0l7.5 4a.5.5 0 0 1 0 .882l-7.5 4a.5.5 0 0 1-.47 0l-7.5-4a.5.5 0 0 1 0-.882l7.5-4z"
+            />
+            <path
+              d="m2.125 8.567-1.86.992a.5.5 0 0 0 0 .882l7.5 4a.5.5 0 0 0 .47 0l7.5-4a.5.5 0 0 0 0-.882l-1.86-.992-5.17 2.756a1.5 1.5 0 0 1-1.41 0l-5.17-2.756z"
+            />
+          </svg>
+        </span>
       </sgds-sidenav-item>
     </sgds-sidenav>
   `;

--- a/test/sidenav.test.ts
+++ b/test/sidenav.test.ts
@@ -59,8 +59,8 @@ describe("sgds-sidenav-item", () => {
          aria-selected="false"
          aria-disabled="false"
        >
-           <slot name="title">
-           </slot>
+          <slot name="icon"></slot>
+          <slot name="title"></slot>
        </a>`
     );
   });


### PR DESCRIPTION
## sidenav
- added summary description
- move `--sidenav-theme-color`to `sidenav`

## sidenav-link
- rename and add css properties
- added css properties descriptions

## sidenav-item
- rename and add css properties
- added css properties descriptions
- added method and props description
- added missing slot `a.sidenav-btn > slot[name="icon"]`

## `storybook` basic 
- added missing slot `a.sidenav-btn > slot[name="icon"]`
- fix storybook notation
