### PR TITLE
Sgds 512 action card

### DIFF
--- a/src/components/ActionCard/sgds-action-card.scss
+++ b/src/components/ActionCard/sgds-action-card.scss
@@ -3,8 +3,7 @@
     &.card {
       &[variant*="card-action"] {
         .card-body {
-          sl-icon {
-            font-size: 1.5rem;
+          ::slotted(svg) {
             margin-right: 1rem;
           }
         }

--- a/src/components/ActionCard/sgds-action-card.ts
+++ b/src/components/ActionCard/sgds-action-card.ts
@@ -123,7 +123,7 @@ export class SgdsActionCard extends CardElement {
           <h6 class="text-muted card-subtitle" part="subtitle">
             <div>
               <slot name="icon"></slot>
-              <slot name="card-subtitle"></slot></slot>
+              <slot name="card-subtitle"></slot>
             </div>
             <div class="card-input">
             ${this.type === "checkbox" ? checkbox : radio}

--- a/src/components/ActionCard/sgds-action-card.ts
+++ b/src/components/ActionCard/sgds-action-card.ts
@@ -4,6 +4,12 @@ import { Ref, createRef, ref } from "lit/directives/ref.js";
 import { html } from "lit/static-html.js";
 import { CardElement } from "../../base/card-element";
 import styles from "./sgds-action-card.scss";
+import generateId from "../../utils/generateId";
+import { SgdsCheckbox } from "../Checkbox";
+import { SgdsRadio } from "../Radio";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { live } from "lit/directives/live.js";
+import { watch } from "../../utils/watch";
 
 export type CardVariant = "card-action" | "card-action-quantity-toggle";
 
@@ -12,66 +18,75 @@ export type TypeVariant = "checkbox" | "radio";
 @customElement("sgds-action-card")
 export class SgdsActionCard extends CardElement {
   static styles = [CardElement.styles, styles];
+
   /** @internal */
-  inputRef: Ref<HTMLInputElement> = createRef();
+  inputRef: Ref<SgdsCheckbox | SgdsRadio> = createRef();
+  /** Name of the HTML form control. Submitted with the form as part of a name/value pair. */
+  @property({ reflect: true }) name: string;
+  /** Value of the HTML form control. Primarily used to differentiate a list of related checkboxes that have the same name. */
+  @property() value: string;
+  /** Disables the input (so the user can't check / uncheck it). */
+  @property({ type: Boolean, reflect: true }) disabled = false;
+  /** Draws the input in a checked state. */
+  @property({ type: Boolean, reflect: true }) checked = false;
 
-  @property({ type: String, reflect: true }) type?: TypeVariant = "checkbox";
-
-  /** Use on actionable cards like SelectableCard and Quantity Toggle Card' */
-  @property({ reflect: true }) variant: CardVariant = "card-action";
-
-  /** The card's subtitle iconName. */
-  @property({ reflect: true }) iconName?: string;
+  /** The type of input of the action card */
+  @property({ type: String, reflect: true }) type: TypeVariant = "checkbox";
 
   /** The input's id. */
-  @property({ reflect: true }) inputId?: string;
+  @property({ reflect: true }) inputId: string = generateId("action-card", "input");
 
+  /** Controls the active styling of the action card */
   @property({ reflect: true, type: Boolean })
   active = false;
 
-  // Declare the click event listener
-  onInputChange() {
+  /** Simulates a click on the input control*/
+  public click() {
     this.inputRef.value.click();
-    if (this.inputRef.value.checked && !this.inputRef.value.disabled) this.active = true;
-    else if (!this.inputRef.value.checked) {
-      this.active = false;
-    }
+  }
+  /** @internal Declare the click event listener*/
+  async handleInputChange() {
+    this.inputRef.value.click();
+    this.emit("sgds-change");
+  }
+
+  @watch("checked")
+  async handleRadioCheckedChange() {
+    this.active = this.checked;
   }
 
   handleKeyDown(event: KeyboardEvent) {
     const hasModifier = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
     if (event.key === "Enter" && !hasModifier) {
-      this.onInputChange();
+      this.handleInputChange();
     }
   }
-  // handleChange(event: string){
-  //   this.checked = this.inputRef.value.checked;
-  //   this.emit(event);
-  // }
 
   render() {
     const checkbox = html`<sgds-checkbox
       ${ref(this.inputRef)}
       ?disabled=${this.disabled}
       checkboxId=${this.inputId}
-      @click=${this.onInputChange}
+      @click=${this.handleInputChange}
       @keydown=${this.handleKeyDown}
+      .value=${ifDefined(this.value)}
+      @sgds-change=${(e: CustomEvent) => (this.checked = e.detail.checked)}
     ></sgds-checkbox>`;
 
     const radio = html`<sgds-radio
       ${ref(this.inputRef)}
       ?disabled=${this.disabled}
       radioId=${this.inputId}
-      @click=${this.onInputChange}
+      @click=${this.handleInputChange}
       @keydown=${this.handleKeyDown}
+      .value=${ifDefined(this.value)}
+      ?checked=${live(this.checked)}
     ></sgds-radio>`;
-
-    const icon = html`<sl-icon name="${this.iconName}"></sl-icon>`;
 
     return html`
       <div
       tabindex=${this.disabled ? "-1" : "0"}
-      @click=${this.onInputChange}
+      @click=${this.handleInputChange}
      @keydown=${this.handleKeyDown}
      
         variant="card-action"
@@ -87,17 +102,11 @@ export class SgdsActionCard extends CardElement {
         <div class="card-body">
           <h6 class="text-muted card-subtitle">
             <div>
-              ${this.iconName == undefined ? undefined : icon}
+              <slot name="icon"></slot>
               <slot name="card-subtitle"></slot></slot>
             </div>
             <div class="card-input">
-            ${
-              this.type == "checkbox" && this.variant == "card-action"
-                ? checkbox
-                : this.type == "radio" && this.variant == "card-action"
-                ? radio
-                : undefined
-            }
+            ${this.type === "checkbox" ? checkbox : radio}
             </div>
           </h6>
           <h5 class="card-title"><slot name="card-title"></slot></h5>

--- a/src/components/ActionCard/sgds-action-card.ts
+++ b/src/components/ActionCard/sgds-action-card.ts
@@ -11,9 +11,24 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
 import { watch } from "../../utils/watch";
 
-export type CardVariant = "card-action" | "card-action-quantity-toggle";
-
 export type TypeVariant = "checkbox" | "radio";
+
+/**
+ * @summary Action Card are cards with built in checkbox or radio components. The ref of input is extended to the Card's body.
+ * @slot icon - Icon content in the card-subtitile
+ * @slot card-subtitle - The subtitle of the card
+ * @slot card-title - The title of the card
+ * @slot card-text - The paragrapher text of the card
+ *
+ * @event sgds-change - Emitted when the checked state of card's checkbox changes or when the selected card's radio has changed
+ *
+ * @csspart base - The action card base wrapper
+ * @csspart body - The action card body 
+ * @csspart subtitle - The action card subtitle
+ * @csspart title - The action card title
+ * @csspart text - The action card text
+ *
+ */
 
 @customElement("sgds-action-card")
 export class SgdsActionCard extends CardElement {
@@ -70,6 +85,7 @@ export class SgdsActionCard extends CardElement {
       @click=${this.handleInputChange}
       @keydown=${this.handleKeyDown}
       .value=${ifDefined(this.value)}
+      ?checked=${live(this.checked)}
       @sgds-change=${(e: CustomEvent) => (this.checked = e.detail.checked)}
     ></sgds-checkbox>`;
 
@@ -88,7 +104,6 @@ export class SgdsActionCard extends CardElement {
       tabindex=${this.disabled ? "-1" : "0"}
       @click=${this.handleInputChange}
      @keydown=${this.handleKeyDown}
-     
         variant="card-action"
         class="sgds card
         ${classMap({
@@ -98,9 +113,10 @@ export class SgdsActionCard extends CardElement {
           ["is-active"]: this.active
         })}
         "
+        part="base"
       >
-        <div class="card-body">
-          <h6 class="text-muted card-subtitle">
+        <div class="card-body" part="body">
+          <h6 class="text-muted card-subtitle" part="subtitle">
             <div>
               <slot name="icon"></slot>
               <slot name="card-subtitle"></slot></slot>
@@ -109,8 +125,8 @@ export class SgdsActionCard extends CardElement {
             ${this.type === "checkbox" ? checkbox : radio}
             </div>
           </h6>
-          <h5 class="card-title"><slot name="card-title"></slot></h5>
-          <p class="card-text"><slot name="card-text"></slot></p>
+          <h5 class="card-title" part="title"><slot name="card-title"></slot></h5>
+          <p class="card-text" part="text"><slot name="card-text"></slot></p>
         </div>
       </div>
     `;

--- a/src/components/ActionCard/sgds-action-card.ts
+++ b/src/components/ActionCard/sgds-action-card.ts
@@ -23,7 +23,7 @@ export type TypeVariant = "checkbox" | "radio";
  * @event sgds-change - Emitted when the checked state of card's checkbox changes or when the selected card's radio has changed
  *
  * @csspart base - The action card base wrapper
- * @csspart body - The action card body 
+ * @csspart body - The action card body
  * @csspart subtitle - The action card subtitle
  * @csspart title - The action card title
  * @csspart text - The action card text

--- a/src/components/ActionCard/sgds-action-card.ts
+++ b/src/components/ActionCard/sgds-action-card.ts
@@ -69,6 +69,10 @@ export class SgdsActionCard extends CardElement {
   async handleRadioCheckedChange() {
     this.active = this.checked;
   }
+  @watch("disabled")
+  async handleDisabledChange() {
+    this.active = !this.disabled;
+  }
 
   handleKeyDown(event: KeyboardEvent) {
     const hasModifier = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;

--- a/src/components/Checkbox/sgds-checkbox.ts
+++ b/src/components/Checkbox/sgds-checkbox.ts
@@ -15,7 +15,7 @@ import styles from "./sgds-checkbox.scss";
  *
  * @slot default - The label of checkbox.
  *
- * @event sgds-change - Emitted when the radio group's selected value changes.
+ * @event sgds-change - Emitted when the checked state changes.
  */
 @customElement("sgds-checkbox")
 export class SgdsCheckbox extends SgdsElement implements SgdsFormControl {

--- a/src/components/Checkbox/sgds-checkbox.ts
+++ b/src/components/Checkbox/sgds-checkbox.ts
@@ -90,7 +90,7 @@ export class SgdsCheckbox extends SgdsElement implements SgdsFormControl {
   handleChange() {
     this.checked = !this.checked;
     this.value = this.input.value;
-    this.emit("sgds-change");
+    this.emit("sgds-change", { detail: { checked: this.checked, value: this.value } });
   }
 
   handleKeyDown(event: KeyboardEvent) {

--- a/src/components/Radio/sgds-radio-group.ts
+++ b/src/components/Radio/sgds-radio-group.ts
@@ -1,12 +1,11 @@
 import { html } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, query, queryAssignedElements, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import SgdsElement from "../../base/sgds-element";
 import { FormSubmitController } from "../../utils/form";
 import { watch } from "../../utils/watch";
 import SgdsRadio from "./sgds-radio";
 import styles from "./sgds-radio-group.scss";
-import { SgdsFormControl } from "../../utils/form";
 
 /**
  * @summary RadioGroup group multiple radios so they function as a single form control.
@@ -16,7 +15,7 @@ import { SgdsFormControl } from "../../utils/form";
  * @event sgds-change - Emitted when the radio group's selected value changes.
  */
 @customElement("sgds-radio-group")
-export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
+export class SgdsRadioGroup extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
   /**@internal */
   protected readonly formSubmitController = new FormSubmitController(this, {
@@ -50,7 +49,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
   @watch("value")
   handleValueChange() {
     if (this.hasUpdated) {
-      this.emit("sgds-change");
+      this.emit("sgds-change", { detail: { value: this.value } });
       this.updateCheckedRadio();
     }
   }
@@ -93,10 +92,9 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
 
     return !this.invalid;
   }
-
-  private getAllRadios() {
-    return [...this.querySelectorAll<SgdsRadio>("sgds-radio")];
-  }
+  /**@internal */
+  @queryAssignedElements()
+  private _radios!: Array<SgdsRadio>;
 
   handleRadioClick(event: MouseEvent) {
     const target = event.target as SgdsRadio;
@@ -106,7 +104,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
     }
 
     this.value = target.value;
-    const radios = this.getAllRadios();
+    const radios = this._radios;
     radios.forEach(radio => (radio.checked = radio === target));
   }
 
@@ -115,7 +113,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
       return;
     }
 
-    const radios = this.getAllRadios().filter(radio => !radio.disabled);
+    const radios = this._radios.filter(radio => !radio.disabled);
     const checkedRadio = radios.find(radio => radio.checked) ?? radios[0];
     //if eventkey is space, index increment is 0, if eventkey arrowup/arrowleft, index is -1, arrowright/arrowdown, index incr is 1
     const incr = event.key === " " ? 0 : ["ArrowUp", "ArrowLeft"].includes(event.key) ? -1 : 1;
@@ -127,7 +125,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
       index = 0;
     }
 
-    this.getAllRadios().forEach(radio => {
+    this._radios.forEach(radio => {
       radio.checked = false;
       radio.tabIndex = -1;
     });
@@ -141,7 +139,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
   }
 
   handleLabelClick() {
-    const radios = this.getAllRadios();
+    const radios = this._radios;
     const checked = radios.find(radio => radio.checked);
     const radioToFocus = checked || radios[0];
 
@@ -152,7 +150,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
   }
 
   handleSlotChange() {
-    const radios = this.getAllRadios();
+    const radios = this._radios;
 
     radios.forEach(radio => (radio.checked = radio.value === this.value));
 
@@ -173,7 +171,7 @@ export class SgdsRadioGroup extends SgdsElement implements SgdsFormControl {
   }
 
   updateCheckedRadio() {
-    const radios = this.getAllRadios();
+    const radios = this._radios;
     radios.forEach(radio => (radio.checked = radio.value === this.value));
     this.invalid = !this.validity.valid;
   }

--- a/src/components/Radio/sgds-radio.ts
+++ b/src/components/Radio/sgds-radio.ts
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { watch } from "../../utils/watch";
 import styles from "./sgds-radio.scss";
@@ -18,8 +18,10 @@ import genId from "../../utils/generateId";
 @customElement("sgds-radio")
 export class SgdsRadio extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
-  /**@internal */
-  @state() checked = false;
+  /**
+   * Draws the radio in a checked state
+   */
+  @property({ type: Boolean, reflect: true }) checked = false;
 
   /** The radio's value attribute. */
   @property() value: string;

--- a/stories/templates/ActionCard/additional.mdx
+++ b/stories/templates/ActionCard/additional.mdx
@@ -3,39 +3,30 @@ export const TemplateType = args =>
     <div class="col">
     <form> 
     <sgds-radio-group>
-      <sgds-action-card type="radio">
+      <sgds-action-card type="radio" name="apple">
         <span slot="card-subtitle">Laptop</span>
         <span slot="card-title">Apple</span>
         <span slot="card-text">Macbook Pro M1</span>
       </sgds-action-card>
-      <sgds-action-card type="radio">
+      <sgds-action-card type="radio" name="microsoft">
         <span slot="card-subtitle">Laptop</span>
-        <span slot="card-title">Apple</span>
-        <span slot="card-text">Macbook Pro M1</span>
+        <span slot="card-title">Microsoft</span>
+        <span slot="card-text">Microsoft Surface Pro</span>
       </sgds-action-card>
-      <sgds-action-card type="radio">
+      <sgds-action-card type="radio" name="acer">
         <span slot="card-subtitle">Laptop</span>
-        <span slot="card-title">Apple</span>
-        <span slot="card-text">Macbook Pro M1</span>
+        <span slot="card-title">Acer</span>
+        <span slot="card-text">Aspire 5</span>
       </sgds-action-card>
       </sgds-radio-group>
       </form>
-      <div>
-        <div class="col">
-          <sgds-action-card type="checkbox">
-            <span slot="card-subtitle">Laptop</span>
-            <span slot="card-title">Apple</span>
-            <span slot="card-text">Macbook Pro M1</span>
-          </sgds-action-card>
-          <div></div>
-        </div>
-      </div>
     </div>
   `;
 
-## Type
+## SgdsActionCard as radio
 
-Use `type` prop : `radio` / `checkbox` to change the selectable card input type
+`SgdsActionCard` `type='radio'` is essentially form radio with a card UI. 
+Use `SgdsRadioGroup` as a wrapper to enable radio behaviour.
 
 <Canvas>
   <Story name="Type">{TemplateType.bind({})}</Story>

--- a/stories/templates/ActionCard/additional.mdx
+++ b/stories/templates/ActionCard/additional.mdx
@@ -1,11 +1,25 @@
 export const TemplateType = args =>
   html`
     <div class="col">
+    <form> 
+    <sgds-radio-group>
       <sgds-action-card type="radio">
         <span slot="card-subtitle">Laptop</span>
         <span slot="card-title">Apple</span>
         <span slot="card-text">Macbook Pro M1</span>
       </sgds-action-card>
+      <sgds-action-card type="radio">
+        <span slot="card-subtitle">Laptop</span>
+        <span slot="card-title">Apple</span>
+        <span slot="card-text">Macbook Pro M1</span>
+      </sgds-action-card>
+      <sgds-action-card type="radio">
+        <span slot="card-subtitle">Laptop</span>
+        <span slot="card-title">Apple</span>
+        <span slot="card-text">Macbook Pro M1</span>
+      </sgds-action-card>
+      </sgds-radio-group>
+      </form>
       <div>
         <div class="col">
           <sgds-action-card type="checkbox">

--- a/stories/templates/ActionCard/basic.js
+++ b/stories/templates/ActionCard/basic.js
@@ -10,6 +10,19 @@ export const Template = args =>
       .iconName=${args.iconName}
       .type=${args.type}
     >
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="currentColor"
+        class="bi bi-box"
+        viewBox="0 0 16 16"
+      >
+        <path
+          d="M8.186 1.113a.5.5 0 0 0-.372 0L1.846 3.5 8 5.961 14.154 3.5 8.186 1.113zM15 4.239l-6.5 2.6v7.922l6.5-2.6V4.24zM7.5 14.762V6.838L1 4.239v7.923l6.5 2.6zM7.443.184a1.5 1.5 0 0 1 1.114 0l7.129 2.852A.5.5 0 0 1 16 3.5v8.662a1 1 0 0 1-.629.928l-7.185 2.874a.5.5 0 0 1-.372 0L.63 13.09a1 1 0 0 1-.63-.928V3.5a.5.5 0 0 1 .314-.464L7.443.184z"
+        />
+      </svg>
       <span slot="card-subtitle">Laptop</span>
       <span slot="card-title">Apple</span>
       <span slot="card-text">Macbook Pro M1</span>

--- a/stories/templates/ActionCard/basic.js
+++ b/stories/templates/ActionCard/basic.js
@@ -2,13 +2,16 @@ import { html } from "lit-html";
 export const Template = args =>
   html`
     <sgds-action-card
-      .active=${args.active}
-      .bgColor=${args.bgColor}
-      .borderColor=${args.borderColor}
-      .textColor=${args.textColor}
-      .disabled=${args.disabled}
-      .iconName=${args.iconName}
-      .type=${args.type}
+      ?active=${args.active}
+      bgColor=${args.bgColor}
+      borderColor=${args.borderColor}
+      textColor=${args.textColor}
+      ?disabled=${args.disabled}
+      type=${args.type}
+      ?checked=${args.checked}
+      name=${args.name}
+      .value=${args.value}
+      inputId=${args.inputId}
     >
       <svg
         slot="icon"

--- a/stories/templates/Radio/basic.js
+++ b/stories/templates/Radio/basic.js
@@ -9,7 +9,8 @@ export const Template = ({
   radioId,
   ariaLabel,
   required,
-  invalidFeedback
+  invalidFeedback,
+  checked
 }) => {
   return html`
     <sgds-radio-group .name=${name} .value=${defaultValue} .required=${required} .invalidFeedback=${invalidFeedback}>
@@ -20,6 +21,7 @@ export const Template = ({
         .radioId=${radioId}
         .ariaLabel=${ariaLabel}
         .isInline=${isInline}
+        ?checked=${checked}
         >Option 1</sgds-radio
       >
       <sgds-radio value="2" .isInline=${isInline}>Option 2</sgds-radio>

--- a/test/action-card.test.ts
+++ b/test/action-card.test.ts
@@ -1,4 +1,4 @@
-import { assert, elementUpdated, expect, fixture, html } from "@open-wc/testing";
+import { assert, elementUpdated, expect, fixture, html, waitUntil } from "@open-wc/testing";
 import { sendKeys } from "@web/test-runner-commands";
 import "../src/components/ActionCard";
 import { SgdsActionCard } from "../src/components/ActionCard";
@@ -53,7 +53,7 @@ describe("<sgds-action-card>", () => {
           <div class="card-body">
             <h6 class="text-muted card-subtitle">
               <div>
-              
+              <slot name="icon"></slot>
                 <slot name="card-subtitle"></slot>
                 </div>
               <div class="card-input">
@@ -68,15 +68,18 @@ describe("<sgds-action-card>", () => {
     );
   });
 
-  it("it should have type checkbox and variant card-action by default", async () => {
+  it("it should have type checkbox by default", async () => {
     const el = await fixture(html`<sgds-action-card></sgds-action-card>`);
     expect(el?.getAttribute("type")).to.equal("checkbox");
-    expect(el?.getAttribute("variant")).to.equal("card-action");
+    expect(el.shadowRoot?.querySelector("sgds-checkbox")).to.exist;
+    expect(el.shadowRoot?.querySelector("sgds-radio")).not.to.exist;
   });
 
   it("it should have type radio when specified", async () => {
     const el = await fixture(html`<sgds-action-card type="radio"></sgds-action-card>`);
     expect(el?.getAttribute("type")).to.equal("radio");
+    expect(el.shadowRoot?.querySelector("sgds-checkbox")).not.to.exist;
+    expect(el.shadowRoot?.querySelector("sgds-radio")).to.exist;
   });
 
   it("when card is clicked, card should contain class is-active", async () => {
@@ -111,5 +114,43 @@ describe("<sgds-action-card>", () => {
     await sendKeys({ press: "Enter" });
     await el.updateComplete;
     expect(el.shadowRoot?.querySelector("div.sgds.card")).to.have.class("is-active");
+  });
+});
+
+describe("radio action card with form group behaviour", () => {
+  it("in sgds-form-group, sgds-action-card type radio should behave like radio options (only one radio is checked at any point)", async () => {
+    const el = await fixture(html` <sgds-radio-group>
+      <sgds-action-card type="radio" name="apple">
+        <span slot="card-subtitle">Laptop</span>
+        <span slot="card-title">Apple</span>
+        <span slot="card-text">Macbook Pro M1</span>
+      </sgds-action-card>
+      <sgds-action-card type="radio" name="microsoft">
+        <span slot="card-subtitle">Laptop</span>
+        <span slot="card-title">Microsoft</span>
+        <span slot="card-text">Microsoft Surface Pro</span>
+      </sgds-action-card>
+      <sgds-action-card type="radio" name="acer">
+        <span slot="card-subtitle">Laptop</span>
+        <span slot="card-title">Acer</span>
+        <span slot="card-text">Acer Aspired 5</span>
+      </sgds-action-card>
+    </sgds-radio-group>`);
+    const appleCard = el.querySelector("sgds-action-card[name='apple']") as SgdsActionCard;
+    const microsoftCard = el.querySelector("sgds-action-card[name='microsoft']") as SgdsActionCard;
+    const acerCard = el.querySelector("sgds-action-card[name='acer']") as SgdsActionCard;
+    appleCard.click();
+    await waitUntil(() => appleCard.checked);
+    microsoftCard.click();
+    await waitUntil(() => microsoftCard.checked);
+    expect(appleCard.checked).to.be.false;
+    expect(acerCard.checked).to.be.false;
+    expect(microsoftCard.checked).to.be.true;
+
+    acerCard.click();
+    await waitUntil(() => acerCard.checked);
+    expect(appleCard.checked).to.be.false;
+    expect(acerCard.checked).to.be.true;
+    expect(microsoftCard.checked).to.be.false;
   });
 });

--- a/test/action-card.test.ts
+++ b/test/action-card.test.ts
@@ -92,13 +92,14 @@ describe("<sgds-action-card>", () => {
     expect(el.shadowRoot?.querySelector("div.sgds.card")).to.have.class("is-active");
   });
 
-  it("when card is disabled, card should be clickable and does not contain class is-active", async () => {
-    const el = await fixture<SgdsActionCard>(html`<sgds-action-card disabled></sgds-action-card>`);
+  it("when card is checked and disabled, class is-active is removed", async () => {
+    const el = await fixture<SgdsActionCard>(html`<sgds-action-card checked></sgds-action-card>`);
+    expect(el.shadowRoot?.querySelector("sgds-checkbox")?.getAttribute("checked")).to.exist;
+    expect(el.shadowRoot?.querySelector("div.sgds.card")).to.have.class("is-active");
 
-    expect(el.shadowRoot?.querySelector("div.sgds.card")).to.not.have.class("is-active");
-    const cardBody = el.shadowRoot?.querySelector("div.card-body") as HTMLInputElement;
-    cardBody.click();
+    el.disabled = true;
     await el.updateComplete;
+    expect(el.shadowRoot?.querySelector("sgds-checkbox")?.getAttribute("disabled")).to.exist;
     expect(el.shadowRoot?.querySelector("div.sgds.card")).to.not.have.class("is-active");
   });
 

--- a/test/action-card.test.ts
+++ b/test/action-card.test.ts
@@ -48,10 +48,10 @@ describe("<sgds-action-card>", () => {
       el,
       `
         <div tabindex="0" variant="card-action" class="sgds card
-            
-          ">
-          <div class="card-body">
-            <h6 class="text-muted card-subtitle">
+          " part="base"  
+          >
+          <div class="card-body" part="body">
+            <h6 class="text-muted card-subtitle" part="subtitle">
               <div>
               <slot name="icon"></slot>
                 <slot name="card-subtitle"></slot>
@@ -60,8 +60,8 @@ describe("<sgds-action-card>", () => {
              <sgds-checkbox checkboxid="checkbox" arialabel="checkbox"></sgds-checkbox>
             </div>
             </h6>
-            <h5 class="card-title"><slot name="card-title"></slot></h5>
-            <p class="card-text"><slot name="card-text"></slot></p>
+            <h5 class="card-title" part="title"><slot name="card-title"></slot></h5>
+            <p class="card-text" part="text"><slot name="card-text"></slot></p>
           </div>
         </div>
       `


### PR DESCRIPTION
Feature added
1) Incorporate form props and behaviours to action card so that it acts like a form component 
2) Set the behaviours for action card when it is a radio. Let radio card be wrapped in radio-group to manage the radio behaviours in a form context
3) Handle the active stylings when radio cards/ checkbox cards are clicked 
4) quantity toggle card variant is not supported yet so I removed variant prop 

Test
Check that test cases have passed and added new test case for the form behaviours

Storybook 
Update with an example of radio cards as a form 
JSdocs added 

