### PR TITLE
style(*): add global styles for fonts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,13 +1,3 @@
-<link
-  href="https://designsystem.gov.sg/css/sgds.css"
-  rel="stylesheet"
-  type="text/css"
-/>
-<link
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css"
-  rel="stylesheet"
-  type="text/css"
-/>
 <script
   type="module"
   id="dev-console-gateway"

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
         src="https://assets.developer.tech.gov.sg/bundled-scripts/dev-console-gateway.bundle.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <style>
-        * {
+        /* * {
             font-family: "bootstrap-icons", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-        }
+        } */
 
         body {
             margin: 0;

--- a/src/base/sgds-element.scss
+++ b/src/base/sgds-element.scss
@@ -1,2 +1,9 @@
 
 @import "~@govtechsg/sgds/sass/sgds.scss";
+
+:host {
+    font-family: $font-family-sans-serif;
+    font-size: $font-size-base;
+    font-weight: $font-weight-base;
+    line-height: $line-height-base;
+}


### PR DESCRIPTION
Up until now, the storybook is loading sgds cdn css that specifies the font via css variables. See image below 
![Screenshot 2023-05-21 at 11 14 11 PM](https://github.com/GovTechSG/sgds-web-component/assets/55618945/14edfdb5-a75c-4e82-9f5a-012a7d8e52f7)

Im  proposing to ship the library with fonts handled by us. 

If you got a good idea too feel free to modify this PR. 

I have removed the cdn of sgds css in storybook and index.html 
