### PR TITLE
fix(mainnav): align dropdown menu right below li

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,11 @@
         <sgds-mainnav-item href="#">About</sgds-mainnav-item>
         <sgds-mainnav-item href="#" slot="end" class="test test2">Info</sgds-mainnav-item>
         <sgds-mainnav-item href="#" slot="end">Contact Us</sgds-mainnav-item>
+        <sgds-mainnav-dropdown togglerText="Dropdown">
+            <sgds-dropdown-item href="https://google.com">Item 1</sgds-dropdown-item>
+            <sgds-dropdown-item href="#">Item 2</sgds-dropdown-item>
+            <sgds-dropdown-item href="#">Item 3</sgds-dropdown-item>
+          </sgds-mainnav-dropdown>
         <sgds-button slot="end">Login</sgds-button>
         <dev-console-widget slot="non-collapsible" iconColor="black" iconWidth="28px" iconHeight="28px">
         </dev-console-widget>

--- a/src/components/Mainnav/sgds-mainnav-dropdown.ts
+++ b/src/components/Mainnav/sgds-mainnav-dropdown.ts
@@ -10,7 +10,7 @@ export class SgdsMainnavDropdown extends DropdownElement {
 
   render() {
     return html`
-      <li class="nav-item">
+      <li class="nav-item dropdown">
         <a
           class="nav-link"
           ?disabled=${this.disabled}

--- a/stories/templates/Mainnav/basic.js
+++ b/stories/templates/Mainnav/basic.js
@@ -1,13 +1,13 @@
 import { html } from "lit-html";
 
-export const Template = ({ expand, brandHref, active, href, disabledMNI }) => {
+export const Template = ({ expand, brandHref, active, href, disabled, menuIsOpen, togglerText, close }) => {
   return html`
     <sgds-mainnav .expand=${expand} .brandHref=${brandHref}>
       <img width="130" src="https://www.designsystem.tech.gov.sg/assets/img/logo-sgds.svg" slot="brand" />
-      <sgds-mainnav-item .active=${active} .href=${href} .disabled=${disabledMNI}
+      <sgds-mainnav-item .active=${active} .href=${href} ?disabled=${disabled}
         >ArgsTable Controlled
       </sgds-mainnav-item>
-      <sgds-mainnav-dropdown togglerText="Dropdown">
+      <sgds-mainnav-dropdown togglerText=${togglerText} ?menuIsOpen=${menuIsOpen} close=${close}>
         <sgds-dropdown-item href="https://google.com">Item 1</sgds-dropdown-item>
         <sgds-dropdown-item href="#">Item 2</sgds-dropdown-item>
         <sgds-dropdown-item href="#">Item 3</sgds-dropdown-item>
@@ -25,7 +25,8 @@ export const Template = ({ expand, brandHref, active, href, disabledMNI }) => {
   `;
 };
 
-export const args = {};
-// export const storyProps = {
-//   height: "500px",
-// }
+export const args = {
+  togglerText: "Dropdown"
+};
+
+export const parameters = {};

--- a/stories/templates/Mainnav/basic.js
+++ b/stories/templates/Mainnav/basic.js
@@ -4,9 +4,7 @@ export const Template = ({ expand, brandHref, active, href, disabled, menuIsOpen
   return html`
     <sgds-mainnav .expand=${expand} .brandHref=${brandHref}>
       <img width="130" src="https://www.designsystem.tech.gov.sg/assets/img/logo-sgds.svg" slot="brand" />
-      <sgds-mainnav-item .active=${active} .href=${href} ?disabled=${disabled}
-        >ArgsTable Controlled
-      </sgds-mainnav-item>
+      <sgds-mainnav-item .active=${active} .href=${href} ?disabled=${disabled}>ArgsTable Controlled </sgds-mainnav-item>
       <sgds-mainnav-dropdown togglerText=${togglerText} ?menuIsOpen=${menuIsOpen} close=${close}>
         <sgds-dropdown-item href="https://google.com">Item 1</sgds-dropdown-item>
         <sgds-dropdown-item href="#">Item 2</sgds-dropdown-item>

--- a/test/mainnav.test.ts
+++ b/test/mainnav.test.ts
@@ -241,7 +241,7 @@ describe("sgds-mainnav-dropdown", () => {
     const el = await fixture(html`<sgds-mainnav-dropdown togglerText="test"></sgds-mainnav-dropdown>`);
     assert.shadowDom.equal(
       el,
-      ` <li class="nav-item">
+      ` <li class="nav-item dropdown">
       <a
         class="nav-link"
         aria-expanded="false"


### PR DESCRIPTION
## :open_book: Description

Fix sgds-mainnav-dropdown alignment issue 

Fixes # (issue)
- Mainnav dropdown was not aligning directly on the bottom of the link
- 
## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- 
## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit test

## :white_check_mark: Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
