### PR TITLE
[CSS] Refactor variant css tokens

### DIFF
--- a/src/base/sgds-element.scss
+++ b/src/base/sgds-element.scss
@@ -9,9 +9,13 @@ $theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value");
     font-size: var(--sgds-body-font-size, $font-size-base);
     font-weight: var(--sgds-body-font-weight, $font-weight-base);
     line-height: var(--sgds-body-line-height, $line-height-base);
-
+    // Generates all rgb color declared in the $theme-colors from _variables.scss
     @each $color, $value in $theme-colors-rgb {
+        
         --sgds-#{$color}-rgb : #{$value};
     }
-
+    @each $color, $value in $theme-colors {
+        
+        --sgds-#{$color} : #{$value};
+    }
 }

--- a/src/base/sgds-element.scss
+++ b/src/base/sgds-element.scss
@@ -1,9 +1,17 @@
 
 @import "~@govtechsg/sgds/sass/sgds.scss";
 
+$theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value");
+//@debug $theme-colors-rgb;
+//debug: ("primary": (89, 37, 220), "secondary": (31, 105, 255), "success": (10, 130, 23), "info": (15, 113, 187), "warning": (247, 144, 9), "danger": (215, 38, 15), "light": (247, 247, 249), "dark": (0, 0, 0))
 :host {
     font-family: var(--sgds-body-font-family, $font-family-sans-serif);
     font-size: var(--sgds-body-font-size, $font-size-base);
     font-weight: var(--sgds-body-font-weight, $font-weight-base);
     line-height: var(--sgds-body-line-height, $line-height-base);
+
+    @each $color, $value in $theme-colors-rgb {
+        --sgds-#{$color}-rgb : #{$value};
+    }
+
 }

--- a/src/components/Badge/sgds-badge.ts
+++ b/src/components/Badge/sgds-badge.ts
@@ -6,18 +6,25 @@ import styles from "./sgds-badge.scss";
 
 export type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
 
+/**
+ * @summary Badges can be used to highlight important bits of information such as labels, notifications & status.
+ * @slot default - slot for badge
+ */
 @customElement("sgds-badge")
 export class SgdsBadge extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
 
+  /** One or more button variant combinations buttons may be one of a variety of visual variants such as: `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `dark`, `light`, `link` */
   @property({ reflect: true }) variant: BadgeVariant = "primary";
-  @property({ type: Boolean, reflect: true }) isLight;
-  @property({ type: Boolean, reflect: true }) roundedPill;
+  /** Visually set badge for lesser color emphasis. */
+  @property({ type: Boolean, reflect: true }) isLight = false;
+  /** Visually set badge with rounded corners. */
+  @property({ type: Boolean, reflect: true }) roundedPill = false;
   render() {
     return html`
       <span
         class="  
-                ${classMap({
+          ${classMap({
           "sgds badge": true,
           [`bg-${this.variant}`]: this.variant,
           "badge-light": this.isLight,


### PR DESCRIPTION
## :open_book: Description

Refactor variant css tokens
Adding `$theme-colors-rgb` color mixin loop 
Generating all $theme-colors in `variables.scss`.

Both badge and spinner components are working as intended.

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in storybook visually. 

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x]  I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
