### PR TITLE
Implement a11y for Breadcrumb

### DIFF
--- a/src/components/Breadcrumb/sgds-breadcrumb.ts
+++ b/src/components/Breadcrumb/sgds-breadcrumb.ts
@@ -16,7 +16,7 @@ import styles from "./sgds-breadcrumb.scss";
 export class SgdsBreadcrumb extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
   /** The aria-label of nav element within breadcrumb component. */
-  @property({ type: String }) ariaLabel: string;
+  @property({ type: String }) ariaLabel: string = 'breadcrumb';
   /**@internal */
   @query("slot") defaultSlot: HTMLSlotElement;
   /**@internal */

--- a/test/breadcrumb.test.ts
+++ b/test/breadcrumb.test.ts
@@ -12,6 +12,7 @@ describe("sgds-breadcrumb", () => {
     assert.shadowDom.equal(
       el,
       `<nav
+      aria-label="breadcrumb"
       part="base"
     >
       <ol class="breadcrumb">


### PR DESCRIPTION
## :open_book: Description

Add default value for aria-label. Previously, default value wasn't specified, even though docs indicate so.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
