### PR TITLE
Implement a11y for Modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,17 @@
         <div class="cotainer">
             <h2>Progress</h2>
             <div class="row">
+                <div class="container">
+                    <sgds-button id="modalShowButton">Open Modal</sgds-button>
+                        <sgds-modal title="hello" titleicon="<svg xmlns=&quot;http://www.w3.org/2000/svg&quot; width=&quot;16&quot; height=&quot;16&quot; fill=&quot;currentColor&quot; class=&quot;bi bi-amd&quot; viewBox=&quot;0 0 16 16&quot;>
+                    <path d=&quot;m.334 0 4.358 4.359h7.15v7.15l4.358 4.358V0H.334ZM.2 9.72l4.487-4.488v6.281h6.28L6.48 16H.2V9.72Z&quot;/>
+                    </svg>">
+                        This is a Modal
+                        <sgds-button slot="footer" variant="link" class="close-modal">Close</sgds-button>
+                        <sgds-button slot="footer" variant="primary" type="submit" form="formA">Submit</sgds-button>
+                    </sgds-modal>
+                </div>
+                
                 <sgds-progress height="40">
                     <sgds-progress-bar value="50"></sgds-progress-bar>
                 </sgds-progress>
@@ -651,6 +662,12 @@ dp.addEventListener('sgds-change-date', event => {
         comboBox.filterFunction = (inputValue, menuItem) => {
             return menuItem.includes(inputValue);
         }
+
+        const modalShowButton = document.querySelector('#modalShowButton');
+        modalShowButton.addEventListener('click', () => {
+            const modal = document.querySelector("sgds-modal");
+            modal.show();
+        });
     </script>
 </body>
 

--- a/src/components/Modal/sgds-modal.ts
+++ b/src/components/Modal/sgds-modal.ts
@@ -52,6 +52,8 @@ export class SgdsModal extends SgdsElement {
   /**@internal */
   @query(".modal-overlay") overlay: HTMLElement;
   /**@internal */
+  @query(".modal-title") heading: HTMLElement;
+  /**@internal */
   private readonly hasSlotController = new HasSlotController(this, "footer");
   /**@internal */
   private modal: Modal;
@@ -168,6 +170,9 @@ export class SgdsModal extends SgdsElement {
         ]));
 
       this.emit("sgds-after-show");
+
+      // Add focus on modal heading after opening it
+      this.heading.focus();
     } else {
       // Hide
       this.emit("sgds-hide");
@@ -221,7 +226,7 @@ export class SgdsModal extends SgdsElement {
           centered: this.centered
         })}
       >
-        <div part="overlay" class="modal-overlay" @click=${() => this.requestClose("overlay")} tabindex="-1"></div>
+        <div part="overlay" class="modal-overlay" @click=${() => this.requestClose("overlay")}></div>
 
         <div
           part="panel"
@@ -231,27 +236,28 @@ export class SgdsModal extends SgdsElement {
           aria-hidden=${this.open ? "false" : "true"}
           aria-label=${ifDefined(this.noHeader ? this.title : undefined)}
           aria-labelledby=${ifDefined(!this.noHeader ? "title" : undefined)}
-          tabindex="0"
+          tabindex="-1"
         >
           ${!this.noHeader
             ? html`
-                <h3
+                <div
                   part="header"
                   class=${classMap({
                     "modal-header": true,
                     centered: this.centeredAlignVariant
                   })}
                 >
-                  <div
+                  <h3
                     part="title"
                     class=${classMap({
                       "modal-title": true,
                       centered: this.centeredAlignVariant
                     })}
                     id="title"
+                    tabindex="-1"
                   >
                     ${this.titleIcon ? withLabelIcon : ""} ${this.title}
-                  </div>
+                  </h3>
                   <button
                     class=${classMap({
                       "modal-close": true,
@@ -262,7 +268,7 @@ export class SgdsModal extends SgdsElement {
                     @click="${() => this.requestClose("close-button")}"
                     aria-label="close modal"
                   ></button>
-                </h3>
+                </div>
               `
             : ""}
 


### PR DESCRIPTION
## :open_book: Description

Add focus on modal when after it opens, so screen reader will announce it after opening.

**Additional related side changes:**
- Update tags for modal-header (should be `<div>`) and modal-title (should be `h3`)


## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
