### PR TITLE
WIP: Implement a11y for Dropdown

### DIFF
--- a/src/base/dropdown-element.ts
+++ b/src/base/dropdown-element.ts
@@ -5,6 +5,7 @@ import { property, state } from "lit/decorators.js";
 import { Ref, createRef } from "lit/directives/ref.js";
 import mergeDeep from "../utils/mergeDeep";
 import SgdsElement from "./sgds-element";
+import generateId from "../utils/generateId";
 
 const ARROW_DOWN = "ArrowDown";
 const ARROW_UP = "ArrowUp";
@@ -27,6 +28,9 @@ export class DropdownElement extends SgdsElement {
   protected myDropdown: Ref<HTMLElement> = createRef();
   /** @internal */
   protected bsDropdown: Dropdown = null;
+
+  /** @internal Unique id generated for the dropdown menu */
+  protected dropdownMenuId: string = generateId("dropdown-menu", "ul");
 
   /** @internal Controls auto-flipping of menu */
   @property({ type: Boolean, state: true })

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -119,7 +119,7 @@ export class SgdsComboBox extends ScopedElementsMixin(DropdownListElement) {
           ?readonly=${this.readonly}
           .value=${this.value}
           @sgds-input=${this._handleInputChange}
-          role="listbox"
+          role="combobox"
           aria-expanded="${this.menuIsOpen}"
           aria-autocomplete="list"
           tabIndex="0"

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -120,15 +120,15 @@ export class SgdsComboBox extends ScopedElementsMixin(DropdownListElement) {
           .value=${this.value}
           @sgds-input=${this._handleInputChange}
           role="combobox"
-          aria-expanded="${this.menuIsOpen}"
+          aria-expanded=${this.menuIsOpen}
           aria-autocomplete="list"
-          tabIndex="0"
+          aria-controls=${this.dropdownMenuId}
         >
         </sgds-input>
         <div class="form-control-icon">
           <slot name="icon"></slot>
         </div>
-        <ul class="dropdown-menu" part="menu" tabindex="-1">
+        <ul id=${this.dropdownMenuId} class="dropdown-menu" part="menu" tabindex="-1">
           ${this.filteredMenuList.map(
             item =>
               html`<sgds-dropdown-item href="javascript:void(0)" @click=${this._handleSelectChange}

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -119,12 +119,16 @@ export class SgdsComboBox extends ScopedElementsMixin(DropdownListElement) {
           ?readonly=${this.readonly}
           .value=${this.value}
           @sgds-input=${this._handleInputChange}
+          role="listbox"
+          aria-expanded="${this.menuIsOpen}"
+          aria-autocomplete="list"
+          tabIndex="0"
         >
         </sgds-input>
         <div class="form-control-icon">
           <slot name="icon"></slot>
         </div>
-        <ul class="dropdown-menu" part="menu">
+        <ul class="dropdown-menu" part="menu" tabindex="-1">
           ${this.filteredMenuList.map(
             item =>
               html`<sgds-dropdown-item href="javascript:void(0)" @click=${this._handleSelectChange}

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -335,6 +335,9 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) {
           readonly
           ?required=${this.required}
           ?disabled=${this.disabled}
+          role="combobox"
+          aria-haspopup="dialog"
+          aria-controls=${this.dropdownMenuId}
         ></sgds-input>
         <button
           ?disabled=${this.disabled}
@@ -344,8 +347,9 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) {
           ${svgEl}
         </button>
         <ul
+          id=${this.dropdownMenuId}
           class="sgds datepicker dropdown-menu"
-          role="menu"
+          role="dialog"
           part="menu"
           @click=${(event: MouseEvent) => event.stopPropagation()}
         >

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -86,6 +86,7 @@ export class SgdsDropdown extends ScopedElementsMixin(DropdownListElement) {
           variant="outline-${this.variant}"
           ?disabled=${this.disabled}
           aria-expanded="${this.menuIsOpen}"
+          aria-haspopup="menu"
           ${ref(this.myDropdown)}
           @click=${() => this.toggleMenu()}
           id=${this.togglerId}

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -82,6 +82,7 @@ export class SgdsDropdown extends ScopedElementsMixin(DropdownListElement) {
     return html`
       <div>
         <sgds-button
+          role="button"
           variant="outline-${this.variant}"
           ?disabled=${this.disabled}
           aria-expanded="${this.menuIsOpen}"

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -178,6 +178,7 @@ describe("sgds-dropdown", () => {
       `  <div>
          <sgds-button
            aria-expanded="false"
+           role="button"
          variant="outline-secondary"
          >
          <svg

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -177,8 +177,9 @@ describe("sgds-dropdown", () => {
       el,
       `  <div>
          <sgds-button
-           aria-expanded="false"
            role="button"
+           aria-expanded="false"
+           aria-haspopup="menu"
          variant="outline-secondary"
          >
          <svg


### PR DESCRIPTION
## :open_book: Description

**sgds-dropdown**
- Add button role, aria-expanded, aria-haspopup

**sgds-combo-box**
- Add combobox role, aria-expanded (will not be read by screen-reader because button role is not indicated), aria-autocomplete, aria-controls

**sgds-datepicker**
- add combobox role, aria-haspopup, aria-controls
- Change dropdown-menu role to 'dialog'


**Current issues**
- Dropdown components that use input as toggler (e.g. combobox, datepicker) are not screen-reader accessible (user cannot click to open dropdown menu)
- When dropdown menu opens, screen-reader does not shift focus to the dropdown menu (even though I implemented aria-controls attribute, might be a limitation of web components (?) ). I tried doing it programatically by calling dropdownMenu.focus() when dropdown menu opens. But not quite a good solution because for dropdown components that use input e.g. combobox, the focus shifts out of the input box, and the user cannot type in stuff in the input box


## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
