### PR TITLE
fix(alert): remove default svg vertical align stylings for alert

### DIFF
--- a/src/components/Alert/sgds-alert.scss
+++ b/src/components/Alert/sgds-alert.scss
@@ -1,9 +1,11 @@
 :host {
   --alert-icon-margin-right: 0.5rem;
+ 
 }
 
 slot[name="icon"]::slotted(svg) {
   margin-right: var(--alert-icon-margin-right);
+  vertical-align: unset !important;
 }
 
 i {


### PR DESCRIPTION

## :open_book: Description

vertical align stylings coming from bootstrap reboot scss causing svg icon to be out of line. 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [X] My code follows the SGDS style guidelines and naming conventions
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
