### PR TITLE
build(vite): temporarily ignoring inline-css warning from vite dev

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig, createLogger } from "vite";
 import postcssLit from "rollup-plugin-postcss-lit";
+
+const logger = createLogger();
+const originalWarning = logger.warn;
+logger.warn = (msg, options) => {
+  if (msg.includes("Default and named imports from CSS files are deprecated")) return;
+  originalWarning(msg, options);
+};
 
 export default defineConfig({
   plugins: [postcssLit({ include: ["**/*.scss", "**/*.scss?*"] })],
@@ -14,5 +21,6 @@ export default defineConfig({
   },
   define: {
     "process.env.VITE_ENV": JSON.stringify(process.env.VITE_ENV)
-  }
+  },
+  customLogger: logger
 });


### PR DESCRIPTION
## :open_book: Description

Temporarily ignoring the vite inline?css warning in dev mode, until i got the bandwidth to fix it. 

Fixes # (issue)

## :pencil2: Type of change
 Tempora
```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
