### PR TITLE
Fix lit-element deprecated console warning [skip-cd]

### DIFF
--- a/cypress/apps/angular-app/package-lock.json
+++ b/cypress/apps/angular-app/package-lock.json
@@ -46,6 +46,7 @@
         "@open-wc/scoped-elements": "^2.2.0",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",
         "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
         "lit": "^2.3.1",
         "tslib": "^2.6.2"
       }

--- a/cypress/apps/react-app/package-lock.json
+++ b/cypress/apps/react-app/package-lock.json
@@ -24,13 +24,15 @@
     },
     "../../../lib": {
       "name": "@govtechsg/sgds-web-component",
-      "version": "0.0.1",
+      "version": "1.0.2",
+      "license": "MIT",
       "dependencies": {
         "@govtechsg/sgds": "^2.1.1",
         "@lit-labs/react": "^1.0.9",
         "@open-wc/scoped-elements": "^2.2.0",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",
         "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
         "lit": "^2.3.1",
         "tslib": "^2.6.2"
       }
@@ -19535,6 +19537,7 @@
         "@open-wc/scoped-elements": "^2.2.0",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",
         "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
         "lit": "^2.3.1",
         "tslib": "^2.6.2"
       }

--- a/cypress/apps/vue-app/package-lock.json
+++ b/cypress/apps/vue-app/package-lock.json
@@ -25,13 +25,15 @@
     },
     "../../../lib": {
       "name": "@govtechsg/sgds-web-component",
-      "version": "0.0.1",
+      "version": "1.0.2",
+      "license": "MIT",
       "dependencies": {
         "@govtechsg/sgds": "^2.1.1",
         "@lit-labs/react": "^1.0.9",
         "@open-wc/scoped-elements": "^2.2.0",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",
         "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
         "lit": "^2.3.1",
         "tslib": "^2.6.2"
       }
@@ -1648,6 +1650,7 @@
         "@open-wc/scoped-elements": "^2.2.0",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",
         "bootstrap": "^5.1.3",
+        "date-fns": "^3.3.1",
         "lit": "^2.3.1",
         "tslib": "^2.6.2"
       }

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
     </style>
     <!-- <script src="https://cdn.jsdelivr.net/npm/clk-web-components" type="module"></script> -->
     <script type="module">
-        // import "@webcomponents/scoped-custom-element-registry";
+        import "@webcomponents/scoped-custom-element-registry";
     </script>
     <script type="module">
         let scriptTarget = document.getElementsByTagName( 'head' )[ 0 ]
@@ -116,7 +116,7 @@
         moduleScript.type = "module";
         if ( process.env.VITE_ENV === 'production' ) {
             // preview production build
-            moduleScript.src = 'dist/index.js'
+            moduleScript.src = 'lib/index.js'
         } else {
             // development server
             moduleScript.src = 'src/index.ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "rollup": "^2.79.1",
         "rollup-plugin-generate-package-json": "^3.2.0",
         "rollup-plugin-postcss": "^4.0.0",
-        "rollup-plugin-postcss-lit": "^1.0.1",
+        "rollup-plugin-postcss-lit": "^2.1.0",
         "rollup-plugin-typescript2": "^0.33.0",
         "rollup-plugin-visualizer": "^5.9.2",
         "sass": "~1.49.9",
@@ -34010,30 +34010,48 @@
       }
     },
     "node_modules/rollup-plugin-postcss-lit": {
-      "version": "1.1.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss-lit/-/rollup-plugin-postcss-lit-2.1.0.tgz",
+      "integrity": "sha512-rtgCG0U2GkT5aLymkZEKXLq36sgtWVJFtL97Vmek0jgaYa6FDs0Xhqd9cCHdDBXPeTctlSZGGs+tpUtIpHMFMQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^4.1.0",
+        "@rollup/pluginutils": "^5.0.2",
         "transform-ast": "^2.4.4"
       }
     },
     "node_modules/rollup-plugin-postcss-lit/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/rollup-plugin-postcss-lit/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/rollup-plugin-postcss-lit/node_modules/estree-walker": {
       "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/rollup-plugin-postcss/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rollup": "^2.79.1",
     "rollup-plugin-generate-package-json": "^3.2.0",
     "rollup-plugin-postcss": "^4.0.0",
-    "rollup-plugin-postcss-lit": "^1.0.1",
+    "rollup-plugin-postcss-lit": "^2.1.0",
     "rollup-plugin-typescript2": "^0.33.0",
     "rollup-plugin-visualizer": "^5.9.2",
     "sass": "~1.49.9",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -23,7 +23,8 @@ const external = [
 const wcPlugins = [
   resolve({
     browser: true,
-    dedupe: external
+    dedupe: external,
+    exportConditions: ['development']
   }),
   replace({
     "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
@@ -105,7 +106,7 @@ const buildSgdsPackage = () => {
     },
     ...buildUMDComponentBundles()
   ];
-  
+
   const reactPackage = [
     {
       input: "src/react/index.ts",


### PR DESCRIPTION
latest version uses lit over lit-element by default

## :open_book: Description

Due to rollup-plugin-postcss-lit, using lit-element package by default. 
Update to latest version resolves the issue as the package is using lit now. 

Fixes # (issue)

#170

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
