### PR TITLE
A11y/datepicker patches [skip-cd]

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,16 +242,16 @@
                     maxdate="2024-01-30T12:00:00.000Z"></sgds-datepicker>
                 <sgds-button type="submit">Submit</sgds-button>
             </form> -->
-
+            <sgds-datepicker
+            label="Choose a date"
+          ></sgds-datepicker>
+          
             <form id="datepicker-form" >
                 <sgds-datepicker
                   name="myDatepicker"
                   id="form-submission-example"
                   label="Choose a date"
                   hintText="The minimum date is 10 June 2023 and maximum date is 19 June 2023"
-                  .displayDate=${args.displayDate}
-                  minDate="2023-06-10T12:00:00.000Z"
-                  maxDate="2023-06-19T12:00:00.000Z"
                   required
                 ></sgds-datepicker>
                 <button type="submit">Submit</button>

--- a/index.html
+++ b/index.html
@@ -274,6 +274,8 @@
             <sgds-datepicker mode="range" initialValue='["20/01/2024", "22/02/2024"]' mindate="2024-01-02T12:00:00.000Z"
                 maxdate="2024-01-30T12:00:00.000Z">
             </sgds-datepicker>
+            <sgds-datepicker mode="range" initialValue='["20/01/2024", "22/02/2024"]'>
+            </sgds-datepicker>
 
             <!-- <sgds-datepicker menuIsOpen noFeedback></sgds-datepicker> -->
 

--- a/src/components/Accordion/sgds-accordion.ts
+++ b/src/components/Accordion/sgds-accordion.ts
@@ -63,7 +63,7 @@ export class SgdsAccordion extends SgdsElement {
       return;
     }
     items.forEach(item => {
-      // Covers all elements within accordion-item 
+      // Covers all elements within accordion-item
       if (!event.composedPath().includes(item)) {
         // Close all the items that didn't dispatch the event.
         item.open = false;

--- a/src/components/Datepicker/datepicker-calendar.scss
+++ b/src/components/Datepicker/datepicker-calendar.scss
@@ -32,7 +32,7 @@ button.year {
       @extend %selected-ends-shared;
     }
   }
-  &:hover {
+  &:hover:not(.active) {
     @extend %active-shared;
   }
   &:focus {
@@ -48,7 +48,7 @@ td {
 
   &[data-day] {
     cursor: pointer;
-    &:hover:not(.disabled) {
+    &:hover:not(.disabled):not(.selected-ends) {
       @extend %active-shared;
     }
     &.active {

--- a/src/components/Datepicker/datepicker-calendar.ts
+++ b/src/components/Datepicker/datepicker-calendar.ts
@@ -7,6 +7,7 @@ import { createYearViewArray, setTimeToNoon } from "../../utils/time";
 import { watch } from "../../utils/watch";
 import styles from "./datepicker-calendar.scss";
 import { ViewEnum } from "./types";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 const TODAY_DATE = new Date();
 
@@ -36,13 +37,26 @@ export class DatepickerCalendar extends SgdsElement {
   static styles = [SgdsElement.styles, styles];
 
   /** @internal */
-  static DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  static DAY_LABELS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
   /** @internal */
   static daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
   /** @internal */
-  static MONTHVIEW_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  static MONTHVIEW_LABELS = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+  ];
 
   /** @internal */
   @property({ type: Array }) selectedDate: Date[] = [];
@@ -339,6 +353,7 @@ export class DatepickerCalendar extends SgdsElement {
               data-date=${dateStr}
               data-day=${day}
               aria-label=${ariaLabel}
+              aria-current=${ifDefined(isCurrentDay && isCurrentMonth && isCurrentYear ? "date" : undefined)}
               class=${classMap({
                 today: isCurrentDay && isCurrentMonth && isCurrentYear,
                 "selected-ends": isFirstSelectedDate || isLastSelectedDate,
@@ -346,10 +361,10 @@ export class DatepickerCalendar extends SgdsElement {
                 disabled: beforeMinDate || afterMinDate
               })}
               @click=${clickHandler}
-              aria-selected=${isSelected}
+              aria-selected=${ifDefined(isSelected ? "true" : undefined)}
               tabindex=${this.focusedDate === new Date(dateStr) ? "3" : "-1"}
               ?disabled=${beforeMinDate || afterMinDate}
-              aria-disabled=${beforeMinDate || afterMinDate ? "true" : "false"}
+              aria-disabled=${ifDefined(beforeMinDate || afterMinDate ? "true" : undefined)}
               role="button"
             >
               ${day}
@@ -372,14 +387,14 @@ export class DatepickerCalendar extends SgdsElement {
     }
 
     const dayView = html`
-      <table class="text-center">
+      <table class="text-center" role="grid">
         <thead>
           <tr>
             ${DatepickerCalendar.DAY_LABELS.map(
               (label: string, index: number) =>
                 html`
-                  <th key=${index}>
-                    <small>${label}</small>
+                  <th key=${index} abbr=${label} scope="col">
+                    <small>${label.slice(0, 3)}</small>
                   </th>
                 `
             )}
@@ -408,6 +423,7 @@ export class DatepickerCalendar extends SgdsElement {
           const isFirstSelectedYear = rangeDates[0].getFullYear() === year;
           const isLastSelectedMonth = rangeDates[rangeDates.length - 1].getMonth() === idx;
           const isLastSelectedYear = rangeDates[rangeDates.length - 1].getFullYear() === year;
+          const ariaLabel = isCurrentMonth ? `Current month ${m} ${year}` : `${m} ${year}`;
           return html` <button
             class=${classMap({
               active: selectedTime.includes(time),
@@ -421,8 +437,9 @@ export class DatepickerCalendar extends SgdsElement {
             data-year=${year}
             tabindex="3"
             aria-selected=${selectedTime.includes(time)}
+            aria-label=${ariaLabel}
           >
-            ${m}
+            ${m.slice(0, 3)}
           </button>`;
         })}
       </div>
@@ -454,6 +471,7 @@ export class DatepickerCalendar extends SgdsElement {
               tabindex="3"
               ?disabled=${y < 1900}
               aria-selected=${selectedYears.includes(y)}
+              aria-label=${ifDefined(CURRENT_YEAR === y ? `Current year, ${y}` : undefined)}
             >
               ${y}
             </button>

--- a/src/components/Datepicker/datepicker-calendar.ts
+++ b/src/components/Datepicker/datepicker-calendar.ts
@@ -1,12 +1,12 @@
-import { HTMLTemplateResult, html, nothing } from "lit";
+import { format, isAfter, isEqual } from "date-fns";
+import { HTMLTemplateResult, html } from "lit";
 import { property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import SgdsElement from "../../base/sgds-element";
 import { createYearViewArray, setTimeToNoon } from "../../utils/time";
 import { watch } from "../../utils/watch";
 import styles from "./datepicker-calendar.scss";
 import { ViewEnum } from "./types";
-import { classMap } from "lit/directives/class-map.js";
-import { isAfter, isEqual, format } from "date-fns";
 
 const TODAY_DATE = new Date();
 

--- a/src/components/Datepicker/datepicker-calendar.ts
+++ b/src/components/Datepicker/datepicker-calendar.ts
@@ -81,13 +81,6 @@ export class DatepickerCalendar extends SgdsElement {
     this.addEventListener("keydown", this._handleKeyPress);
   }
 
-  firstUpdated() {
-    // if (this.selectedDate.length > 0) {
-    //   this.focusedDate = setTimeToNoon(this.selectedDate[0]);
-    // } else {
-    //   this.focusedDate = this.displayDate && setTimeToNoon(this.displayDate);
-    // }
-  }
   updated() {
     /** For KeyboardNavigation (switching months) and ClickNavigation:
      * Runs after render has completed and td of next month has appeared.

--- a/src/components/Datepicker/datepicker-calendar.ts
+++ b/src/components/Datepicker/datepicker-calendar.ts
@@ -356,6 +356,7 @@ export class DatepickerCalendar extends SgdsElement {
               aria-selected=${isSelected}
               tabindex=${this.focusedDate === new Date(dateStr) ? "3" : "-1"}
               ?disabled=${beforeMinDate || afterMinDate}
+              aria-disabled=${beforeMinDate || afterMinDate ? "true" : "false"}
               role="button"
             >
               ${day}

--- a/src/components/Datepicker/datepicker-header.scss
+++ b/src/components/Datepicker/datepicker-header.scss
@@ -11,9 +11,14 @@
     &:focus {
       outline: var(--datepicker-theme-color) auto 2px;
     }
+    &.cursor-not-allowed {
+      cursor: not-allowed;
+    }
+    
   }
 
   svg {
     font-size: 10rem;
   }
 }
+

--- a/src/components/Datepicker/datepicker-header.scss
+++ b/src/components/Datepicker/datepicker-header.scss
@@ -11,14 +11,15 @@
     &:focus {
       outline: var(--datepicker-theme-color) auto 2px;
     }
-    &.cursor-not-allowed {
+    &.disabled {
       cursor: not-allowed;
     }
-    
+    &:hover:not(.disabled) {
+      background-color: var(--datepicker-hover-bg-color);
+    }
   }
 
   svg {
     font-size: 10rem;
   }
 }
-

--- a/src/components/Datepicker/datepicker-header.ts
+++ b/src/components/Datepicker/datepicker-header.ts
@@ -189,7 +189,7 @@ export class DatepickerHeader extends SgdsElement {
             class=${classMap({ "cursor-not-allowed": this.view === "years" })}
             tabindex="1"
             aria-label=${this._ariaLabelForHeaderBtn()}
-            aria-disabled=${this.view === "years"?  "true" : "false"}
+            aria-disabled=${this.view === "years" ? "true" : "false"}
           >
             ${this._renderHeaderTemplate()}
           </button>

--- a/src/components/Datepicker/datepicker-header.ts
+++ b/src/components/Datepicker/datepicker-header.ts
@@ -186,7 +186,7 @@ export class DatepickerHeader extends SgdsElement {
           </button>
           <button
             @click=${this._changeView}
-            class=${classMap({ "cursor-not-allowed": this.view === "years" })}
+            class=${classMap({ disabled: this.view === "years" })}
             tabindex="1"
             aria-disabled=${this.view === "years" ? "true" : "false"}
             aria-live="polite"

--- a/src/components/Datepicker/datepicker-header.ts
+++ b/src/components/Datepicker/datepicker-header.ts
@@ -158,7 +158,7 @@ export class DatepickerHeader extends SgdsElement {
       months: `Current view is months, click to show years between ${this.renderHeader(this.displayDate, "years")}`,
       years: `Current view is years`
     };
-    return message[this.view];
+    return `${this.renderHeader()}. ${message[this.view]}`;
   }
   render() {
     return html`
@@ -167,7 +167,7 @@ export class DatepickerHeader extends SgdsElement {
           <button
             @click="${this.handleClickPrevious}"
             tabindex="0"
-            class="${classMap({ invisible: this._removeCaret() })}"
+            class=${classMap({ invisible: this._removeCaret() })}
             aria-label=${this._ariaLabelForPrevBtn()}
           >
             <svg
@@ -189,6 +189,7 @@ export class DatepickerHeader extends SgdsElement {
             class=${classMap({ "cursor-not-allowed": this.view === "years" })}
             tabindex="1"
             aria-label=${this._ariaLabelForHeaderBtn()}
+            aria-disabled=${this.view === "years"?  "true" : "false"}
           >
             ${this._renderHeaderTemplate()}
           </button>
@@ -233,5 +234,5 @@ export const MONTH_LABELS = [
 const AriaLabelViewState = {
   days: "month",
   months: "year",
-  years: "decade"
+  years: "12 years"
 };

--- a/src/components/Datepicker/datepicker-header.ts
+++ b/src/components/Datepicker/datepicker-header.ts
@@ -230,9 +230,3 @@ export const MONTH_LABELS = [
   "November",
   "December"
 ];
-
-const AriaLabelViewState = {
-  days: "month",
-  months: "year",
-  years: "12 years"
-};

--- a/src/components/Datepicker/datepicker-header.ts
+++ b/src/components/Datepicker/datepicker-header.ts
@@ -1,4 +1,4 @@
-import { isBefore, isEqual, setMonth, setYear } from "date-fns";
+import { isBefore, isEqual } from "date-fns";
 import { html } from "lit";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -137,19 +137,19 @@ export class DatepickerHeader extends SgdsElement {
 
   private _ariaLabelForNextBtn() {
     const nextBtnDate = {
-      days: setMonth(this.displayDate, this.displayDate.getMonth() + 1),
-      months: setYear(this.displayDate, this.displayDate.getFullYear() + 1),
-      years: setYear(this.displayDate, this.displayDate.getFullYear() + 12)
+      days: "Show next month",
+      months: "Show next year",
+      years: "Show next 12 years"
     };
-    return `Go to next ${AriaLabelViewState[this.view]}, ${this.renderHeader(nextBtnDate[this.view])}`;
+    return nextBtnDate[this.view];
   }
   private _ariaLabelForPrevBtn() {
     const prevBtnDate = {
-      days: setMonth(this.displayDate, this.displayDate.getMonth() - 1),
-      months: setYear(this.displayDate, this.displayDate.getFullYear() - 1),
-      years: setYear(this.displayDate, this.displayDate.getFullYear() - 12)
+      days: "Show previous month",
+      months: "Show previous year",
+      years: "Show previous 12 years"
     };
-    return `Go to previous ${AriaLabelViewState[this.view]}, ${this.renderHeader(prevBtnDate[this.view])}`;
+    return prevBtnDate[this.view];
   }
 
   private _ariaLabelForHeaderBtn() {
@@ -188,8 +188,8 @@ export class DatepickerHeader extends SgdsElement {
             @click=${this._changeView}
             class=${classMap({ "cursor-not-allowed": this.view === "years" })}
             tabindex="1"
-            aria-label=${this._ariaLabelForHeaderBtn()}
             aria-disabled=${this.view === "years" ? "true" : "false"}
+            aria-live="polite"
           >
             ${this._renderHeaderTemplate()}
           </button>

--- a/src/components/Datepicker/datepicker-input.ts
+++ b/src/components/Datepicker/datepicker-input.ts
@@ -132,8 +132,8 @@ export class DatepickerInput extends SgdsInput {
     return await this._applyInputMask(this.dateFormat);
   }
   public async focus() {
-    const input = await this.shadowInput
-    return input.focus()
+    const input = await this.shadowInput;
+    return input.focus();
   }
   render() {
     return html`

--- a/src/components/Datepicker/datepicker-input.ts
+++ b/src/components/Datepicker/datepicker-input.ts
@@ -131,7 +131,10 @@ export class DatepickerInput extends SgdsInput {
   public async applyInputMask() {
     return await this._applyInputMask(this.dateFormat);
   }
-
+  public async focus() {
+    const input = await this.shadowInput
+    return input.focus()
+  }
   render() {
     return html`
       ${this._renderLabel()} ${this._renderHintText()}

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -1,6 +1,6 @@
 import { ScopedElementsMixin } from "@open-wc/scoped-elements";
 import { format, parse } from "date-fns";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { property, query, queryAsync, state } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
 import { ref } from "lit/directives/ref.js";
@@ -103,6 +103,8 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
 
   @state() private focusedTabIndex = 3;
 
+  @state() dialogAriaLabel: string;
+
   private initialDisplayDate: Date;
 
   @queryAsync("sgds-datepicker-calendar")
@@ -110,6 +112,9 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
 
   @queryAsync("sgds-datepicker-input")
   private datepickerInputAsync: Promise<DatepickerInput>;
+
+  @queryAsync("sgds-datepicker-header")
+  private datepickerHeaderAsync: Promise<DatepickerHeader>;
 
   @query("sgds-datepicker-input")
   private datepickerInput: DatepickerInput;
@@ -362,6 +367,20 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
   private async _handleInputMaskChange(e: CustomEvent) {
     this.value = e.detail;
   }
+
+  private _dialogAriaLabel() {
+    const view = this.view.replace("s", "");
+    // const header = await this.datepickerHeaderAsync;
+    const header = this.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
+    if (header) {
+      const headerText = header.renderHeader().toString().replace("-", "to");
+      this.dialogAriaLabel = `Choose ${view} from ${headerText}`;
+    }
+  }
+
+  updated() {
+    this._dialogAriaLabel();
+  }
   render() {
     const svgEl = html`
       <svg
@@ -438,6 +457,7 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
           class="sgds datepicker dropdown-menu"
           role="dialog"
           part="menu"
+          aria-label=${this.dialogAriaLabel}
           @click=${(event: MouseEvent) => event.stopPropagation()}
         >
           <sgds-datepicker-header

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -149,6 +149,7 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
     this.addEventListener("sgds-empty-input", this._handleEmptyInput);
     this.addEventListener("keydown", this._handleTab);
     this.addEventListener("sgds-hide", this._handleCloseMenu);
+    this.addEventListener("sgds-show", this._handleOpenMenu);
     this.initialDisplayDate = this.displayDate || new Date();
     if (this.initialValue && this.initialValue.length > 0) {
       // Validate initialValue against the dateFormat regex
@@ -220,6 +221,10 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
   }
 
   private async _handleCloseMenu() {
+    //return focus to input when menu closes
+    const input = await this.datepickerInputAsync;
+    input.focus();
+
     if (this.selectedDateRange.length === 0) {
       this.displayDate = this.initialDisplayDate;
     } else {
@@ -228,6 +233,11 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
       const calendar = await this.calendar;
       calendar._updateFocusedDate();
     }
+  }
+  private async _handleOpenMenu() {
+      const cal = await this.calendar;
+      const input = await this.datepickerInputAsync;
+      cal.focusOnCalendar(input);
   }
 
   private _makeInputValueString = (startDate: Date, endDate: Date, dateFormat: string) => {
@@ -368,19 +378,12 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
     this.value = e.detail;
   }
 
-  private _dialogAriaLabel() {
-    const view = this.view.replace("s", "");
-    // const header = await this.datepickerHeaderAsync;
-    const header = this.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
-    if (header) {
-      const headerText = header.renderHeader().toString().replace("-", "to");
-      this.dialogAriaLabel = `Choose ${view} from ${headerText}`;
-    }
-  }
+  private _dialogAriaLabels = {
+    days: "Choose date",
+    months: "Choose month",
+    years: "Choose year"
+  };
 
-  updated() {
-    this._dialogAriaLabel();
-  }
   render() {
     const svgEl = html`
       <svg
@@ -457,7 +460,7 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
           class="sgds datepicker dropdown-menu"
           role="dialog"
           part="menu"
-          aria-label=${this.dialogAriaLabel}
+          aria-label=${this._dialogAriaLabels[this.view]}
           @click=${(event: MouseEvent) => event.stopPropagation()}
         >
           <sgds-datepicker-header

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -235,9 +235,9 @@ export class SgdsDatepicker extends ScopedElementsMixin(DropdownElement) impleme
     }
   }
   private async _handleOpenMenu() {
-      const cal = await this.calendar;
-      const input = await this.datepickerInputAsync;
-      cal.focusOnCalendar(input);
+    const cal = await this.calendar;
+    const input = await this.datepickerInputAsync;
+    cal.focusOnCalendar(input);
   }
 
   private _makeInputValueString = (startDate: Date, endDate: Date, dateFormat: string) => {

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -1,19 +1,19 @@
 import { ScopedElementsMixin } from "@open-wc/scoped-elements";
 import { format, parse } from "date-fns";
-import { html, nothing } from "lit";
+import { html } from "lit";
 import { property, query, queryAsync, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import { live } from "lit/directives/live.js";
 import { ref } from "lit/directives/ref.js";
 import { DropdownElement } from "../../base/dropdown-element";
+import { type SgdsFormControl } from "../../utils/form";
+import { DATE_PATTERNS, setTimeToNoon } from "../../utils/time";
 import { watch } from "../../utils/watch";
 import { DatepickerCalendar } from "./datepicker-calendar";
 import { DatepickerHeader } from "./datepicker-header";
 import DatepickerInput from "./datepicker-input";
 import styles from "./sgds-datepicker.scss";
 import { ViewEnum } from "./types";
-import { DATE_PATTERNS, setTimeToNoon } from "../../utils/time";
-import { classMap } from "lit/directives/class-map.js";
-import { type SgdsFormControl } from "../../utils/form";
 
 export type DateFormat = "MM/DD/YYYY" | "DD/MM/YYYY" | "YYYY/MM/DD";
 

--- a/src/components/Datepicker/types.ts
+++ b/src/components/Datepicker/types.ts
@@ -1,5 +1,1 @@
-export interface CalendarKeyboardControllerOptions {
-  cell: (table: unknown) => HTMLElement | null;
-}
-
 export type ViewEnum = "days" | "months" | "years";

--- a/src/components/Input/sgds-input.ts
+++ b/src/components/Input/sgds-input.ts
@@ -174,10 +174,9 @@ export class SgdsInput extends SgdsElement implements SgdsFormControl {
         @invalid=${() => this.setInvalid(true)}
         @focus=${this._handleFocus}
         @blur=${this._handleBlur}
+        aria-describedby=${ifDefined(this.invalid && this.hasFeedback ? `${this.inputId}-invalid` : undefined)}
       />
-      ${this.hasFeedback
-        ? html`<div id="${this.inputId}-invalid" class="invalid-feedback">${this.invalidFeedback}</div>`
-        : ""} `;
+      ${this._renderFeedback()} `;
   }
   protected _renderFeedback() {
     return this.hasFeedback

--- a/src/components/Sidenav/sgds-sidenav.ts
+++ b/src/components/Sidenav/sgds-sidenav.ts
@@ -53,7 +53,7 @@ export class SgdsSidenav extends SgdsElement {
       return;
     }
     items.forEach(item => {
-      // Covers all elements within sidenav-item 
+      // Covers all elements within sidenav-item
       if (!event.composedPath().includes(item)) {
         // Close all the items that didn't dispatch the event.
         item.active = false;

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -1572,8 +1572,10 @@ describe("datepicker a11y labels", () => {
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
     expect(prev.getAttribute("aria-label")).to.equal("Go to previous month, February 2024");
-    expect(header.getAttribute("aria-label")).to.equal("March 2024. Current view is days, click to show months in 2024");
-    expect(header.getAttribute("aria-disabled")).to.equal("false")
+    expect(header.getAttribute("aria-label")).to.equal(
+      "March 2024. Current view is days, click to show months in 2024"
+    );
+    expect(header.getAttribute("aria-disabled")).to.equal("false");
     expect(next.getAttribute("aria-label")).to.equal("Go to next month, April 2024");
   });
   it("datepicker-header button aria-labels when view=months, aria-disabled=false", async () => {
@@ -1592,7 +1594,7 @@ describe("datepicker a11y labels", () => {
     expect(header.getAttribute("aria-label")).to.equal(
       "2024. Current view is months, click to show years between 2024 - 2035"
     );
-    expect(header.getAttribute("aria-disabled")).to.equal("false")
+    expect(header.getAttribute("aria-disabled")).to.equal("false");
     expect(next.getAttribute("aria-label")).to.equal("Go to next year, 2025");
   });
   it("datepicker-header button aria-labels when view=years,  aria-disabled=true", async () => {
@@ -1612,7 +1614,7 @@ describe("datepicker a11y labels", () => {
     expect(next.getAttribute("aria-label")).to.equal("Go to next 12 years, 2036 - 2047");
 
     expect(header.classList.contains("cursor-not-allowed")).to.be.true;
-    expect(header.getAttribute("aria-disabled")).to.equal("true")
+    expect(header.getAttribute("aria-disabled")).to.equal("true");
   });
 
   it("aria-selected=true on selected dates when view=days", async () => {
@@ -1769,18 +1771,21 @@ describe("datepicker a11y labels", () => {
     expect(td?.getAttribute("aria-label")).to.equal("Friday, March 1st, 2024");
   });
 
-  it("dates outside of min and max range have aria-disabled=true and vice versa", async() => {
+  it("dates outside of min and max range have aria-disabled=true and vice versa", async () => {
     const mockDate = new Date(2024, 2, 28);
-    const mockMinDate = new Date(2024, 2, 20).toISOString()
-    const mockMaxDate = new Date(2024, 2, 30).toISOString()
+    const mockMinDate = new Date(2024, 2, 20).toISOString();
+    const mockMaxDate = new Date(2024, 2, 30).toISOString();
     const el = await fixture<SgdsDatepicker>(
-      html`<sgds-datepicker .displayDate=${mockDate} menuIsOpen minDate=${mockMinDate} maxDate=${mockMaxDate} ></sgds-datepicker>`
+      html`<sgds-datepicker
+        .displayDate=${mockDate}
+        menuIsOpen
+        minDate=${mockMinDate}
+        maxDate=${mockMaxDate}
+      ></sgds-datepicker>`
     );
-    const calendar = el.shadowRoot?.querySelector("sgds-datepicker-calendar")
-    const tds = calendar?.shadowRoot?.querySelectorAll("td[data-day]")
-    expect(tds?.[0].getAttribute("aria-disabled")).to.equal("true")
-    expect(tds?.[21].getAttribute("aria-disabled")).to.equal("false")
-
-  })
-
+    const calendar = el.shadowRoot?.querySelector("sgds-datepicker-calendar");
+    const tds = calendar?.shadowRoot?.querySelectorAll("td[data-day]");
+    expect(tds?.[0].getAttribute("aria-disabled")).to.equal("true");
+    expect(tds?.[21].getAttribute("aria-disabled")).to.equal("false");
+  });
 });

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -1058,10 +1058,11 @@ describe("sgds-datepicker close and open menu behaviours", async () => {
     await el.updateComplete;
     const header = el.shadowRoot?.querySelector("sgds-datepicker-header") as DatepickerHeader;
     const calendar = el.shadowRoot?.querySelector("sgds-datepicker-calendar") as DatepickerCalendar;
-
+    const input = el.shadowRoot?.querySelector("sgds-datepicker-input") as DatepickerInput;
     const getCalendarActiveElement = () => calendar.shadowRoot?.activeElement;
     await waitUntil(() => getCalendarActiveElement());
-    return { calendar, getCalendarActiveElement, calendarBtnEl, el, header };
+    const getDateInputActiveElement = () => input.shadowRoot?.activeElement;
+    return { calendar, getCalendarActiveElement, getDateInputActiveElement, calendarBtnEl, el, header, input };
   };
   const monthViewSetup = async (initialValue: string[] = []) => {
     const { header, ...etc } = await dayViewSetup(initialValue);
@@ -1098,8 +1099,10 @@ describe("sgds-datepicker close and open menu behaviours", async () => {
     const thisYearEl = calendar.shadowRoot?.querySelector(`button[data-year="${todayYear}"]`);
     expect(getCalendarActiveElement() === thisYearEl).to.be.true;
   });
-  it("in day view, when calendar focus is moved, it should auto focus to the today calendar date after close and open", async () => {
-    const { calendar, getCalendarActiveElement, calendarBtnEl, el } = await dayViewSetup(["01/02/2024"]);
+  it("in day view, when calendar focus is moved, it should auto focus to the today calendar date after close and open, when close focuses to input", async () => {
+    const { calendar, getCalendarActiveElement, calendarBtnEl, getDateInputActiveElement, input } = await dayViewSetup([
+      "01/02/2024"
+    ]);
     const selectedTdEl = calendar.shadowRoot?.querySelector(`td[data-day="1"]`);
     expect(getCalendarActiveElement() === selectedTdEl).to.be.true;
 
@@ -1111,14 +1114,18 @@ describe("sgds-datepicker close and open menu behaviours", async () => {
 
     //close and open menu
     calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === false);
-    calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === true);
+    const inputFocusedEl = input.shadowRoot?.querySelector("input");
 
+    await waitUntil(() => getDateInputActiveElement() === inputFocusedEl);
+    expect(getDateInputActiveElement() === inputFocusedEl).to.be.true;
+    calendarBtnEl.click();
+
+    await waitUntil(() => getCalendarActiveElement() === selectedTdEl);
     expect(getCalendarActiveElement() === selectedTdEl).to.be.true;
   });
-  it("in month view, when calendar focus is moved, it should auto focus to the today calendar date after close and open", async () => {
-    const { calendar, getCalendarActiveElement, calendarBtnEl, el } = await monthViewSetup(["01/02/2024"]);
+  it("in month view, when calendar focus is moved, it should auto focus to the today calendar date after close and open, when close focuses to input", async () => {
+    const { calendar, getCalendarActiveElement, calendarBtnEl, getDateInputActiveElement, input } =
+      await monthViewSetup(["01/02/2024"]);
     const selectedButtonEL = calendar.shadowRoot?.querySelector(`button[data-month="1"]`);
     expect(getCalendarActiveElement() === selectedButtonEL).to.be.true;
 
@@ -1130,14 +1137,18 @@ describe("sgds-datepicker close and open menu behaviours", async () => {
 
     //close and open menu
     calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === false);
+    const inputFocusedEl = input.shadowRoot?.querySelector("input");
+    await waitUntil(() => getDateInputActiveElement() === inputFocusedEl);
+
     calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === true);
+    await waitUntil(() => getCalendarActiveElement() === selectedButtonEL);
 
     expect(getCalendarActiveElement() === selectedButtonEL).to.be.true;
   });
-  it("in year view, when calendar focus is moved, it should auto focus to the today calendar date after close and open", async () => {
-    const { calendar, getCalendarActiveElement, calendarBtnEl, el } = await yearViewSetup(["01/02/2024"]);
+  it("in year view, when calendar focus is moved, it should auto focus to the today calendar date after close and open, when close focuses to input", async () => {
+    const { calendar, getCalendarActiveElement, calendarBtnEl, getDateInputActiveElement, input } = await yearViewSetup(
+      ["01/02/2024"]
+    );
     const selectedButtonEL = calendar.shadowRoot?.querySelector(`button[data-year="2024"]`);
     expect(getCalendarActiveElement() === selectedButtonEL).to.be.true;
 
@@ -1149,9 +1160,10 @@ describe("sgds-datepicker close and open menu behaviours", async () => {
 
     //close and open menu
     calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === false);
+    const inputFocusedEl = input.shadowRoot?.querySelector("input");
+    await waitUntil(() => getDateInputActiveElement() === inputFocusedEl);
     calendarBtnEl.click();
-    await waitUntil(() => el.menuIsOpen === true);
+    await waitUntil(() => getCalendarActiveElement() === selectedButtonEL);
 
     expect(getCalendarActiveElement() === selectedButtonEL).to.be.true;
   });
@@ -1571,12 +1583,9 @@ describe("datepicker a11y labels", () => {
       ></sgds-datepicker-header>`
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
-    expect(prev.getAttribute("aria-label")).to.equal("Go to previous month, February 2024");
-    expect(header.getAttribute("aria-label")).to.equal(
-      "March 2024. Current view is days, click to show months in 2024"
-    );
+    expect(prev.getAttribute("aria-label")).to.equal("Show previous month");
     expect(header.getAttribute("aria-disabled")).to.equal("false");
-    expect(next.getAttribute("aria-label")).to.equal("Go to next month, April 2024");
+    expect(next.getAttribute("aria-label")).to.equal("Show next month");
   });
   it("datepicker-header button aria-labels when view=months, aria-disabled=false", async () => {
     // 28th March 2024
@@ -1590,12 +1599,9 @@ describe("datepicker a11y labels", () => {
       ></sgds-datepicker-header>`
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
-    expect(prev.getAttribute("aria-label")).to.equal("Go to previous year, 2023");
-    expect(header.getAttribute("aria-label")).to.equal(
-      "2024. Current view is months, click to show years between 2024 - 2035"
-    );
+    expect(prev.getAttribute("aria-label")).to.equal("Show previous year");
     expect(header.getAttribute("aria-disabled")).to.equal("false");
-    expect(next.getAttribute("aria-label")).to.equal("Go to next year, 2025");
+    expect(next.getAttribute("aria-label")).to.equal("Show next year");
   });
   it("datepicker-header button aria-labels when view=years,  aria-disabled=true", async () => {
     // 28th March 2024
@@ -1609,9 +1615,8 @@ describe("datepicker a11y labels", () => {
       ></sgds-datepicker-header>`
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
-    expect(prev.getAttribute("aria-label")).to.equal("Go to previous 12 years, 2012 - 2023");
-    expect(header.getAttribute("aria-label")).to.equal("2024 - 2035. Current view is years");
-    expect(next.getAttribute("aria-label")).to.equal("Go to next 12 years, 2036 - 2047");
+    expect(prev.getAttribute("aria-label")).to.equal("Show previous 12 years");
+    expect(next.getAttribute("aria-label")).to.equal("Show next 12 years");
 
     expect(header.classList.contains("cursor-not-allowed")).to.be.true;
     expect(header.getAttribute("aria-disabled")).to.equal("true");
@@ -1633,8 +1638,6 @@ describe("datepicker a11y labels", () => {
     const selectedTd = el.shadowRoot?.querySelector("td.active");
 
     expect(selectedTd?.getAttribute("aria-selected")).to.equal("true");
-    const unselectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='false']");
-    expect(unselectedTds?.length).to.equal(31 - 1);
   });
   it("aria-selected=true on selected MONTHS when view=months", async () => {
     // 28th March 2024
@@ -1652,8 +1655,6 @@ describe("datepicker a11y labels", () => {
     const selectedBtn = el.shadowRoot?.querySelector("button.active");
 
     expect(selectedBtn?.getAttribute("aria-selected")).to.equal("true");
-    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
-    expect(unselectedBtns?.length).to.equal(12 - 1);
   });
   it("aria-selected=true on selected years when view=years", async () => {
     // 28th March 2024
@@ -1671,8 +1672,6 @@ describe("datepicker a11y labels", () => {
     const selectedBtn = el.shadowRoot?.querySelector("button.active");
 
     expect(selectedBtn?.getAttribute("aria-selected")).to.equal("true");
-    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
-    expect(unselectedBtns?.length).to.equal(12 - 1);
   });
   it("aria-selected=true on selected dates when view=days, mode=range", async () => {
     // 28th March 2024
@@ -1691,8 +1690,6 @@ describe("datepicker a11y labels", () => {
     const selectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='true']");
     const selectedCount = 27 - 14 + 1;
     expect(selectedTds?.length).to.equal(selectedCount);
-    const unselectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='false']");
-    expect(unselectedTds?.length).to.equal(31 - selectedCount);
   });
   it("aria-selected=true on selected dates when view=months, mode=range", async () => {
     // 28th March 2024
@@ -1711,8 +1708,6 @@ describe("datepicker a11y labels", () => {
     const selectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='true']");
     const selectedCount = 9 - 2 + 1;
     expect(selectedBtns?.length).to.equal(selectedCount);
-    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
-    expect(unselectedBtns?.length).to.equal(12 - selectedCount);
   });
   it("aria-selected=true on selected dates when view=years, mode=range", async () => {
     // 28th March 2024
@@ -1731,8 +1726,6 @@ describe("datepicker a11y labels", () => {
     const selectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='true']");
     const selectedCount = 2027 - 2024 + 1;
     expect(selectedBtns?.length).to.equal(selectedCount);
-    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
-    expect(unselectedBtns?.length).to.equal(12 - selectedCount);
   });
 
   it(`aria-label of header button changes based on the view of datepicker`, async () => {
@@ -1744,16 +1737,16 @@ describe("datepicker a11y labels", () => {
     const dialog = () => el.shadowRoot?.querySelector("ul[role='dialog']");
     const header = el.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
     const headerButton = header?.shadowRoot?.querySelectorAll("button")[1];
-    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose day from March 2024`);
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose date`);
     headerButton?.click();
     await header?.updateComplete;
     await elementUpdated(el);
     // await el.updateComplete;
-    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose month from 2024`);
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose month`);
     headerButton?.click();
     await header?.updateComplete;
     await elementUpdated(el);
-    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose year from 2024 to 2035`);
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose year`);
   });
   it("aria-label of td dates in calendar", async () => {
     const mockDate = new Date(2024, 2, 28);
@@ -1786,6 +1779,53 @@ describe("datepicker a11y labels", () => {
     const calendar = el.shadowRoot?.querySelector("sgds-datepicker-calendar");
     const tds = calendar?.shadowRoot?.querySelectorAll("td[data-day]");
     expect(tds?.[0].getAttribute("aria-disabled")).to.equal("true");
-    expect(tds?.[21].getAttribute("aria-disabled")).to.equal("false");
+  });
+});
+
+describe("aria-current in calendar", () => {
+  it("for day view, current date is indicated by aria-current", async () => {
+    const todayDate = new Date();
+    const date = todayDate.getDate();
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${todayDate}
+        view="days"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-calendar>`
+    );
+    const currentDayTd = el.shadowRoot?.querySelector(`td[data-day='${date}']`)?.getAttribute("aria-current");
+    expect(currentDayTd).to.equal("date");
+  });
+  it("for month view, current month is indicated in aria-label", async () => {
+    const todayDate = new Date();
+    const month = todayDate.getMonth();
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${todayDate}
+        view="months"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-calendar>`
+    );
+    const currentMonthButtonAriaLabel = el.shadowRoot
+      ?.querySelector(`button[data-month='${month}']`)
+      ?.getAttribute("aria-label");
+
+    expect(currentMonthButtonAriaLabel).to.include("Current month");
+  });
+  it("for year view, current month is indicated in aria-label", async () => {
+    const todayDate = new Date();
+    const year = todayDate.getFullYear();
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${todayDate}
+        view="years"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-calendar>`
+    );
+    const currentMonthButtonAriaLabel = el.shadowRoot
+      ?.querySelector(`button[data-year='${year}']`)
+      ?.getAttribute("aria-label");
+
+    expect(currentMonthButtonAriaLabel).to.include("Current year");
   });
 });

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -1618,7 +1618,7 @@ describe("datepicker a11y labels", () => {
     expect(prev.getAttribute("aria-label")).to.equal("Show previous 12 years");
     expect(next.getAttribute("aria-label")).to.equal("Show next 12 years");
 
-    expect(header.classList.contains("cursor-not-allowed")).to.be.true;
+    expect(header.classList.contains("disabled")).to.be.true;
     expect(header.getAttribute("aria-disabled")).to.equal("true");
   });
 

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -6,7 +6,7 @@ import { SgdsDatepicker } from "../src/components";
 import { setTimeToNoon } from "../src/utils/time";
 import { sendKeys } from "@web/test-runner-commands";
 import "../src/index";
-import sinon from "sinon";
+import sinon, { type SinonFakeTimers } from "sinon";
 
 customElements.define("sgds-datepicker-header", DatepickerHeader);
 customElements.define("sgds-datepicker-calendar", DatepickerCalendar);
@@ -1445,7 +1445,7 @@ describe("datepicker behavour on invalid input", () => {
     const el = await fixture<SgdsDatepicker>(html`<sgds-datepicker .initialValue=${["23/03/2020"]}></sgds-datepicker>`);
     const input = el.shadowRoot?.querySelector<DatepickerInput>("sgds-datepicker-input");
     const header = el.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal("March 2020");
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain("March 2020");
 
     input?.focus();
     await waitUntil(() => el.shadowRoot?.activeElement === input);
@@ -1460,7 +1460,7 @@ describe("datepicker behavour on invalid input", () => {
     el.showMenu();
     await el.updateComplete;
     const initialDisplayDate = `${MONTH_LABELS[new Date().getMonth()]} ${new Date().getFullYear()}`;
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal(initialDisplayDate);
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain(initialDisplayDate);
   });
   it("datepicker resets to initial displayDate when invalid input", async () => {
     const el = await fixture<SgdsDatepicker>(
@@ -1468,7 +1468,7 @@ describe("datepicker behavour on invalid input", () => {
     );
     const input = el.shadowRoot?.querySelector<DatepickerInput>("sgds-datepicker-input");
     const header = el.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal("March 2020");
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain("March 2020");
 
     input?.focus();
     await waitUntil(() => el.shadowRoot?.activeElement === input);
@@ -1482,21 +1482,21 @@ describe("datepicker behavour on invalid input", () => {
     expect(el?.reportValidity()).to.equal(false);
     el.showMenu();
     await el.updateComplete;
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal("January 2025");
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain("January 2025");
   });
   it("datepicker resets to initial specified displayDate when reset ", async () => {
     const el = await fixture<SgdsDatepicker>(
       html`<sgds-datepicker .initialValue=${["23/03/2020"]} .displayDate=${new Date("01/01/2025")}></sgds-datepicker>`
     );
     const header = el.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header") as DatepickerHeader;
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal("March 2020");
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain("March 2020");
     const resetBtn = el.shadowRoot?.querySelector("button[slot='reset-btn']") as HTMLButtonElement;
     resetBtn?.click();
 
     el.showMenu();
     await elementUpdated(el);
     await elementUpdated(header);
-    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.equal("January 2025");
+    expect(header?.shadowRoot?.querySelectorAll("button")[1].textContent).to.contain("January 2025");
   });
 });
 
@@ -1546,5 +1546,223 @@ describe("datepicker in form context", () => {
     );
     const formData = new FormData(el);
     expect(formData.get("myDatepicker")).to.equal("23/03/2020");
+  });
+});
+
+describe("datepicker a11y labels", () => {
+  // Faking the current time to prevent flaky test as the years past
+  let fakeNow: SinonFakeTimers;
+  beforeEach(() => {
+    fakeNow = sinon.useFakeTimers(new Date(2024, 2, 1, 12, 0, 0, 0));
+    expect(new Date()).to.deep.equal(new Date(2024, 2, 1, 12, 0, 0, 0));
+  });
+  afterEach(() => {
+    fakeNow.restore();
+  });
+  it("datepicker-header button aria-labels when view=day", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const el = await fixture<DatepickerHeader>(
+      html`<sgds-datepicker-header
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="days"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-header>`
+    );
+    const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
+    expect(prev.getAttribute("aria-label")).to.equal("Go to previous month, February 2024");
+    expect(header.getAttribute("aria-label")).to.equal("Current view is days, click to show months in 2024");
+    expect(next.getAttribute("aria-label")).to.equal("Go to next month, April 2024");
+  });
+  it("datepicker-header button aria-labels when view=months", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const el = await fixture<DatepickerHeader>(
+      html`<sgds-datepicker-header
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="months"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-header>`
+    );
+    const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
+    expect(prev.getAttribute("aria-label")).to.equal("Go to previous year, 2023");
+    expect(header.getAttribute("aria-label")).to.equal(
+      "Current view is months, click to show years between 2024 - 2035"
+    );
+    expect(next.getAttribute("aria-label")).to.equal("Go to next year, 2025");
+  });
+  it("datepicker-header button aria-labels when view=years", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const el = await fixture<DatepickerHeader>(
+      html`<sgds-datepicker-header
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="years"
+        focusedTabIndex=${0}
+      ></sgds-datepicker-header>`
+    );
+    const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
+    expect(prev.getAttribute("aria-label")).to.equal("Go to previous decade, 2012 - 2023");
+    expect(header.getAttribute("aria-label")).to.equal("Current view is years");
+    expect(next.getAttribute("aria-label")).to.equal("Go to next decade, 2036 - 2047");
+
+    expect(header.classList.contains("cursor-not-allowed")).to.be.true;
+  });
+
+  it("aria-selected=true on selected dates when view=days", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = new Date(2024, 2, 14);
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="days"
+        focusedTabIndex=${0}
+        .selectedDate=${[mockSelectedDate]}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedTd = el.shadowRoot?.querySelector("td.active");
+
+    expect(selectedTd?.getAttribute("aria-selected")).to.equal("true");
+    const unselectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='false']");
+    expect(unselectedTds?.length).to.equal(31 - 1);
+  });
+  it("aria-selected=true on selected MONTHS when view=months", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = new Date(2024, 2, 14);
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="months"
+        focusedTabIndex=${0}
+        .selectedDate=${[mockSelectedDate]}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedBtn = el.shadowRoot?.querySelector("button.active");
+
+    expect(selectedBtn?.getAttribute("aria-selected")).to.equal("true");
+    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
+    expect(unselectedBtns?.length).to.equal(12 - 1);
+  });
+  it("aria-selected=true on selected years when view=years", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = new Date(2024, 2, 14);
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="years"
+        focusedTabIndex=${0}
+        .selectedDate=${[mockSelectedDate]}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedBtn = el.shadowRoot?.querySelector("button.active");
+
+    expect(selectedBtn?.getAttribute("aria-selected")).to.equal("true");
+    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
+    expect(unselectedBtns?.length).to.equal(12 - 1);
+  });
+  it("aria-selected=true on selected dates when view=days, mode=range", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = [new Date(2024, 2, 14), new Date(2024, 2, 27)];
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="days"
+        mode="range"
+        focusedTabIndex=${0}
+        .selectedDate=${mockSelectedDate}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='true']");
+    const selectedCount = 27 - 14 + 1;
+    expect(selectedTds?.length).to.equal(selectedCount);
+    const unselectedTds = el.shadowRoot?.querySelectorAll("td[aria-selected='false']");
+    expect(unselectedTds?.length).to.equal(31 - selectedCount);
+  });
+  it("aria-selected=true on selected dates when view=months, mode=range", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = [new Date(2024, 2, 14), new Date(2024, 9, 27)];
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="months"
+        mode="range"
+        focusedTabIndex=${0}
+        .selectedDate=${mockSelectedDate}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='true']");
+    const selectedCount = 9 - 2 + 1;
+    expect(selectedBtns?.length).to.equal(selectedCount);
+    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
+    expect(unselectedBtns?.length).to.equal(12 - selectedCount);
+  });
+  it("aria-selected=true on selected dates when view=years, mode=range", async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = [new Date(2024, 2, 14), new Date(2027, 9, 27)];
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="years"
+        mode="range"
+        focusedTabIndex=${0}
+        .selectedDate=${mockSelectedDate}
+      ></sgds-datepicker-calendar>`
+    );
+    const selectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='true']");
+    const selectedCount = 2027 - 2024 + 1;
+    expect(selectedBtns?.length).to.equal(selectedCount);
+    const unselectedBtns = el.shadowRoot?.querySelectorAll("button[aria-selected='false']");
+    expect(unselectedBtns?.length).to.equal(12 - selectedCount);
+  });
+
+  it(`aria-label of header button changes based on the view of datepicker`, async () => {
+    // 28th March 2024
+    const mockDate = new Date(2024, 2, 28);
+    const el = await fixture<SgdsDatepicker>(
+      html`<sgds-datepicker .displayDate=${mockDate} menuIsOpen></sgds-datepicker>`
+    );
+    const dialog = () => el.shadowRoot?.querySelector("ul[role='dialog']");
+    const header = el.shadowRoot?.querySelector<DatepickerHeader>("sgds-datepicker-header");
+    const headerButton = header?.shadowRoot?.querySelectorAll("button")[1];
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose day from March 2024`);
+    headerButton?.click();
+    await header?.updateComplete;
+    await elementUpdated(el);
+    // await el.updateComplete;
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose month from 2024`);
+    headerButton?.click();
+    await header?.updateComplete;
+    await elementUpdated(el);
+    expect(dialog()?.getAttribute("aria-label")).to.equal(`Choose year from 2024 to 2035`);
+  });
+  it("aria-label of td dates in calendar", async () => {
+    const mockDate = new Date(2024, 2, 28);
+    const mockSelectedDate = [new Date(2024, 2, 14)];
+    const el = await fixture<DatepickerCalendar>(
+      html`<sgds-datepicker-calendar
+        .displayDate=${mockDate}
+        .focusedDate=${mockDate}
+        view="days"
+        focusedTabIndex=${0}
+        .selectedDate=${mockSelectedDate}
+      ></sgds-datepicker-calendar>`
+    );
+    const td = el.shadowRoot?.querySelector("td[data-day='1']");
+    expect(td?.getAttribute("aria-label")).to.equal("Friday, March 1st, 2024");
   });
 });

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -1559,7 +1559,7 @@ describe("datepicker a11y labels", () => {
   afterEach(() => {
     fakeNow.restore();
   });
-  it("datepicker-header button aria-labels when view=day", async () => {
+  it("datepicker-header button aria-labels when view=day, aria-disabled=false", async () => {
     // 28th March 2024
     const mockDate = new Date(2024, 2, 28);
     const el = await fixture<DatepickerHeader>(
@@ -1572,10 +1572,11 @@ describe("datepicker a11y labels", () => {
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
     expect(prev.getAttribute("aria-label")).to.equal("Go to previous month, February 2024");
-    expect(header.getAttribute("aria-label")).to.equal("Current view is days, click to show months in 2024");
+    expect(header.getAttribute("aria-label")).to.equal("March 2024. Current view is days, click to show months in 2024");
+    expect(header.getAttribute("aria-disabled")).to.equal("false")
     expect(next.getAttribute("aria-label")).to.equal("Go to next month, April 2024");
   });
-  it("datepicker-header button aria-labels when view=months", async () => {
+  it("datepicker-header button aria-labels when view=months, aria-disabled=false", async () => {
     // 28th March 2024
     const mockDate = new Date(2024, 2, 28);
     const el = await fixture<DatepickerHeader>(
@@ -1589,11 +1590,12 @@ describe("datepicker a11y labels", () => {
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
     expect(prev.getAttribute("aria-label")).to.equal("Go to previous year, 2023");
     expect(header.getAttribute("aria-label")).to.equal(
-      "Current view is months, click to show years between 2024 - 2035"
+      "2024. Current view is months, click to show years between 2024 - 2035"
     );
+    expect(header.getAttribute("aria-disabled")).to.equal("false")
     expect(next.getAttribute("aria-label")).to.equal("Go to next year, 2025");
   });
-  it("datepicker-header button aria-labels when view=years", async () => {
+  it("datepicker-header button aria-labels when view=years,  aria-disabled=true", async () => {
     // 28th March 2024
     const mockDate = new Date(2024, 2, 28);
     const el = await fixture<DatepickerHeader>(
@@ -1605,11 +1607,12 @@ describe("datepicker a11y labels", () => {
       ></sgds-datepicker-header>`
     );
     const [prev, header, next] = el.shadowRoot?.querySelectorAll("button") as NodeListOf<HTMLButtonElement>;
-    expect(prev.getAttribute("aria-label")).to.equal("Go to previous decade, 2012 - 2023");
-    expect(header.getAttribute("aria-label")).to.equal("Current view is years");
-    expect(next.getAttribute("aria-label")).to.equal("Go to next decade, 2036 - 2047");
+    expect(prev.getAttribute("aria-label")).to.equal("Go to previous 12 years, 2012 - 2023");
+    expect(header.getAttribute("aria-label")).to.equal("2024 - 2035. Current view is years");
+    expect(next.getAttribute("aria-label")).to.equal("Go to next 12 years, 2036 - 2047");
 
     expect(header.classList.contains("cursor-not-allowed")).to.be.true;
+    expect(header.getAttribute("aria-disabled")).to.equal("true")
   });
 
   it("aria-selected=true on selected dates when view=days", async () => {
@@ -1765,4 +1768,19 @@ describe("datepicker a11y labels", () => {
     const td = el.shadowRoot?.querySelector("td[data-day='1']");
     expect(td?.getAttribute("aria-label")).to.equal("Friday, March 1st, 2024");
   });
+
+  it("dates outside of min and max range have aria-disabled=true and vice versa", async() => {
+    const mockDate = new Date(2024, 2, 28);
+    const mockMinDate = new Date(2024, 2, 20).toISOString()
+    const mockMaxDate = new Date(2024, 2, 30).toISOString()
+    const el = await fixture<SgdsDatepicker>(
+      html`<sgds-datepicker .displayDate=${mockDate} menuIsOpen minDate=${mockMinDate} maxDate=${mockMaxDate} ></sgds-datepicker>`
+    );
+    const calendar = el.shadowRoot?.querySelector("sgds-datepicker-calendar")
+    const tds = calendar?.shadowRoot?.querySelectorAll("td[data-day]")
+    expect(tds?.[0].getAttribute("aria-disabled")).to.equal("true")
+    expect(tds?.[21].getAttribute("aria-disabled")).to.equal("false")
+
+  })
+
 });

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -30,10 +30,13 @@ describe("sgds-input", () => {
   });
 
   it("input's id attribute should contain in .invalid-feedback's id attribute", async () => {
-    const el = await fixture(html`<sgds-input hasFeedback></sgds-input>`);
+    const el = await fixture<SgdsInput>(html`<sgds-input hasFeedback></sgds-input>`);
+    el.invalid = true
+    await elementUpdated(el)
     const input = el.shadowRoot?.querySelector("input");
     const feedback = el.shadowRoot?.querySelector(".invalid-feedback");
     expect(feedback?.getAttribute("id")).to.contain(input?.getAttribute("id"));
+    expect(input?.getAttribute("aria-describedby")).to.contain(feedback?.getAttribute("id"))
   });
 
   it("should be disabled with the disabled attribute", async () => {

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -31,12 +31,12 @@ describe("sgds-input", () => {
 
   it("input's id attribute should contain in .invalid-feedback's id attribute", async () => {
     const el = await fixture<SgdsInput>(html`<sgds-input hasFeedback></sgds-input>`);
-    el.invalid = true
-    await elementUpdated(el)
+    el.invalid = true;
+    await elementUpdated(el);
     const input = el.shadowRoot?.querySelector("input");
     const feedback = el.shadowRoot?.querySelector(".invalid-feedback");
     expect(feedback?.getAttribute("id")).to.contain(input?.getAttribute("id"));
-    expect(input?.getAttribute("aria-describedby")).to.contain(feedback?.getAttribute("id"))
+    expect(input?.getAttribute("aria-describedby")).to.contain(feedback?.getAttribute("id"));
   });
 
   it("should be disabled with the disabled attribute", async () => {


### PR DESCRIPTION
## :open_book: Description

A11y attributes added
1) aria-labels on dates, months to allow screen reader to read out the full date / month 
2) aria-labels on dialog, arrow and header buttons, current month / year buttons
3) aria-live= polite on datepicker header for screen reader to annouce the header 
4) aria-current on today's date
5) aria-invalid and aria-describedby for invalid input state and corresponding feedback 

Styling changes
1) add hover styles to arrow and header buttons 
2) Shift focus back to input so that screen reader can read the selected date 
Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] UT
- [X] e2e

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
