### PR TITLE
Fix quantity toggle [skip-cd]

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,4 +3,4 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;700&display=swap">

--- a/index.html
+++ b/index.html
@@ -649,6 +649,9 @@
             <div class="container">
                 <h2>Quantity Toggle</h2>
                 <div class="row">
+                    <sgds-quantity-toggle step="1" quantitytoggleclasses="" size="sm" name="" buttonvariant="primary" defaultvalue="0"></sgds-quantity-toggle>
+                </div>
+                <div class="row">
                     <sgds-dropdown togglerText="Dropdown">
                         <sgds-dropdown-item>item #1 (argsTable controlled)</sgds-dropdown-item>
                         <sgds-dropdown-item href="#">item #2</sgds-dropdown-item>

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -65,6 +65,9 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
   private inputId: string = genId("quantity-toggle", "input");
 
   handleChange(event: string) {
+    if (parseInt(this.input.value) < this.step || this.input.value === "") {
+      this.input.value = "0";
+    }
     this.value = parseInt(this.input.value);
     this.emit(event);
   }

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -187,8 +187,8 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
             />
           </svg>
         </button>
-        <div id="announcer" role="region" aria-live="assertive" class="visually-hidden">${this.value}</div>
       </div>
+      <div id="announcer" role="region" aria-live="assertive" class="visually-hidden">${this.value}</div>
     `;
   }
 }

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -33,7 +33,7 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
   private readonly formSubmitController = new FormSubmitController(this);
 
   /** The name of the input */
-  @property({ reflect: true }) name: string;
+  @property({ type: String, reflect: true }) name: string;
 
   /** The input's minimum value. */
   @property({ type: Number, reflect: true }) min: number;
@@ -44,18 +44,18 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
   @property() size: "sm" | "lg" = "sm";
 
   /**The input's value. Set to 0 by default */
-  @property({ reflect: true, type: Number }) value = 0;
+  @property({ type: Number, reflect: true }) value = 0;
 
   /** Disables the entire quantity toggle  */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** The quantity toggle's button variants */
-  @property({ type: String, reflect: true }) buttonVariant: ButtonVariant = "primary";
+  @property({ type: String }) buttonVariant: ButtonVariant = "primary";
 
   /**
    * Controls the incremental / decremental value of the input
    */
-  @property({ type: Number, reflect: true }) step = 1;
+  @property({ type: Number }) step = 1;
 
   /** Gets or sets the default value used to reset this element. The initial value corresponds to the one originally specified in the HTML that created this element. */
   @defaultValue()

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -172,7 +172,7 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
             [`btn-${this.buttonVariant}`]: this.buttonVariant
           })}
           @click=${this.onPlus}
-          ?disabled=${this.disabled || (this.max !== undefined && this.value >= this.max)}
+          ?disabled=${this.disabled || (this.max !== undefined && this.max && this.value >= this.max)}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -68,10 +68,28 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
     this.value = parseInt(this.input.value);
     this.emit(event);
   }
+
+  handleKeyDown(event: KeyboardEvent) {
+    const allowedKeys = [
+      "Backspace",
+      "ArrowUp",
+      "ArrowDown",
+      "ArrowLeft",
+      "ArrowRight",
+      ...Array.from(Array(10).keys()).map(key => key.toString())
+    ];
+
+    // Allow keydown event only if the pressed key is in the allowedKeys array
+    if (!allowedKeys.includes(event.key)) {
+      event.preventDefault();
+    }
+  }
+
   /** Simulates a click on the plus button */
   public plus() {
     this.plusBtn.click();
   }
+
   /** Simulates a click on the minus button */
   public minus() {
     this.minusBtn.click();
@@ -137,6 +155,7 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
           .value=${live(this.value.toString())}
           @change=${() => this.handleChange("sgds-change")}
           @input=${() => this.handleChange("sgds-input")}
+          @keydown=${this.handleKeyDown}
           ?disabled=${this.disabled}
           id=${this.inputId}
           aria-label="quantity"

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -135,7 +135,7 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
             [`btn-${this.buttonVariant}`]: this.buttonVariant
           })}
           @click=${this.onMinus}
-          ?disabled=${this.disabled}
+          ?disabled=${this.disabled || (this.min !== undefined ? this.value <= this.min : this.value < 1)}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -172,7 +172,7 @@ export class SgdsQuantityToggle extends SgdsElement implements SgdsFormControl {
             [`btn-${this.buttonVariant}`]: this.buttonVariant
           })}
           @click=${this.onPlus}
-          ?disabled=${this.disabled}
+          ?disabled=${this.disabled || (this.max !== undefined && this.value >= this.max)}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/stories/templates/QuantityToggle/basic.js
+++ b/stories/templates/QuantityToggle/basic.js
@@ -1,18 +1,19 @@
 import { html } from "lit-html";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 export const Template = args =>
   html`
     <sgds-quantity-toggle
-      .value=${args.value}
-      step=${args.step}
-      quantityToggleClasses=${args.quantityToggleClasses}
+      value=${ifDefined(args.value)}
+      step=${ifDefined(args.step)}
+      quantityToggleClasses=${ifDefined(args.quantityToggleClasses)}
       ?disabled=${args.disabled}
-      size=${args.size}
-      name=${args.name}
-      min=${args.min}
-      max=${args.max}
-      buttonVariant=${args.buttonVariant}
-      defaultValue=${args.defaultValue}
+      size=${ifDefined(args.size)}
+      name=${ifDefined(args.name)}
+      min=${ifDefined(args.min)}
+      max=${ifDefined(args.max)}
+      buttonVariant=${ifDefined(args.buttonVariant)}
+      defaultValue=${ifDefined(args.defaultValue)}
     ></sgds-quantity-toggle>
   `;
 

--- a/test/quantitytoggle.test.ts
+++ b/test/quantitytoggle.test.ts
@@ -21,6 +21,48 @@ describe("when minusBtn or plusBtn is clicked", () => {
 
     expect(el.value).to.equal(10);
   });
+
+  it("minusBtn is disabled when reaches 0 without minimum value set", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="1"></sgds-quantity-toggle>`);
+    const minusBtn = el.shadowRoot?.querySelector("button[aria-label^='decrease by']") as HTMLButtonElement;
+
+    minusBtn.click();
+    await el.updateComplete;
+
+    expect(el.value).to.equal(0);
+    expect(minusBtn.hasAttribute("disabled")).to.be.true;
+  });
+
+  it("minusBtn is disabled when reaches minimum value", async () => {
+    const el = await fixture<SgdsQuantityToggle>(
+      html`<sgds-quantity-toggle value="10" min="8"></sgds-quantity-toggle>`
+    );
+    const minusBtn = el.shadowRoot?.querySelector("button[aria-label^='decrease by']") as HTMLButtonElement;
+
+    minusBtn.click();
+    await el.updateComplete;
+
+    expect(el.value).to.equal(9);
+
+    minusBtn.click();
+    await el.updateComplete;
+
+    expect(el.value).to.equal(8);
+    expect(minusBtn.hasAttribute("disabled")).to.be.true;
+  });
+
+  it("minusBtn is disabled when reaches maximum value", async () => {
+    const el = await fixture<SgdsQuantityToggle>(
+      html`<sgds-quantity-toggle value="10" max="11"></sgds-quantity-toggle>`
+    );
+    const plusBtn = el.shadowRoot?.querySelector("button[aria-label^='increase by']") as HTMLButtonElement;
+
+    plusBtn.click();
+    await el.updateComplete;
+
+    expect(el.value).to.equal(11);
+    expect(plusBtn.hasAttribute("disabled")).to.be.true;
+  });
 });
 
 describe("when value change", () => {
@@ -33,6 +75,35 @@ describe("when value change", () => {
     await sendKeys({ press: "0" });
     waitUntil(() => inputHandler.calledOnce);
     expect(inputHandler).to.have.been.calledOnce;
+  });
+
+  it("prevent from entering special characters", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="15"></sgds-quantity-toggle>`);
+    const inputEl = el.shadowRoot?.querySelector("input.form-control") as HTMLInputElement;
+    const inputHandler = sinon.spy();
+    inputEl.focus();
+    el.addEventListener("sgds-input", inputHandler);
+    await sendKeys({ press: "ArrowLeft" });
+    await sendKeys({ press: "ArrowLeft" });
+    waitUntil(() => inputHandler.calledTwice);
+    await sendKeys({ press: "Minus" });
+    waitUntil(() => inputHandler.calledOnce);
+    expect(inputEl.value).to.equal("15");
+  });
+
+  it("resets value to 0 when delete the value", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="15"></sgds-quantity-toggle>`);
+    const inputEl = el.shadowRoot?.querySelector("input.form-control") as HTMLInputElement;
+    const inputHandler = sinon.spy();
+    inputEl.focus();
+    el.addEventListener("sgds-input", inputHandler);
+    await sendKeys({ press: "Backspace" });
+    waitUntil(() => inputHandler.calledOnce);
+    expect(inputEl.value).to.equal("1");
+
+    await sendKeys({ press: "Backspace" });
+    waitUntil(() => inputHandler.calledOnce);
+    expect(inputEl.value).to.equal("0");
   });
 });
 


### PR DESCRIPTION
## :open_book: Description

To fix quantity toggle button and update the test case.

1. prevent the users from entering the negative("-") value or any other alphabets
2. reset the value to 0 when the value is blank (deletion)
3. disable button when number reach 0 / minimum / maximum value

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
