### PR TITLE
feat(accordion): allow accordion active color customisation through n…

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,9 @@
         sgds-sidenav {
             --sidenav-sticky-top: 1.5rem;
         }
-
+        sgds-accordion {
+            --accordion-active-color: blue;
+        }
         /* sgds-sidenav-item::part(sidenav-btn) {
             color: red;
             border-left-color: red;

--- a/src/components/Accordion/sgds-accordion-item.scss
+++ b/src/components/Accordion/sgds-accordion-item.scss
@@ -19,6 +19,9 @@
 
 .accordion-button {
   line-height: var(--accordion-item-line-height);
+  &:not(.collapsed){
+    color: var(--accordion-active-color);
+  }
 }
 
 .accordion-button:not(.collapsed) {

--- a/src/components/Accordion/sgds-accordion.scss
+++ b/src/components/Accordion/sgds-accordion.scss
@@ -1,0 +1,4 @@
+:host {
+    /** NEW in 1.2.4 */
+    --accordion-active-color: var(--sgds-primary);
+  }

--- a/src/components/Accordion/sgds-accordion.ts
+++ b/src/components/Accordion/sgds-accordion.ts
@@ -3,14 +3,18 @@ import { property, queryAssignedNodes } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import SgdsElement from "../../base/sgds-element";
 import type SgdsAccordionItem from "./sgds-accordion-item";
+import styles from "./sgds-accordion.scss";
 
 /**
  * @summary A dropdown mechanism that allow users to either show or hide related content. `SgdsAccordion` is a wrapper to manage the behaviour for multiple `SgdsAccordionItems`
  * @slot default - slot for accordion-item
+ *
+ * @cssprop --accordion-active-color - The text color of all accordion buttons to indicate its active state
+ *
  */
 
 export class SgdsAccordion extends SgdsElement {
-  static styles = [SgdsElement.styles];
+  static styles = [SgdsElement.styles, styles];
 
   /** Allows multiple accordion items to be opened at the same time */
   @property({ type: Boolean, reflect: true }) allowMultiple = false;


### PR DESCRIPTION
## :open_book: Description

Requested by dev portal team
Add css prop `--accordion-active-color` to allow customisation of accordion button color in active state. To be deploy to v1.2.4. 

This follows the lab branch's one as well, that we planned for v2.0

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] UT
- [ ] Test B

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
