### PR TITLE
Fix/accordion animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
             <h2>Accordion</h2>
             <div class="row">
 
-                <sgds-accordion accordionclasses="mb-4">
+                <sgds-accordion accordionclasses="mb-4" >
                     <sgds-accordion-item>
                         <div slot="accordion-header">This is a solo accordion</div>
                         <span slot="accordion-content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores

--- a/index.html
+++ b/index.html
@@ -370,12 +370,12 @@
                         <span slot="accordion-content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores
                             soluta eaque fugit fuga distinctio? Eum.</span>
                     </sgds-accordion-item>
-                    <sgds-accordion-item open="">
+                    <sgds-accordion-item >
                         <div slot="accordion-header">Accordion 2</div>
                         <span slot="accordion-content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores
                             soluta eaque fugit fuga distinctio? Eum.</span>
                     </sgds-accordion-item>
-                    <sgds-accordion-item>
+                    <sgds-accordion-item open>
                         <div slot="accordion-header">Accordion 3</div>
                         <span slot="accordion-content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores
                             soluta eaque fugit fuga distinctio? Eum.</span>

--- a/src/components/Accordion/sgds-accordion-item.scss
+++ b/src/components/Accordion/sgds-accordion-item.scss
@@ -22,11 +22,26 @@
   &:not(.collapsed){
     color: var(--accordion-active-color);
   }
+  svg.bi-chevron-down {
+    margin-left: auto;
+    transition: transform 0.2s ease-in-out;
+    width: 1.3rem;
+    height: 1.3rem;
+  }
 }
 
 .accordion-button:not(.collapsed) {
   font-weight: var(--accordion-item-font-weight);
   box-shadow: none;
+  svg.bi-chevron-down {
+    transform: rotate(-180deg);
+  }
+}
+
+// Temporarily remove background-image for v1. 
+// Proper fix at v2  
+.accordion-button::after {
+  content:unset;
 }
 
 :host([first-of-type]) {

--- a/src/components/Accordion/sgds-accordion-item.scss
+++ b/src/components/Accordion/sgds-accordion-item.scss
@@ -9,7 +9,7 @@
 .accordion-body {
   padding: 0;
   line-height: var(--accordion-item-line-height);
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 .accordion-content {
@@ -48,3 +48,58 @@
     border-top: 0;
   }
 }
+// @keyframes expand {
+//   0% {
+//     height: 64px;
+//     opacity: 0;
+//     display: none;
+//   }
+
+//   // 1%{
+//   //   display: block;
+//   //   opacity: 0;
+//   //   height:0;
+//   // }
+//   // 25%{
+//   //   height: 10px;
+//   //   opacity: 0.25;
+//   // }
+//   50%{
+//     height: 50%;
+//     opacity: 0.5;
+//   }
+
+//   100% {
+//     height: auto;
+//     opacity: 1;
+//     // display: block;
+//   }
+// }
+.hidden{
+  display:none;
+}
+
+// .show {
+//   // animation:  linear;
+//   display: block;
+//   // overflow: hidden;
+//   // opacity: 1;
+//   animation-duration: 0.5s;
+//   animation-name: expand;
+//   animation-timing-function: linear;
+// }
+// .hide {
+//   display: none;
+//   // animation: expand 5s linear;
+//   animation-direction: reverse;
+//   animation-duration: 0.5s;
+//   animation-name: expand;
+//   animation-timing-function: linear;
+// }
+// .accordion-button.expand + .accordion-body {
+ 
+// }
+// .accordion-button.collapsed + .accordion-body {
+//   animation: expand .2s ease-in-out;
+// }
+

--- a/src/components/Accordion/sgds-accordion-item.scss
+++ b/src/components/Accordion/sgds-accordion-item.scss
@@ -63,58 +63,8 @@
     border-top: 0;
   }
 }
-// @keyframes expand {
-//   0% {
-//     height: 64px;
-//     opacity: 0;
-//     display: none;
-//   }
 
-//   // 1%{
-//   //   display: block;
-//   //   opacity: 0;
-//   //   height:0;
-//   // }
-//   // 25%{
-//   //   height: 10px;
-//   //   opacity: 0.25;
-//   // }
-//   50%{
-//     height: 50%;
-//     opacity: 0.5;
-//   }
-
-//   100% {
-//     height: auto;
-//     opacity: 1;
-//     // display: block;
-//   }
-// }
 .hidden{
-  display:none;
+  display: none;
 }
-
-// .show {
-//   // animation:  linear;
-//   display: block;
-//   // overflow: hidden;
-//   // opacity: 1;
-//   animation-duration: 0.5s;
-//   animation-name: expand;
-//   animation-timing-function: linear;
-// }
-// .hide {
-//   display: none;
-//   // animation: expand 5s linear;
-//   animation-direction: reverse;
-//   animation-duration: 0.5s;
-//   animation-name: expand;
-//   animation-timing-function: linear;
-// }
-// .accordion-button.expand + .accordion-body {
- 
-// }
-// .accordion-button.collapsed + .accordion-body {
-//   animation: expand .2s ease-in-out;
-// }
 

--- a/src/components/Accordion/sgds-accordion-item.scss
+++ b/src/components/Accordion/sgds-accordion-item.scss
@@ -9,7 +9,7 @@
 .accordion-body {
   padding: 0;
   line-height: var(--accordion-item-line-height);
-  // overflow: hidden;
+  overflow: hidden;
 }
 
 .accordion-content {

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -43,12 +43,6 @@ export class SgdsAccordionItem extends SgdsElement {
   /** Optional for accordion item. Can be used to insert any utility classes such as `me-auto` */
   @property({ reflect: true }) accordionItemClasses: string;
 
-  firstUpdated() {
-    // this.body.hidden = !this.open;
-    if (!this.open) this.body.classList.add("hidden");
-    // this.body.style.height = this.open ? "auto" : "0";
-  }
-
   private handleSummaryClick() {
     if (this.open) {
       this.hide();
@@ -92,11 +86,9 @@ export class SgdsAccordionItem extends SgdsElement {
       }
 
       await stopAnimations(this.body);
-      // this.body.hidden = false;
-      // this.body.classList.remove("hidden");
+
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      // this.body.style.height = "auto";
 
       this.emit("sgds-after-show");
     } else {
@@ -111,10 +103,6 @@ export class SgdsAccordionItem extends SgdsElement {
   
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      // this.body.hidden = true;
-      
-      // this.body.style.height = "auto";
-
       this.emit("sgds-after-hide");
     }
   }
@@ -152,7 +140,6 @@ export class SgdsAccordionItem extends SgdsElement {
           class=${classMap({
             "accordion-button": true,
             collapsed: !this.open
-            // expand: this.open
           })}
           part="header"
           role="button"
@@ -163,12 +150,24 @@ export class SgdsAccordionItem extends SgdsElement {
           @keydown=${this.handleSummaryKeyDown}
         >
           <slot name="accordion-header"></slot>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-chevron-down"
+            viewBox="0 0 16 16"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"
+            />
+          </svg>
         </button>
         <div
           class=${classMap({
             "accordion-body": true,
             hidden: !this.open
-            // show: this.open
           })}
         >
           <slot name="accordion-content" class="accordion-content" role="region" aria-labelledby="header"></slot>

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -93,7 +93,7 @@ export class SgdsAccordionItem extends SgdsElement {
 
       await stopAnimations(this.body);
       // this.body.hidden = false;
-      this.body.classList.remove("hidden");
+      // this.body.classList.remove("hidden");
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       // this.body.style.height = "auto";
@@ -108,11 +108,11 @@ export class SgdsAccordionItem extends SgdsElement {
       }
 
       await stopAnimations(this.body);
-
+  
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       // this.body.hidden = true;
-      this.body.classList.add("hidden");
+      
       // this.body.style.height = "auto";
 
       this.emit("sgds-after-hide");
@@ -166,8 +166,8 @@ export class SgdsAccordionItem extends SgdsElement {
         </button>
         <div
           class=${classMap({
-            "accordion-body": true
-            // hidden: !this.open
+            "accordion-body": true,
+            hidden: !this.open
             // show: this.open
           })}
         >

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -45,7 +45,7 @@ export class SgdsAccordionItem extends SgdsElement {
 
   firstUpdated() {
     // this.body.hidden = !this.open;
-    if (!this.open) this.body.classList.add("hidden");
+    // if (!this.open) this.body.classList.add("hidden");
     this.body.style.height = this.open ? "auto" : "0";
   }
 
@@ -93,7 +93,7 @@ export class SgdsAccordionItem extends SgdsElement {
 
       await stopAnimations(this.body);
       // this.body.hidden = false;
-      this.body.classList.remove("hidden");
+      // this.body.classList.remove("hidden");
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       this.body.style.height = "auto";
@@ -112,7 +112,7 @@ export class SgdsAccordionItem extends SgdsElement {
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       // this.body.hidden = true;
-      this.body.classList.add("hidden");
+      // this.body.classList.add("hidden");
       this.body.style.height = "auto";
 
       this.emit("sgds-after-hide");
@@ -167,8 +167,8 @@ export class SgdsAccordionItem extends SgdsElement {
         <div
           class=${classMap({
             "accordion-body": true,
-            hide: !this.open,
-            show: this.open
+            hidden: !this.open
+            // show: this.open
           })}
         >
           <slot name="accordion-content" class="accordion-content" role="region" aria-labelledby="header"></slot>

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -45,8 +45,8 @@ export class SgdsAccordionItem extends SgdsElement {
 
   firstUpdated() {
     // this.body.hidden = !this.open;
-    // if (!this.open) this.body.classList.add("hidden");
-    this.body.style.height = this.open ? "auto" : "0";
+    if (!this.open) this.body.classList.add("hidden");
+    // this.body.style.height = this.open ? "auto" : "0";
   }
 
   private handleSummaryClick() {
@@ -93,10 +93,10 @@ export class SgdsAccordionItem extends SgdsElement {
 
       await stopAnimations(this.body);
       // this.body.hidden = false;
-      // this.body.classList.remove("hidden");
+      this.body.classList.remove("hidden");
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      this.body.style.height = "auto";
+      // this.body.style.height = "auto";
 
       this.emit("sgds-after-show");
     } else {
@@ -112,8 +112,8 @@ export class SgdsAccordionItem extends SgdsElement {
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       // this.body.hidden = true;
-      // this.body.classList.add("hidden");
-      this.body.style.height = "auto";
+      this.body.classList.add("hidden");
+      // this.body.style.height = "auto";
 
       this.emit("sgds-after-hide");
     }
@@ -166,8 +166,8 @@ export class SgdsAccordionItem extends SgdsElement {
         </button>
         <div
           class=${classMap({
-            "accordion-body": true,
-            hidden: !this.open
+            "accordion-body": true
+            // hidden: !this.open
             // show: this.open
           })}
         >

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -44,7 +44,8 @@ export class SgdsAccordionItem extends SgdsElement {
   @property({ reflect: true }) accordionItemClasses: string;
 
   firstUpdated() {
-    this.body.hidden = !this.open;
+    // this.body.hidden = !this.open;
+    if (!this.open) this.body.classList.add("hidden");
     this.body.style.height = this.open ? "auto" : "0";
   }
 
@@ -91,8 +92,8 @@ export class SgdsAccordionItem extends SgdsElement {
       }
 
       await stopAnimations(this.body);
-      this.body.hidden = false;
-
+      // this.body.hidden = false;
+      this.body.classList.remove("hidden");
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       this.body.style.height = "auto";
@@ -110,7 +111,8 @@ export class SgdsAccordionItem extends SgdsElement {
 
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      this.body.hidden = true;
+      // this.body.hidden = true;
+      this.body.classList.add("hidden");
       this.body.style.height = "auto";
 
       this.emit("sgds-after-hide");
@@ -142,13 +144,15 @@ export class SgdsAccordionItem extends SgdsElement {
         part="base"
         class=${classMap({
           "sgds accordion-item": true,
-          [`${this.accordionItemClasses}`]: this.accordionItemClasses
+          [`${this.accordionItemClasses}`]: this.accordionItemClasses,
+          show: this.open
         })}
       >
         <button
           class=${classMap({
             "accordion-button": true,
             collapsed: !this.open
+            // expand: this.open
           })}
           part="header"
           role="button"
@@ -160,7 +164,13 @@ export class SgdsAccordionItem extends SgdsElement {
         >
           <slot name="accordion-header"></slot>
         </button>
-        <div class="accordion-body">
+        <div
+          class=${classMap({
+            "accordion-body": true,
+            hide: !this.open,
+            show: this.open
+          })}
+        >
           <slot name="accordion-content" class="accordion-content" role="region" aria-labelledby="header"></slot>
         </div>
       </div>

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -43,6 +43,10 @@ export class SgdsAccordionItem extends SgdsElement {
   /** Optional for accordion item. Can be used to insert any utility classes such as `me-auto` */
   @property({ reflect: true }) accordionItemClasses: string;
 
+  firstUpdated() {
+    if (!this.open) this.body.classList.add("hidden");
+  }
+
   private handleSummaryClick() {
     if (this.open) {
       this.hide();
@@ -86,10 +90,10 @@ export class SgdsAccordionItem extends SgdsElement {
       }
 
       await stopAnimations(this.body);
+      this.body.classList.remove("hidden");
 
       const { keyframes, options } = getAnimation(this, "accordion.show");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-
       this.emit("sgds-after-show");
     } else {
       // Hide
@@ -102,6 +106,13 @@ export class SgdsAccordionItem extends SgdsElement {
       await stopAnimations(this.body);
 
       const { keyframes, options } = getAnimation(this, "accordion.hide");
+      const animationDuration = options.duration as number;
+      // Workaround to fix GSIB delay after animateTo.
+      //Setting a timeout of duration slightly less than animation's duraton to prevent case where animation runs faster than .hidden class is added
+      setTimeout(() => {
+        this.body.classList.add("hidden");
+      }, animationDuration - 20);
+
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       this.emit("sgds-after-hide");
     }
@@ -166,8 +177,7 @@ export class SgdsAccordionItem extends SgdsElement {
         </button>
         <div
           class=${classMap({
-            "accordion-body": true,
-            hidden: !this.open
+            "accordion-body": true
           })}
         >
           <slot name="accordion-content" class="accordion-content" role="region" aria-labelledby="header"></slot>
@@ -182,7 +192,7 @@ setDefaultAnimation("accordion.show", {
     { height: "0", opacity: "0" },
     { height: "auto", opacity: "1" }
   ],
-  options: { duration: 200, easing: "ease-in-out" }
+  options: { duration: 350, easing: "ease-in-out" }
 });
 
 setDefaultAnimation("accordion.hide", {
@@ -190,7 +200,7 @@ setDefaultAnimation("accordion.hide", {
     { height: "auto", opacity: "1" },
     { height: "0", opacity: "0" }
   ],
-  options: { duration: 200, easing: "ease-in-out" }
+  options: { duration: 350, easing: "ease-in-out" }
 });
 
 export default SgdsAccordionItem;

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -100,7 +100,7 @@ export class SgdsAccordionItem extends SgdsElement {
       }
 
       await stopAnimations(this.body);
-  
+
       const { keyframes, options } = getAnimation(this, "accordion.hide");
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
       this.emit("sgds-after-hide");

--- a/src/components/Accordion/sgds-accordion.ts
+++ b/src/components/Accordion/sgds-accordion.ts
@@ -5,6 +5,8 @@ import SgdsElement from "../../base/sgds-element";
 import type SgdsAccordionItem from "./sgds-accordion-item";
 import styles from "./sgds-accordion.scss";
 
+const VALID_KEYS = ["Enter", "ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"];
+
 /**
  * @summary A dropdown mechanism that allow users to either show or hide related content. `SgdsAccordion` is a wrapper to manage the behaviour for multiple `SgdsAccordionItems`
  * @slot default - slot for accordion-item
@@ -53,15 +55,12 @@ export class SgdsAccordion extends SgdsElement {
     });
   }
 
-  async onToggle(event: Event): Promise<void> {
-    // Let the event pass through the DOM so that it can be
-    // prevented from the outside if a user so desires.
-    if (this.allowMultiple || event.defaultPrevented) {
+  private async _onToggle(event: Event) {
+    if (this.allowMultiple) {
       // No toggling when `allowMultiple` or the user prevents it.
       return;
     }
     const items = [...this.items] as SgdsAccordionItem[];
-
     if (items && !items.length) {
       // no toggling when there aren't items.
       return;
@@ -75,6 +74,11 @@ export class SgdsAccordion extends SgdsElement {
     });
   }
 
+  private async _onKeyboardToggle(event: KeyboardEvent) {
+    if (!VALID_KEYS.includes(event.key)) return;
+    return this._onToggle(event);
+  }
+
   render() {
     return html`
       <div
@@ -83,7 +87,7 @@ export class SgdsAccordion extends SgdsElement {
           [`${this.accordionClasses}`]: this.accordionClasses
         })}
       >
-        <slot @click=${this.onToggle}></slot>
+        <slot @click=${this._onToggle} @keydown=${this._onKeyboardToggle}></slot>
       </div>
     `;
   }

--- a/test/accordion.test.ts
+++ b/test/accordion.test.ts
@@ -54,7 +54,7 @@ describe("<sgds-accordion-item>", () => {
     `);
     const body = el.shadowRoot?.querySelector<HTMLElement>(".accordion-body");
 
-    expect(body?.hidden).to.be.true;
+    expect(body?.classList.contains("hidden")).to.be.true;
   });
 
   it("should emit sgds-show and sgds-after-show when calling show()", async () => {
@@ -102,7 +102,7 @@ describe("<sgds-accordion-item>", () => {
 
     expect(hideHandler).to.have.been.calledOnce;
     expect(afterHideHandler).to.have.been.calledOnce;
-    expect(body?.hidden).to.be.true;
+    expect(body?.classList.contains("hidden")).to.be.true;
   });
 
   it("should emit sgds-show and sgds-after-show when setting open = true", async () => {
@@ -150,7 +150,7 @@ describe("<sgds-accordion-item>", () => {
 
     expect(hideHandler).to.have.been.calledOnce;
     expect(afterHideHandler).to.have.been.calledOnce;
-    expect(body?.hidden).to.be.true;
+    expect(body?.classList.contains("hidden")).to.be.true;
   });
 
   it("should not open when preventing sgds-show", async () => {


### PR DESCRIPTION
## :open_book: Description
1) fix for accordion's flickering. 

Flickering was due to styling added to style attribute causing some performance delays where animation has ended but the style attribute has not been added to the element.

I tried using javascript to add a .hidden class with display:none; right after the animation but there is still some delays causing flickering. My guess is the browser in gsib is doing some checks after the animation where it delays the next line of javascript code to run. 

The solution 
- I added a .hidden class display:none, that gets added to the DOM with a setTimeout of animationDuration - 20 milliseconds. 
This is to prevent the case where animation has completed before .hidden is added to the DOM

2) Change accordion caret to svg so that the fill color inherits the parent color

3) Handle keydown on SgdsAccordion for allowMultiple=true (previously was not handled for keyboard) 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in GSIB, no flickerings
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
