### PR TITLE
fix(pagination): duplicate first page button

### DIFF
--- a/src/components/Pagination/sgds-pagination.ts
+++ b/src/components/Pagination/sgds-pagination.ts
@@ -139,7 +139,12 @@ export class SgdsPagination extends SgdsElement {
   }
 
   private _renderFirstPage() {
-    const sanitizeStartPage = this.currentPage - Math.floor(this._sanitizeLimit / 2);
+    let sanitizeStartPage = this.currentPage - Math.floor(this._sanitizeLimit / 2);
+
+    if (this.pages.length - sanitizeStartPage < this.limit) {
+      sanitizeStartPage = this.pages.length + 1 - this.limit;
+    }
+
     if (sanitizeStartPage > 1) {
       return html`
         <li key=${1} class="page-item ${this.currentPage === 1 ? "active" : ""}">

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -473,6 +473,21 @@ describe("sgds-pagination", () => {
     expect(ellipsises?.length).to.equal(1);
     expect(ellipsises?.[0]).to.exist;
   });
+  it("showFirstPage set to true and limit set to page.length, no duplicate first page", async () => {
+    //8 pages, at page 8
+    const el = (await fixture(
+      html`
+        <sgds-pagination dataLength="40" limit="8" itemsPerPage="5" currentPage="8" showFirstPage></sgds-pagination>
+      `
+    )) as SgdsPagination;
+    const pageOne = el.shadowRoot?.querySelectorAll("li")[1];
+    const pageTwo = el.shadowRoot?.querySelectorAll("li")[2];
+    const pageThree = el.shadowRoot?.querySelectorAll("li")[3];
+
+    expect(pageOne?.textContent).to.contain("1");
+    expect(pageTwo?.textContent).to.contain("2");
+    expect(pageThree?.textContent).to.contain("3");
+  });
   it("showLastPage set to true, last page always appears and only last ellipsis shown", async () => {
     //8 pages, at page 1
     const el = (await fixture(


### PR DESCRIPTION
## :open_book: Description

Fix duplicate first page button when `showFirstPage` is set and `limit` equals to page length.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
