### PR TITLE
Fix/bug in input touch validation

### DIFF
--- a/src/components/Input/sgds-input.ts
+++ b/src/components/Input/sgds-input.ts
@@ -154,7 +154,7 @@ export class SgdsInput extends SgdsFormValidatorMixin(FormControlElement) implem
 
   protected _handleBlur() {
     const sgdsBlur = this.emit("sgds-blur", { cancelable: true });
-
+    this.setInvalid(!this._mixinCheckValidity());
     if (sgdsBlur.defaultPrevented) return;
 
     this._isTouched = true;

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -248,11 +248,11 @@ describe("when using constraint validation", () => {
     expect(el.checkValidity()).to.be.false;
   });
 
-  it("when required, blurring out an empty and touched field should cause input to be invalid", async() => {
+  it("when required, blurring out an empty and touched field should cause input to be invalid", async () => {
     const el = await fixture<SgdsInput>(html` <sgds-input required></sgds-input> `);
     expect(el.invalid).to.be.false;
 
-     el.focus();
+    el.focus();
     await sendKeys({ type: "ssd" });
     el.blur();
     await el.updateComplete;
@@ -268,15 +268,44 @@ describe("when using constraint validation", () => {
     expect(el.invalid).to.be.true;
     expect(el.checkValidity()).to.be.false;
 
-      el.focus();
+    el.focus();
     await sendKeys({ type: "ssd" });
     await sendKeys({ press: "Backspace" });
     await sendKeys({ press: "Backspace" });
     await sendKeys({ press: "Backspace" });
     await sendMouse({ type: "click", position: [0, 0] });
-     expect(el.invalid).to.be.true;
+    expect(el.invalid).to.be.true;
     expect(el.checkValidity()).to.be.false;
-  })
+  });
+  it("when NOT required, blurring out an empty and touched field should NOT cause input to be invalid", async () => {
+    const el = await fixture<SgdsInput>(html` <sgds-input></sgds-input> `);
+    expect(el.invalid).to.be.false;
+
+    el.focus();
+    await sendKeys({ type: "ssd" });
+    el.blur();
+    await el.updateComplete;
+    expect(el.value).to.equal("ssd");
+    expect(el.invalid).to.be.false;
+
+    el.focus();
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendMouse({ type: "click", position: [0, 0] });
+
+    expect(el.invalid).to.be.false;
+    expect(el.checkValidity()).to.be.true;
+
+    el.focus();
+    await sendKeys({ type: "ssd" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendMouse({ type: "click", position: [0, 0] });
+    expect(el.invalid).to.be.false;
+    expect(el.checkValidity()).to.be.true;
+  });
 
   it("for an invalid field,  invalid is set to false (reset) when user is typing", async () => {
     const el = await fixture<SgdsInput>(html` <sgds-input invalid></sgds-input> `);

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -2,7 +2,7 @@ import "./sgds-web-component";
 import type { SgdsInput, SgdsButton } from "../src/components";
 import { expect, fixture, html, oneEvent, waitUntil, assert, elementUpdated } from "@open-wc/testing";
 import sinon from "sinon";
-import { sendKeys } from "@web/test-runner-commands";
+import { sendKeys, sendMouse } from "@web/test-runner-commands";
 
 describe("sgds-input", () => {
   it("renders with default values", async () => {
@@ -247,6 +247,36 @@ describe("when using constraint validation", () => {
     expect(el.invalid).to.be.true;
     expect(el.checkValidity()).to.be.false;
   });
+
+  it("when required, blurring out an empty and touched field should cause input to be invalid", async() => {
+    const el = await fixture<SgdsInput>(html` <sgds-input required></sgds-input> `);
+    expect(el.invalid).to.be.false;
+
+     el.focus();
+    await sendKeys({ type: "ssd" });
+    el.blur();
+    await el.updateComplete;
+    expect(el.value).to.equal("ssd");
+    expect(el.invalid).to.be.false;
+
+    el.focus();
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendMouse({ type: "click", position: [0, 0] });
+
+    expect(el.invalid).to.be.true;
+    expect(el.checkValidity()).to.be.false;
+
+      el.focus();
+    await sendKeys({ type: "ssd" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendKeys({ press: "Backspace" });
+    await sendMouse({ type: "click", position: [0, 0] });
+     expect(el.invalid).to.be.true;
+    expect(el.checkValidity()).to.be.false;
+  })
 
   it("for an invalid field,  invalid is set to false (reset) when user is typing", async () => {
     const el = await fixture<SgdsInput>(html` <sgds-input invalid></sgds-input> `);


### PR DESCRIPTION
## :open_book: Description

Found a bug for input validation. The first time i blur an empty required input behaves normally, but subsequently when i go back and repeat the same steps, the validation does take place again. 

https://github.com/user-attachments/assets/e1128021-e42e-47a4-a6ab-8498e388051c


Fixes # (issue)

- SgdsInput to handle validation during on blur event

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I first wrote a test case to mimick the steps in the video and ensure it fails when run, reproducing the bug
- Made the fix which is to check validation when blurring event 
- Ran the test case and ensures it fails 
- Wrote another test case to check that validation don't take place when "required" prop is not added. 


## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
