### PR TITLE
fix(switch): hide label to avoid flex gap issue

### DIFF
--- a/test/switch.test.ts
+++ b/test/switch.test.ts
@@ -1,4 +1,4 @@
-import { expect, assert, fixture, html } from "@open-wc/testing";
+import { expect, assert, fixture, html, oneEvent } from "@open-wc/testing";
 import { SgdsSwitch } from "../src/components/Switch/sgds-switch";
 import "../src/components/Switch";
 
@@ -8,29 +8,114 @@ describe("<sgds-switch>", () => {
     assert.shadowDom.equal(
       el,
       `
-            <div
-        class="form-check"
-      >
-        <label class="d-none form-check-label left-label"
-          ><slot name="leftLabel"></slot
-        ></label>
-        <input
-          class="form-check-input"
-          type="checkbox"
-          aria-disabled="false"
-          aria-checked="false"
-        />
-        <label class="form-check-label"
-          ><slot></slot
-        ></label>
-      </div>
-            `,
+        <div class="form-check">
+          <label class="form-check-label left-label d-none">
+            <slot name="leftLabel"></slot>
+          </label>
+          <input
+            class="form-check-input"
+            type="checkbox"
+            aria-disabled="false"
+            aria-checked="false"
+          />
+          <label class="form-check-label d-none">
+            <slot></slot>
+          </label>
+        </div>
+      `,
       { ignoreAttributes: ["id", "for"] }
     );
   });
-  it("semantically matches the shadowDOM when leftLabel slot is present", async () => {
-    const el = await fixture<SgdsSwitch>(html`<sgds-switch><span slot="leftLabel">Hello</span></sgds-switch>`);
-    const leftLabel = el.shadowRoot?.querySelector("label.left-label");
-    expect(leftLabel?.classList.value).to.not.contain("d-none");
+
+  it("toggles checked state on click", async () => {
+    const el = await fixture<SgdsSwitch>(html`<sgds-switch></sgds-switch>`);
+    const input = el.shadowRoot?.querySelector("input");
+
+    input?.click();
+    expect(el.checked).to.be.true;
+
+    input?.click();
+    expect(el.checked).to.be.false;
+  });
+
+  it("emits sgds-change event on toggle", async () => {
+    const el = await fixture<SgdsSwitch>(html`<sgds-switch></sgds-switch>`);
+    const input = el.shadowRoot?.querySelector("input");
+    const listener = oneEvent(el, "sgds-change");
+
+    input?.click();
+
+    const event = await listener;
+    expect(event).to.exist;
+    expect(event.detail.checked).to.equal(true);
+  });
+
+  it("applies disabled state correctly", async () => {
+    const el = await fixture<SgdsSwitch>(html`<sgds-switch disabled></sgds-switch>`);
+    const input = el.shadowRoot?.querySelector("input");
+
+    expect(input?.disabled).to.be.true;
+
+    input?.click();
+    expect(el.checked).to.be.false;
+  });
+
+  it("renders with leftLabel slot", async () => {
+    const el = await fixture<SgdsSwitch>(html`
+      <sgds-switch>
+        <span slot="leftLabel">Left Label</span>
+      </sgds-switch>
+    `);
+
+    const leftLabelSlot = el.shadowRoot?.querySelector("slot[name='leftLabel']");
+    expect(leftLabelSlot).to.exist;
+
+    const leftLabel = el.querySelector('[slot="leftLabel"]');
+    expect(leftLabel).to.have.trimmed.text("Left Label");
+  });
+
+  it("renders with default (rightLabel) slot", async () => {
+    const el = await fixture<SgdsSwitch>(html`
+      <sgds-switch>
+        <span>Right Label</span>
+      </sgds-switch>
+    `);
+
+    const defaultSlot = el.shadowRoot?.querySelector("slot:not([name])");
+    expect(defaultSlot).to.exist;
+
+    const content = el.querySelector("span");
+    expect(content).to.have.trimmed.text("Right Label");
+  });
+
+  it("hides left label when default slot is filled", async () => {
+    const el = await fixture<SgdsSwitch>(html`
+      <sgds-switch>
+        <span>Right Label</span>
+      </sgds-switch>
+    `);
+
+    const leftLabel = el.shadowRoot?.querySelector(".left-label");
+    expect(leftLabel?.classList.contains("d-none")).to.be.true;
+  });
+
+  it("hides right label when leftLabel slot is filled", async () => {
+    const el = await fixture<SgdsSwitch>(html`
+      <sgds-switch>
+        <span slot="leftLabel">Left Label</span>
+      </sgds-switch>
+    `);
+
+    const rightLabel = el.shadowRoot?.querySelectorAll(".form-check-label")[1];
+    expect(rightLabel?.classList.contains("d-none")).to.be.true;
+  });
+
+  it("toggles with Enter key", async () => {
+    const el = await fixture<SgdsSwitch>(html`<sgds-switch></sgds-switch>`);
+    const input = el.shadowRoot?.querySelector("input");
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+
+    input?.dispatchEvent(event);
+    expect(el.checked).to.be.true;
   });
 });


### PR DESCRIPTION
## :open_book: Description

There is a gap for empty label on the right when the label is displayed on the left. Refactored the component to hide the empty label.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
