### PR TITLE
fix(DropdownItem): click area bug

### DIFF
--- a/src/components/Dropdown/dropdown-item.css
+++ b/src/components/Dropdown/dropdown-item.css
@@ -1,15 +1,15 @@
 .dropdown-item {
-    background-color: var(--sgds-bg-transparent);
-    padding: var(--sgds-padding-sm) var(--sgds-padding-lg);
-    clear: both;
-    display: flex;
-    gap: var(--sgds-gap-sm);
-    align-items: center;
-    color: var(--sgds-color-default);
-    text-align: inherit;
-    white-space: nowrap;
-    cursor: pointer;
-  }
+  background-color: var(--sgds-bg-transparent);
+  padding: var(--sgds-padding-sm) var(--sgds-padding-lg);
+  clear: both;
+  display: flex;
+  gap: var(--sgds-gap-sm);
+  align-items: center;
+  color: var(--sgds-color-default);
+  text-align: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+}
 
 .dropdown-item:not(.nav-link):hover {
   background-color: var(--sgds-bg-translucent-subtle);
@@ -33,10 +33,10 @@
   opacity: var(--sgds-opacity-50);
   pointer-events: none;
 }
-::slotted(*){
+::slotted(*) {
   display: flex;
   gap: var(--sgds-gap-sm);
-  text-decoration: none !important; 
+  text-decoration: none !important;
   color: inherit !important;
 }
 
@@ -63,3 +63,9 @@
   color: var(--sgds-primary-color-default);
   background-color: var(--sgds-bg-translucent-subtle);
 }
+
+/* ::slotted(*) {
+  width: 100%;
+  border: 1px solid red;
+
+} */

--- a/src/components/Dropdown/sgds-dropdown-item.ts
+++ b/src/components/Dropdown/sgds-dropdown-item.ts
@@ -33,6 +33,9 @@ export class SgdsDropdownItem extends SgdsElement {
         this.anchor[0].click();
       }
     });
+    this.addEventListener("click", () => {
+      this.anchor.length > 0 && this.anchor[0].click();
+    });
     this.setAttribute("role", "menuitem");
     this.setAttribute("aria-disabled", `${this.disabled}`);
   }

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -526,4 +526,14 @@ describe("sgds-dropdown-item", () => {
     const el = await fixture(html`<sgds-dropdown-item active>test</sgds-dropdown-item>`);
     expect(el.shadowRoot?.querySelector("div.dropdown-item")).to.have.class("active");
   });
+  it("when clicked on, should trigger a navigation", async () => {
+    const el = await fixture<SgdsDropdownItem>(html`<sgds-dropdown-item>
+      <a>Example</a>
+    </sgds-dropdown-item>`);
+    const anchor = el.querySelector("a");
+    const anchorSpy = sinon.spy();
+    anchor?.addEventListener("click", anchorSpy);
+    el.click();
+    expect(anchorSpy.calledOnce).to.be.true;
+  });
 });


### PR DESCRIPTION
## :open_book: Description

Bug found that when clicking outside of the label of Dropdown Item but still within the area of DropdownItem, the navigation doesnt work 

This is because the navigation is tied to "anchor" tag, which area does not span the entire dropdown item. I tried to use width 100%, but the height will still be a problem due to the padding in DropdownItem 

hence i applied a javascript solution to listen for click events happening in DropdownItem and trigger a click on the anchor if that happens 



Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
