### PR TITLE
jx/modal

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,5 +8,6 @@
 <style>
   body {
     font-family: Inter, sans-serif;
+    overflow: auto !important;
   }
 </style>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -1,13 +1,19 @@
 :host([size="sm"]) .modal-panel {
-  max-width: 480px;
+  max-width: var(--sgds-dimension-480);
+}
+
+:host([size="md"]) .modal-panel {
+  max-width: var(--sgds-dimension-640);
 }
 
 :host([size="lg"]) .modal-panel {
-  max-width: 800px;
+  max-width: var(--sgds-dimension-800);
 }
 
 :host([size="fullscreen"]) .modal-panel {
-  max-width: 1128px;
+  max-width: var(--sgds-dimension-1320);
+  padding: var(--sgds-padding-none);
+  margin: var(--sgds-margin-xl) var(--sgds-margin-xs);
 }
 
 :host(:not([size="fullscreen"])) .modal-panel {
@@ -33,24 +39,58 @@
 
 .modal-panel {
   width: 100%;
-  max-width: 640px;
+  max-width: var(--sgds-dimension-640);
   border-radius: var(--sgds-border-radius-md);
-  margin: var(--sgds-spacer-9) var(--sgds-spacer-6);
+  padding: var(--sgds-padding-xl);
+  margin: var(--sgds-margin-2-xl) var(--sgds-margin-xs);
   position: relative;
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - var(--sgds-spacer-9) - var(--sgds-spacer-9));
+  max-height: calc(100% - var(--sgds-margin-2-xl) - var(--sgds-margin-2-xl));
 }
 
 .modal-panel:focus {
   outline: none;
 }
 
+.modal-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sgds-gap-2-xl);
+  min-height: 0;
+  position: relative;
+}
+
+.modal-header__close {
+  position: absolute;
+  top: calc(-1 * var(--sgds-padding-md));
+  right: calc(-1 * var(--sgds-padding-md));
+}
+
+@media screen and (max-width: 1024px) {
+  :host([size="fullscreen"]) .modal-panel {
+    margin: var(--sgds-margin-md)
+  } 
+}
+
+@media screen and (max-width: 768px) {
+  :host([size="fullscreen"]) .modal-panel {
+    margin: var(--sgds-margin-sm)
+  } 
+}
+
+@media screen and (max-width: 512px) {
+  :host([size="fullscreen"]) .modal-panel {
+    margin: var(--sgds-margin-sm) var(--sgds-margin-xs)
+  } 
+}
+
 /* Ensure there's enough vertical padding for phones that don't update vh when chrome appears (e.g. iPhone) */
 @media screen and (max-width: 420px) {
-  .modal-panel {
-    margin: var(--sgds-spacer-8) var(--sgds-spacer-6);
-    max-height: calc(100% - var(--sgds-spacer-8) - var(--sgds-spacer-8));
+  :host(:not([size="fullscreen"])) .modal-panel {
+    margin: var(--sgds-margin-sm) var(--sgds-margin-xs);
+    max-height: calc(100% - var(--sgds-margin-sm) - var(--sgds-margin-sm));
   }
 }
 
@@ -64,7 +104,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: var(--sgds-padding-xl);
+  max-width: var(--sgds-dimension-872);
 }
 .modal-header__title-description {
   display: flex;
@@ -93,14 +133,13 @@ slot[name="description"]::slotted(*) {
 }
 
 .modal-body {
+  flex: 1 1 auto;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-  padding: 0 var(--sgds-padding-xl) var(--sgds-padding-xl);
 }
 
 .modal-body slot::slotted(*) {
   --sgds-paragraph-spacing-xl: var(--sgds-margin-none);
-  margin: var(--sgds-paragraph-spacing-xl, --sgds-margin-none);
 }
 
 .modal-footer {
@@ -109,7 +148,7 @@ slot[name="description"]::slotted(*) {
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--sgds-gap-md);
-  padding: var(--sgds-padding-xl);
+  padding-top: var(--sgds-padding-md);
 }
 
 .modal:not(.has-footer) .modal-footer {

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -10,16 +10,6 @@
   max-width: var(--sgds-dimension-800);
 }
 
-:host([size="fullscreen"]) .modal-panel {
-  max-width: var(--sgds-dimension-1320);
-  padding: var(--sgds-padding-none);
-  margin: var(--sgds-margin-xl) var(--sgds-margin-xs);
-}
-
-:host(:not([size="fullscreen"])) .modal-panel {
-  background-color: var(--sgds-surface-default);
-}
-
 :host([size="fullscreen"]) .modal-overlay {
   background-color: var(--sgds-surface-default);
 }
@@ -39,14 +29,19 @@
 
 .modal-panel {
   width: 100%;
-  max-width: var(--sgds-dimension-640);
   border-radius: var(--sgds-border-radius-md);
-  padding: var(--sgds-padding-xl);
-  margin: var(--sgds-margin-2-xl) var(--sgds-margin-xs);
   position: relative;
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - var(--sgds-margin-2-xl) - var(--sgds-margin-2-xl));
+  gap: var(--sgds-gap-2-xl);
+  margin: var(--sgds-margin-sm) var(--sgds-margin-xs);
+  max-height: calc(100% - var(--sgds-margin-sm) - var(--sgds-margin-sm));
+}
+
+:host(:not([size="fullscreen"])) .modal-panel {
+  background-color: var(--sgds-surface-default);
+  padding: var(--sgds-padding-xl);
+  max-width: var(--sgds-dimension-640);
 }
 
 .modal-panel:focus {
@@ -68,30 +63,37 @@
   right: calc(-1 * var(--sgds-padding-md));
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (min-width: 512px) {
   :host([size="fullscreen"]) .modal-panel {
-    margin: var(--sgds-margin-md)
+    margin: var(--sgds-margin-sm);
   } 
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (min-width: 768px) {
   :host([size="fullscreen"]) .modal-panel {
-    margin: var(--sgds-margin-sm)
+    margin: var(--sgds-margin-md);
+    max-height: calc(100% - var(--sgds-margin-md) - var(--sgds-margin-md));
   } 
 }
 
-@media screen and (max-width: 512px) {
+@media screen and (min-width: 1024px) {
   :host([size="fullscreen"]) .modal-panel {
-    margin: var(--sgds-margin-sm) var(--sgds-margin-xs)
+    margin: var(--sgds-margin-xl) var(--sgds-margin-xs);
+    max-height: calc(100% - var(--sgds-margin-xl) - var(--sgds-margin-xl));
+    max-width: var(--sgds-dimension-896);
   } 
 }
 
-/* Ensure there's enough vertical padding for phones that don't update vh when chrome appears (e.g. iPhone) */
-@media screen and (max-width: 420px) {
-  :host(:not([size="fullscreen"])) .modal-panel {
-    margin: var(--sgds-margin-sm) var(--sgds-margin-xs);
-    max-height: calc(100% - var(--sgds-margin-sm) - var(--sgds-margin-sm));
-  }
+@media screen and (min-width: 1280px) {
+  :host([size="fullscreen"]) .modal-panel {
+    max-width: var(--sgds-dimension-1176);
+  } 
+}
+
+@media screen and (min-width: 1440px) {
+  :host([size="fullscreen"]) .modal-panel {
+    max-width: var(--sgds-dimension-1320);
+  } 
 }
 
 .modal.show .modal-panel {
@@ -106,10 +108,15 @@
   justify-content: space-between;
   max-width: var(--sgds-dimension-872);
 }
+
 .modal-header__title-description {
   display: flex;
   flex-direction: column;
-  gap: var(--sgds-gap-xs);
+  gap: var(--sgds-gap-sm);
+}
+
+:host([size="fullscreen"]) .modal-header__title-description {
+  gap: var(--sgds-gap-md);
 }
 
 slot[name="title"]::slotted(*) {

--- a/src/components/Modal/sgds-modal.ts
+++ b/src/components/Modal/sgds-modal.ts
@@ -273,20 +273,22 @@ export class SgdsModal extends SgdsElement {
           aria-labelledby="title"
           tabindex="-1"
         >
-          <div class="modal-header">
-            <div class="modal-header__title-description">
-              <slot class="modal-title" id="title" name="title"></slot>
-              <slot name="description"></slot>
+          <div class="modal-content">
+            <div class="modal-header">
+              <div class="modal-header__title-description">
+                <slot class="modal-title" id="title" name="title"></slot>
+                <slot name="description"></slot>
+              </div>
+              <sgds-close-button
+                class="modal-header__close"
+                @click="${() => this.requestClose("close-button")}"
+                ariaLabel="close modal"
+              ></sgds-close-button>
             </div>
-            <sgds-close-button
-              class="modal-header__close"
-              @click="${() => this.requestClose("close-button")}"
-              ariaLabel="close modal"
-            ></sgds-close-button>
-          </div>
-          <div class="modal-body">
-            <slot></slot>
-          </div>
+            <div class="modal-body">
+              <slot></slot>
+            </div>
+          </div class="modal-content">
           <div class="modal-footer">
             <slot name="footer"></slot>
           </div>

--- a/src/components/Modal/sgds-modal.ts
+++ b/src/components/Modal/sgds-modal.ts
@@ -14,6 +14,7 @@ import SgdsCloseButton from "../../internals/CloseButton/sgds-close-button";
 import modalStyle from "./modal.css";
 import headerStyles from "../../styles/header-class.css";
 import svgStyles from "../../styles/svg.css";
+import { SM_BREAKPOINT, MD_BREAKPOINT } from "../../utils/breakpoints";
 /**
  * @summary The modal component inform users about a specific task and may contain critical information which users then have to make a decision.
  *
@@ -100,7 +101,7 @@ export class SgdsModal extends SgdsElement {
 
     if (buttonElements.length <= 1) return;
 
-    if (panelWidth < 512 || (this.size === "fullscreen" && panelWidth < 768)) {
+    if (panelWidth < SM_BREAKPOINT || (this.size === "fullscreen" && panelWidth < MD_BREAKPOINT)) {
       buttonElements.forEach(buttonElement => {
         const button = buttonElement as SgdsButton;
         button.fullWidth = true;

--- a/src/components/Modal/sgds-modal.ts
+++ b/src/components/Modal/sgds-modal.ts
@@ -100,7 +100,7 @@ export class SgdsModal extends SgdsElement {
 
     if (buttonElements.length <= 1) return;
 
-    if (panelWidth <= 360) {
+    if (panelWidth < 512 || (this.size === "fullscreen" && panelWidth < 768)) {
       buttonElements.forEach(buttonElement => {
         const button = buttonElement as SgdsButton;
         button.fullWidth = true;

--- a/src/themes/root.css
+++ b/src/themes/root.css
@@ -238,10 +238,16 @@
   --sgds-dimension-384: 384px;
   --sgds-dimension-480: 480px;
   --sgds-dimension-512: 512px;
+  --sgds-dimension-640: 640px;
   --sgds-dimension-688: 688px;
   --sgds-dimension-768: 768px;
+  --sgds-dimension-800: 800px;
+  --sgds-dimension-872: 872px;
+  --sgds-dimension-896: 896px;
   --sgds-dimension-1024: 1024px;
+  --sgds-dimension-1176: 1176px;
   --sgds-dimension-1280: 1280px;
+  --sgds-dimension-1320: 1320px;
   --sgds-dimension-1440: 1440px;
 
   /* Semantic - Padding */

--- a/src/utils/breakpoints.ts
+++ b/src/utils/breakpoints.ts
@@ -1,5 +1,6 @@
-export const LG_BREAKPOINT = 1024;
-export const MD_BREAKPOINT = 768;
+export const XS_BREAKPOINT = 320;
 export const SM_BREAKPOINT = 512;
+export const MD_BREAKPOINT = 768;
+export const LG_BREAKPOINT = 1024;
 export const XL_BREAKPOINT = 1280;
 export const XXL_BREAKPOINT = 1440;

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -8,7 +8,7 @@ const locks = new Set();
  */
 export function lockBodyScrolling(lockingEl: HTMLElement) {
   locks.add(lockingEl);
-  document.body.style.overflow = 'hidden';
+  document.body.style.overflow = "hidden";
 }
 
 /**
@@ -52,6 +52,6 @@ export function unlockBodyScrolling(lockingEl: HTMLElement) {
   locks.delete(lockingEl);
 
   if (locks.size === 0) {
-    document.body.style.overflow = '';
+    document.body.style.overflow = "";
   }
 }

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -8,7 +8,7 @@ const locks = new Set();
  */
 export function lockBodyScrolling(lockingEl: HTMLElement) {
   locks.add(lockingEl);
-  document.body.classList.add("sl-scroll-lock");
+  document.body.style.overflow = 'hidden';
 }
 
 /**
@@ -52,6 +52,6 @@ export function unlockBodyScrolling(lockingEl: HTMLElement) {
   locks.delete(lockingEl);
 
   if (locks.size === 0) {
-    document.body.classList.remove("sl-scroll-lock");
+    document.body.style.overflow = '';
   }
 }

--- a/test/drawer.test.ts
+++ b/test/drawer.test.ts
@@ -146,4 +146,18 @@ describe("<sgds-drawer>", () => {
 
     expect(el.open).to.be.false;
   });
+
+  it("should lock or unlock scrolling on body when drawer opens or closes respectively", async () => {
+    document.body.style.overflow = "auto";
+    const el = await fixture<SgdsDrawer>(html` <sgds-drawer open></sgds-drawer> `);
+    el.open = true;
+    expect(document.body.style.overflow).to.equal("hidden");
+
+    const afterHideHandler = sinon.spy();
+    el.addEventListener("sgds-after-hide", afterHideHandler);
+    el.open = false;
+
+    await waitUntil(() => afterHideHandler.calledOnce);
+    expect(document.body.style.overflow).to.not.equal("hidden");
+  });
 });

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -11,10 +11,10 @@ describe("<sgds-modal>", () => {
     assert.shadowDom.equal(
       el,
       `
-   <div
-       class="modal"
-       hidden=""
-     >
+    <div
+      class="modal"
+      hidden=""
+    >
         <div class="modal-overlay"></div>
         <div
           class="modal-panel"
@@ -24,22 +24,23 @@ describe("<sgds-modal>", () => {
           aria-labelledby="title"
           tabindex="-1"
         >
-         <div class="modal-header">
-            <div class="modal-header__title-description">
-              <slot class="modal-title" id="title" name="title"></slot>
-              <slot name="description"></slot>
-            </div>
-            <sgds-close-button
-            class="modal-header__close"
-            ariaLabel="close modal"
-            size="md" 
-            variant="default"
-          ></sgds-close-button>
-          </div>
-          <div class="modal-body">
-            <slot>
-            </slot>
-          </div>
+          <div class="modal-content">
+            <div class="modal-header">
+                <div class="modal-header__title-description">
+                  <slot class="modal-title" id="title" name="title"></slot>
+                  <slot name="description"></slot>
+                </div>
+                <sgds-close-button
+                class="modal-header__close"
+                ariaLabel="close modal"
+                size="md" 
+                variant="default"
+              ></sgds-close-button>
+              </div>
+              <div class="modal-body">
+                <slot></slot>
+              </div>
+          </div class="modal=content">
           <div class="modal-footer">
             <slot name="footer">
             </slot>
@@ -176,5 +177,19 @@ describe("<sgds-modal>", () => {
   it("noCloseButton prop removes button from modal", async () => {
     const el = await fixture<SgdsModal>(html`<sgds-modal noCloseButton></sgds-modal>`);
     expect(el.shadowRoot?.querySelector("button.btn-close")).to.be.null;
+  });
+
+  it("should lock or unlock scrolling on body when modal opens or closes respectively", async () => {
+    document.body.style.overflow = "auto";
+    const el = await fixture<SgdsModal>(html` <sgds-modal open></sgds-modal> `);
+    el.open = true;
+    expect(document.body.style.overflow).to.equal("hidden");
+
+    const afterHideHandler = sinon.spy();
+    el.addEventListener("sgds-after-hide", afterHideHandler);
+    el.open = false;
+
+    await waitUntil(() => afterHideHandler.calledOnce);
+    expect(document.body.style.overflow).to.not.equal("hidden");
   });
 });

--- a/test/modal.test.ts
+++ b/test/modal.test.ts
@@ -40,7 +40,7 @@ describe("<sgds-modal>", () => {
               <div class="modal-body">
                 <slot></slot>
               </div>
-          </div class="modal=content">
+          </div>
           <div class="modal-footer">
             <slot name="footer">
             </slot>


### PR DESCRIPTION
## :open_book: Description

* Update margin/padding/dimensions for modal 
* Update button group full-width toggle logic
* Update modal content hierarchy to better work with slots
* Disable scrolling on `<body>` when a UI element like modal or dialog is open, and re-enable scrolling when there are no more locking elements
* Override overflow in storybook `preview-head.html` so scroll doesn't get locked by open modals/drawers due to `scroll.ts`
* Update default values in CSS to follow mobile-first approach
* Update dimension primitives/constants
 
Fixes # 1152, 1153

## :pencil2: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :test_tube: How Has This Been Tested?

* Added a test case in modal and drawer to check that `overflow: hidden` is conditionally applied and removed when the UI elements are opened and closed
* Can also check by inspecting the body tag in browser tools and attempting to scroll in the background

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [-] Any dependent changes have been merged and published in downstream modules
