### PR TITLE
Fix/datepicker on change handling

### DIFF
--- a/playground/Datepicker.html
+++ b/playground/Datepicker.html
@@ -5,7 +5,7 @@
 
 
 <form>
-  <sgds-datepicker noFlip required hasFeedback value="18/07/2025"></sgds-datepicker>
+  <sgds-datepicker noFlip hasFeedback value="18/07/2025"></sgds-datepicker>
   <sgds-datepicker noFlip required value="07/08/2024 - 09/08/2024" mode="range"></sgds-datepicker>
 
   <sgds-button type="submit">Submit</sgds-button>

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -343,7 +343,10 @@ export class SgdsDatepicker extends SgdsFormValidatorMixin(DropdownElement) impl
     this._manageInternalsBadInput();
   }
   private async _handleEmptyInput() {
-    this._manageEmptyInput();
+    if (this.required) {
+      this._manageEmptyInput();
+    }
+    return;
   }
   private async _resetDatepicker(resetValue = "") {
     this.displayDate = this.initialDisplayDate;
@@ -356,7 +359,7 @@ export class SgdsDatepicker extends SgdsFormValidatorMixin(DropdownElement) impl
     await input.applyInputMask();
 
     this._mixinResetValidity(input);
-    if (this.isValueEmpty() && this.required) {
+    if (this.isValueEmpty()) {
       this._handleEmptyInput();
     }
   }

--- a/test/datepicker.test.ts
+++ b/test/datepicker.test.ts
@@ -1596,6 +1596,21 @@ describe("datepicker in form context", () => {
     const formData = new FormData(el);
     expect(formData.get("myDatepicker")).to.equal("23/03/2020");
   });
+  it("allows empty value datepicker, not required field to be submitted in form", async () => {
+    const el = await fixture<HTMLFormElement>(
+      html`<form><sgds-datepicker value="23/03/2020" name="myDatepicker"></sgds-datepicker></form>`
+    );
+    const datepicker = el.querySelector("sgds-datepicker") as SgdsDatepicker;
+    const input = datepicker?.shadowRoot?.querySelector("sgds-datepicker-input")?.shadowRoot?.querySelector("input");
+    input?.focus();
+    for (let i = 0; i < 8; i++) {
+      await sendKeys({ press: "Backspace" });
+    }
+    input?.blur();
+    await elementUpdated(datepicker);
+    expect(datepicker.value).to.equal("");
+    expect(el.checkValidity()).to.be.true;
+  });
   it("For required, should be invalid when touched and blurred but empty", async () => {
     const el = await fixture<HTMLFormElement>(
       html`<form><sgds-datepicker name="myDatepicker" required></sgds-datepicker></form>`


### PR DESCRIPTION
## :open_book: Description

#292


- Change event `@sgds-change-date` should not run in the first render since user did not trigger a change in date 
-  `value` state becomes `value` prop in favour of `initialValue`. 
-  `initialValue` prop deprecated but still working until v4  
- Refactor _resetDatepicker() to differentiate between a form reset and a user action reset (for example, user use keyboard to backspace the input, resetting the datepicker and its calendar)
- Only run empty input validation when `required` is true
Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
