### PR TITLE
style(icon list): align icon and text at top instead of center

### DIFF
--- a/playground/IconList.html
+++ b/playground/IconList.html
@@ -1,0 +1,48 @@
+<script type="module" src="../src/index.ts"></script>
+<link href="../src/themes/day.css" rel="stylesheet" type="text/css" />
+<link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
+<link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
+
+<div class="sgds-container">
+  <div class="sgds-grid">
+    <div class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4">
+      <sgds-icon-list size="sm">
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="md"></sgds-icon>item one item one item one item one item one item one item one item one item one item one item one item one item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="md"></sgds-icon>item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="md"></sgds-icon>item one
+        </div>
+      </sgds-icon-list>
+    </div>
+    <div class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4">
+      <sgds-icon-list>
+        <div role="listitem">
+          <sgds-icon name="placeholder"></sgds-icon>item one item one item one item one item one item one item one item one item one item one item one item one item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder"></sgds-icon>item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder"></sgds-icon>item one
+        </div>
+      </sgds-icon-list>
+    </div>
+    <div class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4">
+      <sgds-icon-list size="lg">
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="xl"></sgds-icon>item one item one item one item one item one item one item one item one item one item one item one item one item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="xl"></sgds-icon>item one
+        </div>
+        <div role="listitem">
+          <sgds-icon name="placeholder" size="xl"></sgds-icon>item one
+        </div>
+      </sgds-icon-list>
+    </div>
+  </div>
+</div>

--- a/src/components/IconList/icon-list.css
+++ b/src/components/IconList/icon-list.css
@@ -7,7 +7,7 @@ slot {
 slot::slotted(*){
   display: flex;
   gap: var(--sgds-gap-xs);
-  align-items: center;
+  align-items: flex-start;
 }
 
 .sm {


### PR DESCRIPTION
## :open_book: Description

#309 
Fix the alignment of the icon list and text to align at top instead of center

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
