### PR TITLE
fix(footer): fix slots being hidden in html page even when slotted elements

### DIFF
--- a/playground/Footer.html
+++ b/playground/Footer.html
@@ -1,0 +1,61 @@
+<script type="module" src="../src/index.ts"></script>
+<link href="../src/themes/day.css" rel="stylesheet" type="text/css" />
+<link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
+<link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
+
+<sgds-footer>
+  <h2 slot="title">Name of portal/digital service</h2>
+  <p slot="description">Description of portal/digital service</p>
+  <sgds-footer-item slot="items">
+    <div slot="title">Application Guidelines</div>
+    <a href="/application-guidelines/lorem-ipsum-one/second-level-a/">hello world</a>
+    <a href="/application-guidelines/lorem-ipsum-one/part-A/">Second Level B</a>
+    <a href="/application-guidelines/lorem-ipsum-three/">Lorem Ipsum Three</a>
+  </sgds-footer-item>
+  <sgds-footer-item slot="items">
+    <div slot="title">Legislation</div>
+    <a href="#">Legislation</a>
+    <a href="https://en.wikipedia.org/wiki/Year" target="_blank">External Link One</a>
+    <a href="https://en.wikipedia.org/wiki/Spring_(season)" target="_blank">External Link Two</a>
+  </sgds-footer-item>
+  <sgds-footer-item slot="items">
+    <div slot="title">Resources</div>
+    <a href="/resource_room/">All</a>
+    <a href="/resource_room/forms-and-templates/" target="_blank">Forms and Templates</a>
+    <a href="/resource_room/guides/" target="_blank">Guides</a>
+  </sgds-footer-item>
+  <sgds-footer-item slot="items">
+    <div slot="title">Resources</div>
+    <a href="/resource_room/">All</a>
+    <a href="/resource_room/forms-and-templates/" target="_blank">Forms and Templates</a>
+    <a href="/resource_room/guides/" target="_blank">Guides</a>
+  </sgds-footer-item>
+  <sgds-footer-item slot="items">
+    <div slot="title">Resources</div>
+    <a href="/resource_room/">All</a>
+    <a href="/resource_room/forms-and-templates/" target="_blank">Forms and Templates</a>
+    <a href="/resource_room/guides/" target="_blank">Guides</a>
+  </sgds-footer-item>
+  <sgds-footer-item slot="items">
+    <div slot="title">Resources</div>
+    <a href="/resource_room/">All</a>
+    <a href="/resource_room/forms-and-templates/" target="_blank">Forms and Templates</a>
+    <a href="/resource_room/guides/" target="_blank">Guides</a>
+  </sgds-footer-item>
+
+  <a slot="social-media" href="https://www.facebook.com">
+    <sgds-icon name="facebook"></sgds-icon>
+  </a>
+  <a slot="social-media" href="https://www.instagram.com">
+    <sgds-icon name="instagram"></sgds-icon>
+  </a>
+  <a slot="social-media" href="https://www.linkedin.com">
+    <sgds-icon name="linkedin"></sgds-icon>
+  </a>
+  <a slot="social-media" href="https://www.x.com">
+    <sgds-icon name="twitter-x"></sgds-icon>
+  </a>
+  <a slot="social-media" href="https://www.youtube.com">
+    <sgds-icon name="youtube"></sgds-icon>
+  </a>
+</sgds-footer>

--- a/src/components/Footer/sgds-footer.ts
+++ b/src/components/Footer/sgds-footer.ts
@@ -1,6 +1,7 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import SgdsElement from "../../base/sgds-element";
+import { HasSlotController } from "../../utils/slot";
 import footerStyle from "./footer.css";
 
 /**
@@ -51,56 +52,47 @@ export class SgdsFooter extends SgdsElement {
   @property({ type: String })
   termsOfUseHref = "#";
 
-  firstUpdated() {
-    const socialMediaSlot = this.shadowRoot.querySelector("slot[name='social-media']") as HTMLSlotElement;
-    const footerTitleSlot = this.shadowRoot.querySelector("slot[name='title']") as HTMLSlotElement;
-    const footerDescriptionSlot = this.shadowRoot.querySelector("slot[name='description']") as HTMLSlotElement;
-    const footerItemsSlot = this.shadowRoot.querySelector("slot[name='items']") as HTMLSlotElement;
-    const socialMediaChildNodes = socialMediaSlot.assignedNodes({ flatten: true });
-    const footerTitleChildNodes = footerTitleSlot.assignedNodes({ flatten: true });
-    const footerDescriptionChildNodes = footerDescriptionSlot.assignedNodes({ flatten: true });
-    const footerItemsChildNodes = footerItemsSlot.assignedNodes({ flatten: true });
-    if (socialMediaChildNodes.length === 0) {
-      const socialMediaContainer = this.shadowRoot.querySelector(".social-media") as HTMLDivElement;
-      socialMediaContainer.style.display = "none";
-    }
-
-    if (footerTitleChildNodes.length === 0 && footerDescriptionChildNodes.length === 0) {
-      const footerHeaderContainer = this.shadowRoot.querySelector(".footer-header") as HTMLDivElement;
-      footerHeaderContainer.style.display = "none";
-    }
-
-    if (footerItemsChildNodes.length === 0) {
-      const footerItemsContainer = this.shadowRoot.querySelector(".footer-items") as HTMLDivElement;
-      footerItemsContainer.style.display = "none";
-    }
-
-    if (
-      footerTitleChildNodes.length === 0 &&
-      footerDescriptionChildNodes.length === 0 &&
-      footerItemsChildNodes.length === 0
-    ) {
-      const footerTopContainer = this.shadowRoot.querySelector(".footer-top") as HTMLDivElement;
-      footerTopContainer.style.display = "none";
-    }
-  }
+  private readonly hasSlotController = new HasSlotController(this, "social-media", "title", "description", "items");
 
   render() {
+    const hasSocialMediaSlot = this.hasSlotController.test("social-media");
+    const hasTitleSlot = this.hasSlotController.test("title");
+    const hasDescriptionSlot = this.hasSlotController.test("description");
+    const hasItemsSlot = this.hasSlotController.test("items");
+
+    const displayFooterHeader = hasTitleSlot || hasDescriptionSlot;
+    const displayFooterItems = hasItemsSlot;
+    const displaySocialMedia = hasSocialMediaSlot;
+    const displayFooterTop = displayFooterHeader || displayFooterItems;
+
     return html`
       <footer class="footer">
-        <section class="footer-top">
-          <div class="footer-header">
-            <slot name="title"></slot>
-            <slot name="description"></slot>
-          </div>
-          <div class="footer-items">
-            <slot name="items"></slot>
-          </div>
-        </section>
+        ${displayFooterTop
+          ? html` <section class="footer-top">
+              ${displayFooterHeader
+                ? html`
+                    <div class="footer-header">
+                      <slot name="title"></slot>
+                      <slot name="description"></slot>
+                    </div>
+                  `
+                : nothing}
+              ${displayFooterItems
+                ? html` <div class="footer-items">
+                    <slot name="items"></slot>
+                  </div>`
+                : nothing}
+            </section>`
+          : nothing}
+
         <section class="footer-bottom">
-          <div class="social-media">
-            <slot name="social-media"></slot>
-          </div>
+          ${displaySocialMedia
+            ? html`
+                <div class="social-media">
+                  <slot name="social-media"></slot>
+                </div>
+              `
+            : nothing}
           <div class="footer-mandatory-links">
             <ul>
               <li><a href=${this.contactHref}>Contact</a></li>

--- a/test/footer.test.ts
+++ b/test/footer.test.ts
@@ -9,23 +9,8 @@ describe("footer", () => {
     assert.shadowDom.equal(
       el,
       `
-          <footer class="footer">
-          <section class="footer-top" style="display: none;">
-            <div class="footer-header" style="display: none;">
-              <slot name="title"></slot>
-              <slot name="description"></slot>
-            </div>
-            <div class="footer-items" style="display: none;">
-              <slot name="items"></slot>
-            </div>
-          </section>
+        <footer class="footer">
           <section class="footer-bottom">
-            <div
-              class="social-media"
-              style="display: none;"
-            >
-              <slot name="social-media"></slot>
-            </div>
             <div class="footer-mandatory-links">
               <ul>
                 <li><a href="#">Contact</a></li>
@@ -46,7 +31,7 @@ describe("footer", () => {
             </div>
           </section>
         </footer>
-          `
+      `
     );
   });
 


### PR DESCRIPTION
## :open_book: Description

When rendering sgds-footer in an HTML file, the slots appear hidden even though elements have been assigned to them.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
