### PR TITLE
fix(validation): make ElementInternals instantiation idempotent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/sgds-web-component",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/sgds-web-component",
-      "version": "3.3.1",
+      "version": "3.3.2-rc.0",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govtechsg/sgds-web-component",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.0",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -22,7 +22,8 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
 
     connectedCallback(): void {
       super.connectedCallback();
-      this.inputValidationController = new InputValidationController(this);
+      this.inputValidationController ??= new InputValidationController(this);
+      console.log("TESTING: HOW MANY TIMES IS CONNECTEDCALLBACK CALLED IN REACT");
     }
     async firstUpdated(changedProperties) {
       super.firstUpdated(changedProperties);

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -22,8 +22,8 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
 
     connectedCallback(): void {
       super.connectedCallback();
+      /** Idempotency guarantee */
       this.inputValidationController ??= new InputValidationController(this);
-      console.log("TESTING: HOW MANY TIMES IS CONNECTEDCALLBACK CALLED IN REACT");
     }
     async firstUpdated(changedProperties) {
       super.firstUpdated(changedProperties);


### PR DESCRIPTION
## :open_book: Description

In react development mode, strict mode is enabled and is encouraged for users to run strict mode. The strict mode stress tests the component and calls connectedCallback more than once. Hence, we should make sure that the attachInternals() is idempotent and should not run more than once even if connectedCallback is called multiple times. 

In production mode, react runs connectedCallback once. 


Tested in v3.3.2-rc.0 with a nextjs app

Fixes # (issue)

#368


## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
