### PR TITLE
Fix/modal position

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.3.2-rc.0
+npm install @govtechsg/sgds-web-component@3.3.2
 
 ```
 
@@ -65,14 +65,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2-rc.0/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2-rc.0/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2-rc.0" async></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2" async></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2-rc.0/components/Masthead/index.umd.js" async></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.3.2/components/Masthead/index.umd.js" async></script>
 
 ```
 

--- a/playground/Modal.html
+++ b/playground/Modal.html
@@ -5,8 +5,15 @@
 
 <sgds-modal open>
   <sgds-select id="select-example" label="Select label" hinttext="Select an option" placeholder="Select an option"></sgds-select>
+<div class="d-flex-row">
+      <sgds-tooltip content="This is a tooltip" placement="top">
+ <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M11 1.6C5.80855 1.6 1.60002 5.80852 1.60002 11C1.60002 16.1915 5.80855 20.4 11 20.4C16.1915 20.4 20.4 16.1915 20.4 11C20.4 5.80852 16.1915 1.6 11 1.6ZM0.400024 11C0.400024 5.14578 5.14581 0.4 11 0.4C16.8542 0.4 21.6 5.14578 21.6 11C21.6 16.8542 16.8542 21.6 11 21.6C5.14581 21.6 0.400024 16.8542 0.400024 11ZM11 9.4C11.3314 9.4 11.6 9.66863 11.6 10V15C11.6 15.3314 11.3314 15.6 11 15.6C10.6687 15.6 10.4 15.3314 10.4 15V10C10.4 9.66863 10.6687 9.4 11 9.4Z" fill="#0E0E0E"></path>
+          <path d="M11 6.15002C10.5306 6.15002 10.15 6.53058 10.15 7.00002C10.15 7.46947 10.5306 7.85002 11 7.85002H11.01C11.4795 7.85002 11.8601 7.46947 11.8601 7.00002C11.8601 6.53058 11.4795 6.15002 11.01 6.15002H11Z" fill="#0E0E0E"></path>
+        </svg>
+      </sgds-tooltip>
     </div>
-    <script>
+        <script>
       const comboBox = document.querySelector("#select-example");
       comboBox.menuList = [
         { label: "Afghanistan", value: "1" },

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -58,7 +58,7 @@
 }
 
 .modal-header__close {
-  position: absolute;
+  position: relative;
   top: calc(-1 * var(--sgds-padding-md));
   right: calc(-1 * var(--sgds-padding-md));
 }

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -35,7 +35,7 @@
 .modal-panel {
   width: 100%;
   border-radius: var(--sgds-border-radius-md);
-  position: relative;
+  z-index: 2; /* shift above overlay  */
   display: flex;
   flex-direction: column;
   gap: var(--sgds-gap-2-xl);
@@ -55,7 +55,6 @@
   flex-direction: column;
   gap: var(--sgds-gap-2-xl);
   min-height: 0;
-  position: relative;
 }
 
 .modal-header__close {


### PR DESCRIPTION
## :open_book: Description

As much as possible trying to use default position: static, over position: relative/ absolute in Modal

Modal panel can be positioned with flex box and using z-index to bring it above overlay 

This is to prevent the case when another component of position: relative is used inside modal and breaks its positioned. 
Example tooltip. 
<img width="758" height="461" alt="Screenshot 2025-09-16 at 4 07 10 PM" src="https://github.com/user-attachments/assets/cf834c8b-09f0-4b5d-afe1-d5867c9df098" />


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
