### PR TITLE
style(subnav): apply transparent border at bottom to prevent content shift during navigation

### DIFF
--- a/src/components/Subnav/subnav-item.css
+++ b/src/components/Subnav/subnav-item.css
@@ -58,5 +58,6 @@
 
   ::slotted(*) {
     padding: var(--sgds-padding-lg) var(--sgds-padding-none);
+    border-bottom: var(--sgds-border-width-2) solid transparent;
   }
 }


### PR DESCRIPTION
## :open_book: Description

Add transparent border on non-active subnav menu to prevent content shift

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
