### PR TITLE
build(*): use full name of floating ui to externalise it

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,7 +19,7 @@ const external = [
   /lit\/.*/,
   "imask",
   "date-fns",
-  "@floating-ui"
+  "@floating-ui/dom"
 ];
 
 const copyPlugin = copy({


### PR DESCRIPTION
## :open_book: Description

Should include full name or regex that matches "floating-ui/dom" else this package won't be properly externalized from the final library build resulting in this error

<img width="734" height="133" alt="Screenshot 2025-10-08 at 11 38 24 AM" src="https://github.com/user-attachments/assets/d856f575-cf9c-435c-ad9d-80d595d0799c" />


pushed this build to rc and tested  v3.5.1-rc.2  on local angular app. Error is gone


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
