### PR TITLE
fix(subnav): hide the container of actions slot when the slot is empty

### DIFF
--- a/src/components/Subnav/sgds-subnav.ts
+++ b/src/components/Subnav/sgds-subnav.ts
@@ -1,6 +1,6 @@
 import SgdsElement from "../../base/sgds-element";
 import { html, PropertyValueMap } from "lit";
-import { query, state } from "lit/decorators.js";
+import { property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { watch } from "../../utils/watch";
 import { waitForEvent } from "../../utils/event";
@@ -10,6 +10,7 @@ import { LG_BREAKPOINT, MD_BREAKPOINT } from "../../utils/breakpoints";
 import SgdsIcon from "../Icon/sgds-icon";
 import subnavStyle from "./subnav.css";
 import gridStyle from "../../css/grid.css";
+import { HasSlotController } from "../../utils/slot";
 
 const VALID_KEYS = ["Enter", " "];
 
@@ -33,6 +34,9 @@ export class SgdsSubnav extends SgdsElement {
   static dependencies = {
     "sgds-icon": SgdsIcon
   };
+
+  /** Used only for SSR to indicate the presence of the `actions` slot. */
+  @property({ type: Boolean }) hasActionsSlot = false;
 
   @query("nav")
   private nav: HTMLElement;
@@ -58,6 +62,8 @@ export class SgdsSubnav extends SgdsElement {
   @state()
   private isMenuOpen = false;
 
+  private readonly hasSlotController = new HasSlotController(this, "actions");
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -77,6 +83,10 @@ export class SgdsSubnav extends SgdsElement {
     super.firstUpdated(changedProperties);
 
     this._handleResize();
+  }
+
+  updated() {
+    if (!this.hasActionsSlot) this.hasActionsSlot = this.hasSlotController.test("actions");
   }
 
   private _handleResize = async () => {
@@ -238,7 +248,12 @@ export class SgdsSubnav extends SgdsElement {
             <div class="subnav-nav">
               <slot></slot>
             </div>
-            <div class="subnav-actions">
+            <div
+              class="${classMap({
+                "subnav-actions": true,
+                "no-actions": !this.hasActionsSlot
+              })}"
+            >
               <slot name="actions"></slot>
             </div>
           </div>

--- a/src/components/Subnav/subnav.css
+++ b/src/components/Subnav/subnav.css
@@ -78,6 +78,10 @@ slot[name="header"]::slotted(*) {
   width: 100%;
 }
 
+.no-actions {
+  display: none;
+}
+
 slot[name="actions"]::slotted(*) {
   width: 100%;
 }

--- a/test/sub-nav.test.ts
+++ b/test/sub-nav.test.ts
@@ -81,4 +81,23 @@ describe("<sgds-subnav>", () => {
     expect(button).to.exist;
     expect(button?.textContent?.trim()).to.equal("Action");
   });
+
+  it("handles absence of actions slot correctly", async () => {
+    const el = await fixture<SgdsSubnav>(html`
+      <sgds-subnav>
+        <div slot="header">Subnav Header</div>
+        <sgds-subnav-item>Home</sgds-subnav-item>
+      </sgds-subnav>
+    `);
+
+    const actionsContainer = el.shadowRoot?.querySelector(".subnav-actions");
+    expect(actionsContainer).to.exist;
+
+    expect(actionsContainer?.classList.contains("no-actions")).to.be.true;
+
+    const slottedActions = el.querySelector('[slot="actions"]');
+    expect(slottedActions).to.not.exist;
+
+    expect(el.hasActionsSlot).to.be.false;
+  });
 });


### PR DESCRIPTION
## :open_book: Description

Fix layout issue where subnav `actions` slot container takes up space without content

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
