### PR TITLE
build(rollup): fix breaking umd break after migration to pnpm

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -107,27 +107,6 @@ const buildSgdsPackage = () => {
     }
   ];
 
-  const umdPlugins = [
-    resolve({
-      browser: true,
-      exportConditions: ["development"]
-    }),
-    replace({
-      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
-      preventAssignment: true
-    }),
-    postcss({
-      minimize: true,
-      inject: false
-    }),
-    litcss(),
-    typescript({
-      tsconfig: "tsconfig.json",
-      useTsconfigDeclarationDir: true
-    }),
-    visualizer()
-  ];
-
   const umdBundles = [
     // bundled form for cdn
     {


### PR DESCRIPTION
## :open_book: Description

UMD build was breaking after migrating to pnpm

Previously, npm was on a flat structure and all packages are hoisted to the root node_modules, so configuring node-resolve rollup plugin with dedupe external dependencies was ok, Rollup can  easily find and deduplicate all versions of dependencies across the flat structure.

But pnpm uses a isolated structure with symlinks: 

Each package only has access to its declared dependencies. When Rollup tries to resolve internal imports (like lit-element/lit-element.js imported by lit/index.js) with dedupe: external, pnpm's isolation causes resolution issues. Those internal imports can't be properly deduped and end up marked as external instead of bundled.

The end result is umd bundle missing out on some crucial packages

The warnings during build goes away with this fix. 

Tested with v3.7.0-rc.4 released on CDN and local installation. Both works fine 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
