### PR TITLE
fix(docs): add missing newline before code block in React.md

### DIFF
--- a/docs/React.md
+++ b/docs/React.md
@@ -9,6 +9,7 @@ Our library still outputs the React version of each of our web components for ba
 ### Usage 
 
 You can directly use the native web components
+
 ```jsx
 //Select.ts
 import "@govtechsg/sgds-web-component/components/Select";


### PR DESCRIPTION
## :open_book: Description

> [!NOTE]
> **Note:** While [CONTRIBUTING.md][1] suggests creating an issue first, this is a small documentation formatting fix, so I've opened a PR directly.

This PR fixes a markdown rendering issue in the React documentation where a code block was incorrectly parsed and rendered as an interactive component on the page instead of displaying as a code snippet.

### Root Cause

The markdown parser requires a blank line between preceding text and a code block fence (```) to properly recognize it as a code block. Without this blank line, the parser incorrectly interprets the code block content, causing it to render as JSX/React components on the documentation page.

### Changes

- Added a blank line between the introductory text and the code block in `docs/React.md` (line 12)
- This ensures proper markdown parsing and correct rendering of the code example

## :pencil2: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :camera: Before & After

### Before

https://www.webcomponent.designsystem.tech.gov.sg/?path=/docs/frameworks-react--docs

![Screenshot 2026-01-25 at 7 10 09 PM](https://github.com/user-attachments/assets/9277a7ae-ceaf-4618-b9de-129bab1024ce)

*The code block is incorrectly rendered as an interactive `<sgds-select>` component on the page, appearing as a dropdown UI element instead of code.*

### After

![Screenshot 2026-01-25 at 7 11 47 PM](https://github.com/user-attachments/assets/5f3d556c-8156-4cf3-874a-91a10dfb50a6)

*The code block now correctly displays as a code snippet with proper syntax highlighting, showing the JSX code example.*

## :test_tube: How Has This Been Tested?

- [x] Verified markdown rendering in local documentation preview
- [x] Confirmed code block displays correctly in markdown preview tools
- [x] Tested that the fix doesn't affect other code blocks in the same file
- [x] Verified the change follows markdown best practices

**Testing Instructions:**
1. Open `docs/React.md` in a markdown previewer or documentation site
2. Navigate to the "React 19 and onwards" > "Usage" section
3. Verify that the code block displays as formatted code, not as a rendered component
4. Confirm there is proper spacing between the introductory text and the code block

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

[1]: https://github.com/GovTechSG/sgds-web-component/blob/master/CONTRIBUTING.md