### PR TITLE
style(SystemBanner): added max width to the banner container and exclude sgds-icon from slotted styles [run-chromatic]

### DIFF
--- a/playground/SystemBanner.html
+++ b/playground/SystemBanner.html
@@ -3,15 +3,32 @@
 <link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
 <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
 
-<h3> long message only</h3>
-<sgds-system-banner show>
+<sgds-masthead></sgds-masthead>
+
+<sgds-mainnav>
+  <div slot="brand">SGDS</div>
+  <div slot="end">End slot</div>
+</sgds-mainnav>
+<sgds-system-banner show dismissible>
   <sgds-system-banner-item>
-    <div>
      1 Etiam suscipit nisi eget porta cursus. Ut sit amet felis aliquet, pellentesque mi at, vulputate nunc. Vivamus ac
       facilisis tellus. Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,
       congue sapien eu, rhoncus  Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,
       congue sapien eu, rhoncus
-    </div>
+      <sgds-link size="sm" variant="light" slot="action"
+      ><a href="#">Action link<sgds-icon name="arrow-right"  size="md"></sgds-icon></a
+    ></sgds-link>
+  </sgds-system-banner-item>
+</sgds-system-banner>
+<sgds-footer></sgds-footer>
+
+<h3> long message only</h3>
+<sgds-system-banner show>
+  <sgds-system-banner-item>
+     1 Etiam suscipit nisi eget porta cursus. Ut sit amet felis aliquet, pellentesque mi at, vulputate nunc. Vivamus ac
+      facilisis tellus. Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,
+      congue sapien eu, rhoncus  Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,
+      congue sapien eu, rhoncus
   </sgds-system-banner-item>
 </sgds-system-banner>
 <br/>

--- a/playground/SystemBanner.html
+++ b/playground/SystemBanner.html
@@ -3,6 +3,11 @@
 <link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
 <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
 
+<style>
+.icon-color {
+  color: var(--sgds-warning-color-fixed-light);
+}
+</style>
 <sgds-masthead></sgds-masthead>
 
 <sgds-mainnav>
@@ -11,6 +16,7 @@
 </sgds-mainnav>
 <sgds-system-banner show dismissible>
   <sgds-system-banner-item>
+    <sgds-icon slot="icon" name="exclamation-triangle-fill" size="md" class="icon-color"></sgds-icon>
      1 Etiam suscipit nisi eget porta cursus. Ut sit amet felis aliquet, pellentesque mi at, vulputate nunc. Vivamus ac
       facilisis tellus. Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,
       congue sapien eu, rhoncus  Maecenas ac libero scelerisque tellus maximus accumsan a vehicula arcu. Aenean quis leo gravida,

--- a/src/components/SystemBanner/system-banner-item.css
+++ b/src/components/SystemBanner/system-banner-item.css
@@ -9,7 +9,7 @@
 }
 
 /* Handles inline links and all texts */
-::slotted(*) {
+::slotted(:not(sgds-icon)) {
   font-size: var(--sgds-font-size-1, 14px) !important;
   line-height: var(--sgds-line-height-20, 20px) !important;
   color: var(--sgds-color-fixed-light) !important;

--- a/src/components/SystemBanner/system-banner.css
+++ b/src/components/SystemBanner/system-banner.css
@@ -70,8 +70,8 @@ sgds-close-button {
 
 @media (min-width: 1440px) { /** --sgds-breakpoint-2-xl */
   .banner{
-    padding-left: var(--sgds-mainnav-padding-x, 32px);
-    padding-right: var(--sgds-mainnav-padding-x, 32px);
+    padding-left: var(--sgds-mainnav-padding-x);
+    padding-right: var(--sgds-mainnav-padding-x);
     max-width: var(--sgds-mainnav-max-width);
     margin: auto;
   }

--- a/src/components/SystemBanner/system-banner.css
+++ b/src/components/SystemBanner/system-banner.css
@@ -1,3 +1,9 @@
+:host{
+  display: block;
+  width: 100%;
+  background-color: var(--sgds-surface-fixed-dark);
+}
+
 .banner {
   display: flex;
   flex-direction: row;
@@ -55,4 +61,20 @@ sgds-close-button {
   .pagination {
     position: static;
   }
+  .banner{
+    padding-left: var(--sgds-mainnav-mobile-padding-x);
+    padding-right: var(--sgds-mainnav-mobile-padding-x);
+  }
 }
+
+
+@media (min-width: 1440px) { /** --sgds-breakpoint-2-xl */
+  .banner{
+    padding-left: var(--sgds-mainnav-padding-x, 32px);
+    padding-right: var(--sgds-mainnav-padding-x, 32px);
+    max-width: var(--sgds-mainnav-max-width);
+    margin: auto;
+  }
+
+}
+

--- a/src/components/SystemBanner/system-banner.css
+++ b/src/components/SystemBanner/system-banner.css
@@ -12,7 +12,7 @@
   background-color: var(--sgds-surface-fixed-dark);
   min-height: var(--sgds-dimension-64);
   color: var(--sgds-color-fixed-light);
-  padding: var(--sgds-padding-sm) var(--sgds-padding-2-xl);
+  padding: var(--sgds-padding-sm) calc(var(--sgds-padding-sm) + var(--sgds-mainnav-mobile-padding-x));
   position: relative;
 }
 .content {

--- a/stories/templates/SystemBanner/additional.stories.js
+++ b/stories/templates/SystemBanner/additional.stories.js
@@ -37,7 +37,7 @@ export const Dismissible = {
     dismissible: true,
     show: true
   },
-  parameters: {},
+  parameters,
   tags: ["!dev"]
 };
 
@@ -45,6 +45,6 @@ export const ShowMore = {
   render: ShowMoreHookTemplate.bind({}),
   name: "Show More",
   args: {},
-  parameters: {},
+  parameters,
   tags: ["!dev"]
 };

--- a/stories/templates/SystemBanner/basic.js
+++ b/stories/templates/SystemBanner/basic.js
@@ -37,7 +37,7 @@ export const args = {
 
 export const parameters = {
   layout: "fullscreen",
-   chromatic: {
+  chromatic: {
     modes: {
       mobile: allModes["sm"],
       desktop: allModes["lg"]

--- a/stories/templates/SystemBanner/basic.js
+++ b/stories/templates/SystemBanner/basic.js
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
+import { allModes } from "../../../.storybook/modes";
 
 export const Template = args => html`<sgds-system-banner ?dismissible=${args.dismissible} ?show=${args.show}>
   <sgds-system-banner-item>
@@ -35,4 +35,12 @@ export const args = {
   show: true
 };
 
-export const parameters = {};
+export const parameters = {
+  layout: "fullscreen",
+   chromatic: {
+    modes: {
+      mobile: allModes["sm"],
+      desktop: allModes["lg"]
+    }
+  }
+};


### PR DESCRIPTION
## :open_book: Description

1. Apply same max width token as mainnav to align content of system banner 
2. Updated css selector to style slotted elements to exclude sgds-icon 


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
