### PR TITLE
fix(Card): card should have hover effects [skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -69,7 +69,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.11.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.11.0" async crossorigin="anonymous" integrity="sha384-LlVAwGe5SbrXlwcU8PEUgkdfhZmnuMxaR1a8/rDxspZKlYjloq27Nb3PMMAHgcDm"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.11.0" async crossorigin="anonymous" integrity="sha384-eMKijIR6z3YjRqNPOcn6ZdzNt232FD+fREbHhIcw3IiYBqKjqCLhZimZ0g4x9IVz"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.11.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-1wUwIXJHnxYMzBRufDBYBCODFgRySae3vrH2Ysy8yy1qxXlZcFgh+EaiMGH48y2s"></script>

--- a/src/base/card.css
+++ b/src/base/card.css
@@ -1,6 +1,9 @@
 :host([disabled]) {
   cursor: not-allowed;
 }
+:host(:not([noPadding])) .card:not(.disabled):hover {
+  box-shadow: 0px 0px 1px 0px rgba(14, 14, 14, 0.12), 0px 8px 16px 0px rgba(14, 14, 14, 0.12);
+}
 
 :host([stretchedLink]) slot[name="footer"]::slotted(sgds-link),
 :host([stretchedLink]) slot[name="footer"]::slotted(a),

--- a/src/components/IconCard/icon-card.css
+++ b/src/components/IconCard/icon-card.css
@@ -1,9 +1,6 @@
 :host([noPadding]) .card {
   border: var(--sgds-border-width-1) solid var(--sgds-border-color-transparent);
-}
-
-:host(:not([noPadding])) .card:not(.disabled):hover {
-  box-shadow: 0px 0px 1px 0px rgba(14, 14, 14, 0.12), 0px 8px 16px 0px rgba(14, 14, 14, 0.12);
+  background-color: inherit;
 }
 
 :host([orientation="vertical"][noPadding]) .card-body {

--- a/src/components/ImageCard/image-card.css
+++ b/src/components/ImageCard/image-card.css
@@ -1,9 +1,6 @@
 :host([noPadding]) .card {
   border: var(--sgds-border-width-1) solid var(--sgds-border-color-transparent);
-}
-
-:host(:not([noPadding])) .card:not(.disabled):hover {
-  box-shadow: 0px 0px 1px 0px rgba(14, 14, 14, 0.12), 0px 8px 16px 0px rgba(14, 14, 14, 0.12);
+  background-color: inherit;
 }
 
 :host([orientation="vertical"][noPadding]) .card-body {

--- a/src/components/ThumbnailCard/thumbnail-card.css
+++ b/src/components/ThumbnailCard/thumbnail-card.css
@@ -1,9 +1,6 @@
 :host([noPadding]) .card {
   border: var(--sgds-border-width-1) solid var(--sgds-border-color-transparent);
-}
-
-:host(:not([noPadding])) .card:not(.disabled):hover {
-  box-shadow: 0px 0px 1px 0px rgba(14, 14, 14, 0.12), 0px 8px 16px 0px rgba(14, 14, 14, 0.12);
+  background-color: inherit;
 }
 
 :host([orientation="vertical"][noPadding]) .card-body {


### PR DESCRIPTION
background of noPadding card should inherit parent

1. Background of noPadding card should inherit parent color. 

<img width="1932" height="1234" alt="image" src="https://github.com/user-attachments/assets/b48e2aaa-80a6-41c0-93da-736fbbba0fe2" />


2. SgdsCard should have hover effect as well. 


## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
