### PR TITLE
fix(Accordion, Mainnav): slot modifications should happen at slotchange [skip-cd]

### DIFF
--- a/contributing/architecture-decision-record/slotchange-vs-firstupdated-for-slot-attribute-setting.md
+++ b/contributing/architecture-decision-record/slotchange-vs-firstupdated-for-slot-attribute-setting.md
@@ -1,0 +1,54 @@
+# Use slotchange Event for All DOM Mutations on Slotted Children
+
+## Status
+
+Accepted
+
+## Context
+
+Several components (`SgdsAccordion`, `SgdsMainnav`) need to perform initialisation work on their slotted child elements. Examples include:
+
+- `SgdsAccordion` setting `variant`, `density`, `first-of-type`, `nth-of-type`, and `last-of-type` attributes on each `sgds-accordion-item`.
+- `SgdsMainnav` setting the `expand` attribute on every slotted `sgds-mainnav-item` and `sgds-mainnav-dropdown`.
+- `SgdsMainnavItem` adding click event listeners to anchor elements found inside its slot.
+
+The original implementation performed these mutations (attributes, event listeners, property assignments, style changes) inside Lit's `firstUpdated` lifecycle hook, iterating over slot-assigned elements retrieved via `@queryAssignedElements`.
+
+`firstUpdated` fires after Lit's first render completes — meaning the component's own shadow DOM (including the `<slot>` element) exists. However, **browser slot assignment is a separate step** that the browser performs when it distributes light DOM children into a shadow DOM slot. The timing of this step relative to the Lit update cycle is not guaranteed. `@queryAssignedElements` calls `slot.assignedElements()` under the hood, which returns an empty array if the browser has not yet completed slot distribution at that point.
+
+Whether `firstUpdated` wins or loses this race depends on:
+
+- **How the component was upgraded**: if the element was already in the parsed HTML before the custom element was defined (e.g. CDN-loaded script, or any deferred `<script type="module">`), the upgrade happens after HTML parsing, and slot distribution may not be complete when `firstUpdated` fires.
+- **Browser-internal scheduling**: slot assignment and `slotchange` dispatch are not part of the Lit lifecycle contract and can be deferred to a separate microtask or task.
+
+The result is that `@queryAssignedElements` inside `firstUpdated` is unreliable across loading strategies. All mutations silently no-op, leaving slotted children without correct attributes, event listeners, or styles.
+
+## Decision
+
+All DOM mutations targeting slotted child elements — including `setAttribute`, `addEventListener`, direct property assignment, and style changes — must be moved out of `firstUpdated` and into a `slotchange` event handler wired directly to the slot element in the render template:
+
+```html
+<slot @slotchange=${this._handleSlotChange}></slot>
+```
+
+The `slotchange` event fires once the browser has assigned elements to the slot, regardless of whether the script was loaded synchronously (local module) or asynchronously (CDN). This makes all slot-dependent initialisation reliable across all loading strategies.
+
+`firstUpdated` must not be used to read or mutate slotted children.
+
+## Consequences
+
+Easier:
+
+- All slot-dependent initialisation (attributes, event listeners, property sets, style mutations) works consistently whether the library is loaded via CDN or as a local module.
+- The fix aligns with how the codebase already handles the SSR `slotchange` gap (see `force-slotchange-event-ssr.md`), so the two patches are complementary.
+- No additional lifecycle hooks or flags are needed.
+
+More difficult:
+
+- Developers must remember that `@queryAssignedElements` is unreliable inside `firstUpdated` when the component may be loaded via CDN. Any future slot-dependent initialisation — whether it is an attribute, event listener, or any other DOM mutation — must go into a `slotchange` handler instead.
+- If a parent property changes after initial render (e.g. `variant` is updated at runtime), the `slotchange` handler alone will not re-propagate the new value. A `@watch` or `updated` hook targeting those specific properties must also call the same propagation logic.
+- Event listeners added inside a `slotchange` handler may be registered multiple times if slotted elements change dynamically. Handlers should guard against duplicate registration (e.g. by removing the listener before re-adding it).
+
+## Date of proposal
+
+17/03/2026

--- a/playground/Accordion.html
+++ b/playground/Accordion.html
@@ -1,0 +1,145 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height" />
+    <script type="module" src="../src/index.ts"></script>
+    <link href="../src/themes/day.css" rel="stylesheet" type="text/css" />
+    <link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
+    <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
+    <style>
+      .container {
+        max-width: 800px;
+        margin: 36px auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>
+        <h2>Default</h2>
+        <sgds-accordion id="accordion-default">
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #1</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item>
+            <div slot="header">Accordion title #2</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #3</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+        </sgds-accordion>
+      </div>
+
+      <div>
+        <h2>Border variant</h2>
+        <sgds-accordion variant="border" id="accordion-border">
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #1</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item>
+            <div slot="header">Accordion title #2</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #3</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+        </sgds-accordion>
+      </div>
+
+      <div>
+        <h2>Compact density</h2>
+        <sgds-accordion density="compact" id="accordion-compact">
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #1</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item>
+            <div slot="header">Accordion title #2</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #3</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+        </sgds-accordion>
+      </div>
+
+      <div>
+        <h2>Allow multiple active accordion</h2>
+        <sgds-accordion allowMultiple id="accordion-multiple">
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #1</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item>
+            <div slot="header">Accordion title #2</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #3</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+        </sgds-accordion>
+      </div>
+
+      <div>
+        <h2>Disabled state</h2>
+        <sgds-accordion id="accordion-disabled">
+          <sgds-accordion-item disabled>
+            <div slot="header">Accordion title #1</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item>
+            <div slot="header">Accordion title #2</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+          <sgds-accordion-item open>
+            <div slot="header">Accordion title #3</div>
+            <div slot="content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores soluta eaque fugit fuga distinctio? Eum.</div>
+          </sgds-accordion-item>
+        </sgds-accordion>
+      </div>
+    </div>
+
+    <script>
+      // Verify position/variant/density attributes are set via slotchange (CDN timing fix).
+      // Open the browser console to see results.
+      customElements.whenDefined("sgds-accordion").then(() => {
+        const checks = [
+          { id: "accordion-default", expectedVariant: "default", expectedDensity: "default" },
+          { id: "accordion-border", expectedVariant: "border", expectedDensity: "default" },
+          { id: "accordion-compact", expectedVariant: "default", expectedDensity: "compact" }
+        ];
+
+        checks.forEach(({ id, expectedVariant, expectedDensity }) => {
+          const items = document.getElementById(id).querySelectorAll("sgds-accordion-item");
+          const passed = [...items].every(
+            item =>
+              item.getAttribute("variant") === expectedVariant &&
+              item.getAttribute("density") === expectedDensity
+          );
+          console.log(`[${id}] variant/density attrs correct:`, passed ? "✅ PASS" : "❌ FAIL");
+        });
+
+        const defaultItems = document.getElementById("accordion-default").querySelectorAll("sgds-accordion-item");
+        console.log("[accordion-default] first-of-type on item 1:", defaultItems[0].hasAttribute("first-of-type") ? "✅ PASS" : "❌ FAIL");
+        console.log("[accordion-default] nth-of-type on item 2:", defaultItems[1].hasAttribute("nth-of-type") ? "✅ PASS" : "❌ FAIL");
+        console.log("[accordion-default] last-of-type on item 3:", defaultItems[2].hasAttribute("last-of-type") ? "✅ PASS" : "❌ FAIL");
+
+        const singleItem = document.getElementById("accordion-single").querySelector("sgds-accordion-item");
+        const noPositionAttrs =
+          !singleItem.hasAttribute("first-of-type") &&
+          !singleItem.hasAttribute("nth-of-type") &&
+          !singleItem.hasAttribute("last-of-type");
+        console.log("[accordion-single] no position attrs on single item:", noPositionAttrs ? "✅ PASS" : "❌ FAIL");
+      });
+    </script>
+  </body>
+</html>

--- a/src/components/Accordion/sgds-accordion.ts
+++ b/src/components/Accordion/sgds-accordion.ts
@@ -1,4 +1,4 @@
-import { html, PropertyValueMap } from "lit";
+import { html } from "lit";
 import { property, queryAssignedElements } from "lit/decorators.js";
 import SgdsElement from "../../base/sgds-element";
 import type SgdsAccordionItem from "./sgds-accordion-item";
@@ -37,8 +37,7 @@ export class SgdsAccordion extends SgdsElement {
     ) as SgdsAccordionItem[];
   }
 
-  firstUpdated(changedProperties: PropertyValueMap<this>) {
-    super.firstUpdated(changedProperties);
+  private _handleSlotChange() {
     const items = [...this.items] as SgdsAccordionItem[];
     items.forEach((item, index) => {
       if (items.length > 1) {
@@ -88,7 +87,7 @@ export class SgdsAccordion extends SgdsElement {
   render() {
     return html`
       <div class="accordion">
-        <slot @click=${this._onToggle} @keydown=${this._onKeyboardToggle}></slot>
+        <slot @slotchange=${this._handleSlotChange} @click=${this._onToggle} @keydown=${this._onKeyboardToggle}></slot>
       </div>
     `;
   }

--- a/src/components/Mainnav/sgds-mainnav.ts
+++ b/src/components/Mainnav/sgds-mainnav.ts
@@ -134,11 +134,6 @@ export class SgdsMainnav extends SgdsElement {
       this._handleMobileNav();
       this._breakpointReached = true;
     }
-
-    const items = [...this.defaultSlotItems, ...this.endSlotItems] as SgdsMainnavItem[] | SgdsMainnavDropdown[];
-    items.forEach((item: SgdsMainnavItem | SgdsMainnavDropdown) => {
-      item.setAttribute("expand", this.expand);
-    });
   }
 
   private _handleClickOutOfElement(e: MouseEvent, self: HTMLElement) {
@@ -234,7 +229,7 @@ export class SgdsMainnav extends SgdsElement {
     this.body.style.height = "auto";
     this.emit("sgds-after-hide");
   }
-
+  /** @internal */
   @watch("expanding", { waitUntilFirstUpdate: true })
   async handleOpenChange() {
     if (this.expanding) {
@@ -271,12 +266,20 @@ export class SgdsMainnav extends SgdsElement {
     return waitForEvent(this, "sgds-after-hide");
   }
 
+  private _handleDefaultSlotChange(e: Event) {
+    const childElements = (e.target as HTMLSlotElement).assignedElements({ flatten: true });
+    childElements.forEach(el => {
+      el.setAttribute("expand", this.expand);
+    });
+  }
+
   // assigning name attribute to elements added in slot="end", to use wildcard css selector to assign styles only to *-mainnav-item
-  _handleSlotChange(e: Event) {
+  private _handleSlotChange(e: Event) {
     const childElements = (e.target as HTMLSlotElement).assignedElements({ flatten: true });
 
     childElements.forEach(e => {
       e.setAttribute("name", e.tagName.toLowerCase());
+      e.setAttribute("expand", this.expand);
     });
   }
 
@@ -291,7 +294,7 @@ export class SgdsMainnav extends SgdsElement {
           </a>
           <div class="navbar-body navbar-collapse" id=${this.collapseId}>
             <div class="navbar-nav navbar-nav-scroll">
-              <slot></slot>
+              <slot @slotchange=${this._handleDefaultSlotChange}></slot>
               <slot
                 name="end"
                 class=${classMap({ "slot-end": !this.breakpointReached })}

--- a/test/mainnav.test.ts
+++ b/test/mainnav.test.ts
@@ -240,6 +240,43 @@ describe("sgds-mainnav", () => {
     expect(el.querySelector("sgds-mainnav-item")).to.have.attribute("name", "sgds-mainnav-item");
     expect(el.querySelector("sgds-button")).to.have.attribute("name", "sgds-button");
   });
+
+  it("slotchange on default slot sets expand attribute on slotted items using component expand value", async () => {
+    const el = await fixture<SgdsMainnav>(
+      html`<sgds-mainnav expand="md">
+        <sgds-mainnav-item></sgds-mainnav-item>
+        <sgds-mainnav-dropdown><span slot="toggler">Menu</span></sgds-mainnav-dropdown>
+      </sgds-mainnav>`
+    );
+    await el.updateComplete;
+    expect(el.querySelector("sgds-mainnav-item")).to.have.attribute("expand", "md");
+    expect(el.querySelector("sgds-mainnav-dropdown")).to.have.attribute("expand", "md");
+  });
+
+  it("slotchange on end slot sets both expand and name attributes on slotted items", async () => {
+    const el = await fixture<SgdsMainnav>(
+      html`<sgds-mainnav expand="xl">
+        <sgds-mainnav-item slot="end"></sgds-mainnav-item>
+        <sgds-mainnav-dropdown slot="end"><span slot="toggler">Menu</span></sgds-mainnav-dropdown>
+      </sgds-mainnav>`
+    );
+    await el.updateComplete;
+    expect(el.querySelector("sgds-mainnav-item")).to.have.attribute("expand", "xl");
+    expect(el.querySelector("sgds-mainnav-item")).to.have.attribute("name", "sgds-mainnav-item");
+    expect(el.querySelector("sgds-mainnav-dropdown")).to.have.attribute("expand", "xl");
+    expect(el.querySelector("sgds-mainnav-dropdown")).to.have.attribute("name", "sgds-mainnav-dropdown");
+  });
+
+  it("default slot items do not receive name attribute", async () => {
+    const el = await fixture<SgdsMainnav>(
+      html`<sgds-mainnav expand="lg">
+        <sgds-mainnav-item></sgds-mainnav-item>
+      </sgds-mainnav>`
+    );
+    await el.updateComplete;
+    expect(el.querySelector("sgds-mainnav-item")).to.have.attribute("expand", "lg");
+    expect(el.querySelector("sgds-mainnav-item")).not.to.have.attribute("name");
+  });
 });
 
 describe("sgds-mainnav-item", () => {


### PR DESCRIPTION
## :open_book: Description

Issue observed when Mainnav v3.14.0 loaded via CDN

<img width="1915" height="174" alt="Screenshot 2026-03-17 at 5 30 03 PM" src="https://github.com/user-attachments/assets/b0f65e4c-05d8-425f-befc-7d959538f064" />

- Problem was that slot items were modified in firstUpdated, which is not guaranteed that slotted items are ready by then. 
- The attributes added in firstUpdated, was supposed to influenced some stylings. but in CDN, that attribute addition did not happen resulting in mis-styled components
- slot changes should be done in `@slotchange`

- scanned the repo and found Accordion making the mistake, hence the correction at Accordion. 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit test added
- [X] Published to rc and confirmed issue resolved. Checked safari too

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
