### PR TITLE
fix(Alert): close button colour fixed dark in warning filled [run-chromatic]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0" async crossorigin="anonymous" integrity="sha384-lFW7w8nP8Y05yVrqavObHe5P5U1w8SvSjpDy7gVmJ4KUMqi/K21Bmy4rfJdna/jW"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0" async crossorigin="anonymous" integrity="sha384-h8svZXmqPtL/IQU0crMLU080q5fWN5gXeSeWUY6K/3R5DywtNUZs163mXr7AxRbs"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-ITgmRQ1eDoGTKD6ytTZVquH/6jBLIuZzFPDjUVaN525LjuJl3zngwzf/hYiDgJbn"></script>

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0" async crossorigin="anonymous" integrity="sha384-u1ktrriWdoCw4puOpMP+BHHDJzJV2hehSxWEMCXLy+UcrJQhkvv6D5fZiazh3HMJ"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0" async crossorigin="anonymous" integrity="sha384-lFW7w8nP8Y05yVrqavObHe5P5U1w8SvSjpDy7gVmJ4KUMqi/K21Bmy4rfJdna/jW"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-ITgmRQ1eDoGTKD6ytTZVquH/6jBLIuZzFPDjUVaN525LjuJl3zngwzf/hYiDgJbn"></script>

--- a/playground/Alert.html
+++ b/playground/Alert.html
@@ -19,7 +19,7 @@
     <div class="container">
       <div>
         <h2>Info (default)</h2>
-        <sgds-alert show variant="info" title="Info Alert">
+        <sgds-alert show variant="info" title="Info Alert" dismissible>
           <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
           <div>This is an informational message with a <sgds-alert-link href="#">link</sgds-alert-link>.</div>
         </sgds-alert>
@@ -27,7 +27,7 @@
 
       <div>
         <h2>Success</h2>
-        <sgds-alert show variant="success" title="Success Alert">
+        <sgds-alert show variant="success" title="Success Alert" dismissible>
           <sgds-icon slot="icon" name="check-circle-fill"></sgds-icon>
           <div>Operation completed successfully.</div>
         </sgds-alert>
@@ -35,7 +35,7 @@
 
       <div>
         <h2>Danger</h2>
-        <sgds-alert show variant="danger" title="Error Alert">
+        <sgds-alert show variant="danger" title="Error Alert" dismissible>
           <sgds-icon slot="icon" name="exclamation-circle-fill"></sgds-icon>
           <div>Something went wrong. Please try again.</div>
         </sgds-alert>
@@ -43,7 +43,7 @@
 
       <div>
         <h2>Warning</h2>
-        <sgds-alert show variant="warning" title="Warning Alert">
+        <sgds-alert show variant="warning" title="Warning Alert" dismissible>
           <sgds-icon slot="icon" name="exclamation-triangle-fill"></sgds-icon>
           <div>Proceed with caution.</div>
         </sgds-alert>
@@ -51,7 +51,7 @@
 
       <div>
         <h2>Neutral</h2>
-        <sgds-alert show variant="neutral" title="Neutral Alert">
+        <sgds-alert show variant="neutral" title="Neutral Alert" dismissible>
           <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
           <div>Here is some neutral information.</div>
         </sgds-alert>
@@ -59,15 +59,43 @@
 
       <div>
         <h2>Outlined</h2>
-        <sgds-alert show variant="info" title="Outlined Alert" outlined>
+        <sgds-alert show variant="info" title="Outlined Alert" outlined dismissible>
           <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
+          <div>This alert uses the outlined style.</div>
+        </sgds-alert>
+      </div>
+      <div>
+        <h2>Outlined</h2>
+        <sgds-alert show variant="info" title="Outlined Alert" outlined dismissible>
+          <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
+          <div>This alert uses the outlined style.</div>
+        </sgds-alert>
+      </div>
+      <div>
+        <h2>Outlined Warning</h2>
+        <sgds-alert show variant="warning" title="Outlined Warning Alert" outlined dismissible>
+          <sgds-icon slot="icon" name="exclamation-triangle-fill"></sgds-icon>
+          <div>This alert uses the outlined style.</div>
+        </sgds-alert>
+      </div>
+      <div>
+        <h2>Outlined Success</h2>
+        <sgds-alert show variant="success" title="Outlined Success Alert" outlined dismissible>
+          <sgds-icon slot="icon" name="check-circle-fill"></sgds-icon>
+          <div>This alert uses the outlined style.</div>
+        </sgds-alert>
+      </div>
+      <div>
+        <h2>Outlined Danger</h2>
+        <sgds-alert show variant="danger" title="Outlined Danger Alert" outlined dismissible>
+          <sgds-icon slot="icon" name="exclamation-circle-fill"></sgds-icon>
           <div>This alert uses the outlined style.</div>
         </sgds-alert>
       </div>
 
       <div>
         <h2>Dismissible</h2>
-        <sgds-alert show variant="info" title="Dismissible Alert" dismissible>
+        <sgds-alert show variant="info" title="Dismissible Alert" dismissible dismissible>
           <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
           <div>This alert can be closed by the user.</div>
         </sgds-alert>

--- a/src/components/Alert/alert-link.css
+++ b/src/components/Alert/alert-link.css
@@ -3,13 +3,16 @@
   cursor: pointer;
 }
 
-.alert-link, .alert-link:hover {
+.alert-link,
+.alert-link:hover {
   color: var(--sgds-alert-color);
   text-decoration-line: underline;
+  font-size: var(--sgds-font-size-body-sm);
+  font-weight: var(--sgds-font-weight-regular);
+  line-height: var(--sgds-line-height-2-xs);
 }
 
 .alert-link:focus-visible {
   outline: var(--sgds-outline-focus);
   outline-offset: var(--sgds-outline-offset-focus);
-
 }

--- a/src/components/Alert/alert.css
+++ b/src/components/Alert/alert.css
@@ -3,7 +3,7 @@
 }
 
 :host([variant="warning"]) .alert {
-  --sgds-alert-color: var(--sgds-color-fixed-dark);
+  --sgds-alert-color: var(--sgds-warning-fixed-dark);
   background-color: var(--sgds-warning-surface-default);
 }
 
@@ -12,7 +12,7 @@
 }
 
 :host([variant="neutral"]) .alert {
-  background-color: var(--sgds-neutral-surface-default);
+  background-color: var(--sgds-neutral-surface-emphasis);
 }
 
 :host([variant="success"][outlined]) .alert {
@@ -33,6 +33,26 @@
 :host([variant="neutral"][outlined]) .alert {
   background-color: var(--sgds-neutral-surface-muted);
   border: var(--sgds-border-width-1) solid var(--sgds-neutral-border-color-default);
+}
+
+:host([outlined]) .alert-icon__outlined::slotted(*) {
+  color: var(--sgds-primary-color-fixed-dark);
+}
+
+:host([variant="success"][outlined]) .alert-icon__outlined::slotted(*) {
+  color: var(--sgds-success-color-fixed-dark);
+}
+
+:host([variant="warning"][outlined]) .alert-icon__outlined::slotted(*) {
+  color: var(--sgds-warning-color-fixed-light);
+}
+
+:host([variant="danger"][outlined]) .alert-icon__outlined::slotted(*) {
+  color: var(--sgds-danger-color-fixed-dark);
+}
+
+:host([variant="neutral"][outlined]) .alert-icon__outlined::slotted(*) {
+  color: var(--sgds-color-fixed-dark);
 }
 
 .alert {
@@ -64,4 +84,13 @@
 
 .alert-title {
   font-weight: var(--sgds-font-weight-semibold);
+  font-size: var(--sgds-font-size-subtitle-sm);
+  font-style: normal;
+  font-weight: var(--sgds-font-weight-semibold);
+  line-height: var(--sgds-line-height-2-xs); /* 125% */
+}
+.alert-content__description::slotted(*) {
+  font-size: var(--sgds-font-size-body-sm);
+  font-weight: var(--sgds-font-weight-regular);
+  line-height: var(--sgds-line-height-2-xs);
 }

--- a/src/components/Alert/sgds-alert.ts
+++ b/src/components/Alert/sgds-alert.ts
@@ -64,10 +64,10 @@ export class SgdsAlert extends SgdsElement {
             role="alert"
             aria-hidden=${this.show ? "false" : "true"}
           >
-            <slot name="icon"></slot>
+            <slot name="icon" class=${classMap({ "alert-icon__outlined": this.outlined })}></slot>
             <div class="alert-content">
               ${this.title ? html`<div class="alert-title">${this.title}</div>` : nothing}
-              <slot></slot>
+              <slot class="alert-content__description"></slot>
             </div>
             ${this.dismissible
               ? html`<sgds-close-button

--- a/src/components/Alert/sgds-alert.ts
+++ b/src/components/Alert/sgds-alert.ts
@@ -73,7 +73,7 @@ export class SgdsAlert extends SgdsElement {
               ? html`<sgds-close-button
                   aria-label="close the alert"
                   @click=${this.close}
-                  tone=${this.outlined ? "fixed-dark" : "fixed-light"}
+                  tone=${this.outlined || this.variant === "warning" ? "fixed-dark" : "fixed-light"}
                 ></sgds-close-button>`
               : nothing}
           </div>

--- a/stories/templates/Alert/additional.stories.js
+++ b/stories/templates/Alert/additional.stories.js
@@ -45,16 +45,42 @@ const OutlinedVariantTemplate = args => {
   `;
 };
 const DismissibleTemplate = args => {
+  const variants = [
+    { variant: "info", icon: "info-circle-fill" },
+    { variant: "success", icon: "check-circle-fill" },
+    { variant: "danger", icon: "exclamation-circle-fill" },
+    { variant: "warning", icon: "exclamation-triangle-fill" },
+    { variant: "neutral", icon: "info-circle-fill" }
+  ];
   return html`
     <div class="d-flex-column">
-      <sgds-alert show title="Title" dismissible>
-        <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
-        <div>A dismissible alert</div>
-      </sgds-alert>
-      <sgds-alert show title="Title" outlined dismissible>
-        <sgds-icon slot="icon" name="info-circle-fill"></sgds-icon>
-        <div>A non-dismissible alert</div>
-      </sgds-alert>
+      ${variants.map(
+        v => html`
+          <sgds-alert
+            show
+            variant=${v.variant}
+            title="${v.variant.charAt(0).toUpperCase() + v.variant.slice(1)} alert"
+            dismissible
+          >
+            <sgds-icon slot="icon" name=${v.icon}></sgds-icon>
+            <div>A dismissible alert</div>
+          </sgds-alert>
+        `
+      )}
+      ${variants.map(
+        v => html`
+          <sgds-alert
+            show
+            variant=${v.variant}
+            title="${v.variant.charAt(0).toUpperCase() + v.variant.slice(1)} outlined alert"
+            outlined
+            dismissible
+          >
+            <sgds-icon slot="icon" name=${v.icon}></sgds-icon>
+            <div>A dismissible outlined alert</div>
+          </sgds-alert>
+        `
+      )}
     </div>
   `;
 };

--- a/test/alert.test.ts
+++ b/test/alert.test.ts
@@ -145,6 +145,40 @@ describe("<Alert>", () => {
     expect(base?.classList.contains("show")).to.be.true;
   });
 
+  describe("close button tone", () => {
+    it("should have tone='fixed-light' by default (non-outlined, non-warning variant)", async () => {
+      const el = await fixture<SgdsAlert>(html`<sgds-alert show dismissible></sgds-alert>`);
+      const closeButton = el.shadowRoot?.querySelector("sgds-close-button");
+      expect(closeButton?.getAttribute("tone")).to.equal("fixed-light");
+    });
+
+    it("should have tone='fixed-dark' when outlined is true", async () => {
+      const el = await fixture<SgdsAlert>(html`<sgds-alert show dismissible outlined></sgds-alert>`);
+      const closeButton = el.shadowRoot?.querySelector("sgds-close-button");
+      expect(closeButton?.getAttribute("tone")).to.equal("fixed-dark");
+    });
+
+    it("should have tone='fixed-dark' when variant is 'warning'", async () => {
+      const el = await fixture<SgdsAlert>(html`<sgds-alert show dismissible variant="warning"></sgds-alert>`);
+      const closeButton = el.shadowRoot?.querySelector("sgds-close-button");
+      expect(closeButton?.getAttribute("tone")).to.equal("fixed-dark");
+    });
+
+    it("should have tone='fixed-dark' when both outlined and variant='warning'", async () => {
+      const el = await fixture<SgdsAlert>(html`<sgds-alert show dismissible outlined variant="warning"></sgds-alert>`);
+      const closeButton = el.shadowRoot?.querySelector("sgds-close-button");
+      expect(closeButton?.getAttribute("tone")).to.equal("fixed-dark");
+    });
+
+    it("should have tone='fixed-light' for non-warning variants without outlined", async () => {
+      for (const variant of ["info", "success", "danger", "neutral"] as const) {
+        const el = await fixture<SgdsAlert>(html`<sgds-alert show dismissible variant=${variant}></sgds-alert>`);
+        const closeButton = el.shadowRoot?.querySelector("sgds-close-button");
+        expect(closeButton?.getAttribute("tone"), `variant="${variant}"`).to.equal("fixed-light");
+      }
+    });
+  });
+
   describe("Web Accessibility", () => {
     it("Should have alert role", async () => {
       const el = await fixture<SgdsAlert>(html`<sgds-alert show></sgds-alert>`);

--- a/test/alert.test.ts
+++ b/test/alert.test.ts
@@ -40,7 +40,7 @@ describe("<Alert>", () => {
         <div class="alert show" role="alert" aria-hidden="false">
         <slot name="icon"></slot>
         <div class="alert-content">
-           <slot></slot>
+           <slot class="alert-content__description">
           </div>        
         </div>
       `
@@ -75,7 +75,7 @@ describe("<Alert>", () => {
                 </svg>  
                 </slot>
         <div class="alert-content">
-           <slot></slot>
+           <slot class="alert-content__description">
           </div>        
         </div>
       `


### PR DESCRIPTION
## :open_book: Description

Fix close button colour in warning 


#520, #521, #529

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
