### PR TITLE
style(Form): form control component removed min width [skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.16.0
+npm install @govtechsg/sgds-web-component@3.16.1-rc.2
 
 ```
 
@@ -53,14 +53,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.1-rc.2/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.1-rc.2/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0" async crossorigin="anonymous" integrity="sha384-F5LRLloHEK6tuoYtNQ9dlphntGhb0cHew2heUM9CUG9V9d+xqweQZCbSSfYPgkPu"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.1-rc.2" async crossorigin="anonymous" integrity="sha384-Fac1dcR+ZUsXkpuxOsemc5Ld/Pu6/sHkOKu3fZg/ckl5nxa9o+CQ2gdETEadyjJs"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-ITgmRQ1eDoGTKD6ytTZVquH/6jBLIuZzFPDjUVaN525LjuJl3zngwzf/hYiDgJbn"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.16.1-rc.2/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-NTZt1tFTkbhjjHYUtbUDmLqrKG7WmyhNCm1QhFxafmpPq2e7ozALWTPLO2DhBTSP"></script>
 
 ```
 

--- a/src/components/ComboBox/combo-box.css
+++ b/src/components/ComboBox/combo-box.css
@@ -29,7 +29,6 @@
 
 .combobox .form-control-group {
   min-height: var(--sgds-dimension-48);
-  min-width: var(--sgds-dimension-256);
   height: unset;
 }
 

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -525,7 +525,12 @@ export class SgdsComboBox extends SelectElement {
       (this.isFocused || this.menuIsOpen) && this.value !== "" && this.clearable && !this.readonly;
     return html`
       <div
-        class=${classMap({ "form-control-container": true, disabled: this.disabled, combobox: true })}
+        class=${classMap({
+          "form-control-container": true,
+          "m-width-256": true,
+          disabled: this.disabled,
+          combobox: true
+        })}
         @keydown=${this._handleMultiSelectKeyDown}
       >
         ${this._renderLabel()}

--- a/src/components/Datepicker/datepicker.css
+++ b/src/components/Datepicker/datepicker.css
@@ -35,6 +35,10 @@ sgds-icon-button{
   --btn-border-radius: 0 var(--sgds-form-border-radius-md) var(--sgds-form-border-radius-md) 0;
 }
 
+.m-width-160 {
+  min-width: var(--sgds-dimension-160);
+}
+
 .datepicker-container {
   display: flex;
 }

--- a/src/components/Datepicker/sgds-datepicker.ts
+++ b/src/components/Datepicker/sgds-datepicker.ts
@@ -421,7 +421,7 @@ export class SgdsDatepicker extends SgdsFormValidatorMixin(DropdownElement) impl
 
   render() {
     return html`
-      <div class="datepicker-container">
+      <div class="datepicker-container m-width-160">
         <sgds-datepicker-input
           .value=${live(this.value)}
           ?required=${this.required}

--- a/src/components/Input/sgds-input.ts
+++ b/src/components/Input/sgds-input.ts
@@ -297,7 +297,7 @@ export class SgdsInput extends SgdsFormValidatorMixin(FormControlElement) implem
   render() {
     return html`
       <div
-        class="form-control-container ${classMap({
+        class="form-control-container m-width-160 ${classMap({
           disabled: this.disabled
         })}"
       >

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -230,7 +230,7 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
 
   render() {
     return html`
-      <div class="form-control-container">
+      <div class="form-control-container m-width-256">
         ${this._renderLabel()}
         <div class="input-group">
           <sgds-icon-button

--- a/src/components/Select/sgds-select.ts
+++ b/src/components/Select/sgds-select.ts
@@ -209,7 +209,8 @@ export class SgdsSelect extends SelectElement {
         class=${classMap({
           disabled: this.disabled,
           select: true,
-          "form-control-container": true
+          "form-control-container": true,
+          "m-width-160": true
         })}
       >
         ${this._renderLabel()}

--- a/src/components/Textarea/sgds-textarea.ts
+++ b/src/components/Textarea/sgds-textarea.ts
@@ -202,7 +202,7 @@ export class SgdsTextarea extends SgdsFormValidatorMixin(FormControlElement) imp
   render() {
     return html`
       <div
-        class="form-control-container ${classMap({
+        class="form-control-container m-width-256 ${classMap({
           disabled: this.disabled
         })}"
       >

--- a/src/styles/form-text-control.css
+++ b/src/styles/form-text-control.css
@@ -21,9 +21,9 @@
   padding: 0px var(--sgds-form-padding-x);
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   height: var(--sgds-dimension-48);
-  min-width: var(--sgds-dimension-256);
   width: -webkit-fill-available;
   width: -moz-available;
+  overflow: hidden;
 }
 
 .form-control {
@@ -35,6 +35,7 @@
   outline: none;
   padding: 0;
   flex-grow: 1;
+  min-width: 0;
   color: var(--sgds-form-color-default);
   font-size: var(--sgds-font-size-16);
   line-height: var(--sgds-line-height-24);

--- a/src/styles/form-text-control.css
+++ b/src/styles/form-text-control.css
@@ -10,6 +10,14 @@
   gap: var(--sgds-form-gap-md);
 }
 
+.m-width-160 {
+  min-width: var(--sgds-dimension-160);
+}
+
+.m-width-256 {
+  min-width: var(--sgds-dimension-256);
+}
+
 .form-control-group {
   display: flex;
   align-items: center;
@@ -36,6 +44,7 @@
   padding: 0;
   flex-grow: 1;
   min-width: 0;
+  width: 100%;
   color: var(--sgds-form-color-default);
   font-size: var(--sgds-font-size-16);
   line-height: var(--sgds-line-height-24);

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -118,7 +118,7 @@ describe("sgds-combo-box ", () => {
     assert.shadowDom.equal(
       el,
       `
-      <div class="combobox form-control-container">
+      <div class="combobox form-control-container m-width-256">
         <div class="form-control-group">
           <div class="combobox-input-container">
             <input

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -10,7 +10,7 @@ describe("sgds-input", () => {
     assert.shadowDom.equal(
       el,
       `
-        <div class="form-control-container">
+        <div class="form-control-container m-width-160">
           <label class="form-label" for="test-id">label</label>
            <div class="form-control-row">
           <div class="form-control-group">
@@ -31,7 +31,7 @@ describe("sgds-input", () => {
     assert.shadowDom.equal(
       el,
       `
-        <div class="form-control-container">
+        <div class="form-control-container m-width-160">
         <div class="form-control-row">
           <div class="form-control-group">
             <slot name="icon"></slot>
@@ -50,7 +50,7 @@ describe("sgds-input", () => {
     assert.shadowDom.equal(
       el,
       `
-        <div class="form-control-container">
+        <div class="form-control-container m-width-160">
         <div class="form-control-row">
           <div class="form-control-group">
             <slot name="icon"></slot>
@@ -71,7 +71,7 @@ describe("sgds-input", () => {
     assert.shadowDom.equal(
       el,
       `
-        <div class="form-control-container">
+        <div class="form-control-container m-width-160">
           <div class="form-control-row">
             <div class="form-control-group">
               <slot name="icon"></slot>

--- a/test/select.test.ts
+++ b/test/select.test.ts
@@ -83,7 +83,7 @@ describe("<sgds-select>", () => {
     assert.shadowDom.equal(
       el,
       `
-        <div class="form-control-container select">
+        <div class="form-control-container m-width-160 select">
           <div class="form-control-group">
               <input
                 aria-invalid="false"

--- a/test/textarea.test.ts
+++ b/test/textarea.test.ts
@@ -10,7 +10,7 @@ describe("sgds-textarea", () => {
     assert.shadowDom.equal(
       el,
       `
-      <div class="form-control-container">
+      <div class="form-control-container m-width-256">
         <label class="form-label"></label>
         <textarea class=" form-control-group textarea-resize-vertical "  rows="4" placeholder="Placeholder" maxlength="10" aria-invalid="false" spellcheck="false" required=""></textarea>
         <div class="textarea-info-container">


### PR DESCRIPTION
## :open_book: Description

1) Reduce min-width to 160px for the following components: Input, Datepicker, Select. Expected to be put into tabel 
- QT is expected to be have reduced minwidth to 160px too,  but remains unchanged before of its outdated style. 

2) Components not to be put into Table remains at 256px minimum width 
- Textarea, Combobox


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
