### PR TITLE
fix(Subnav): activate z-index and lockBodyScroll when menu is open [skip-cd] [run-chromatic]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "workbench.colorCustomizations": {
     "activityBar.background": "#203220",
-    "titleBar.activeBackground": "#2C452D",
+    "titleBar.activeBackground": "#2C452D"
   },
   "todo-tree.highlights.customHighlight": {
     "TODO": {

--- a/src/components/Subnav/sgds-subnav.ts
+++ b/src/components/Subnav/sgds-subnav.ts
@@ -133,7 +133,7 @@ export class SgdsSubnav extends SgdsElement {
     if (this.isMenuOpen) {
       this.hide();
     } else {
-      document.querySelector("body").style.overflow = "hidden";
+      this._lockBodyScroll();
       this.show();
     }
 
@@ -164,9 +164,28 @@ export class SgdsSubnav extends SgdsElement {
     }
 
     this.isMenuOpen = false;
-    document.querySelector("body").style.removeProperty("overflow");
+    this._unlockBodyScroll();
 
     return waitForEvent(this, "sgds-after-hide");
+  }
+
+  private _lockBodyScroll() {
+    if (typeof window === "undefined") return;
+
+    const scrollY = window.scrollY;
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+  }
+
+  private _unlockBodyScroll() {
+    if (typeof window === "undefined") return;
+
+    const scrollY = parseInt(document.body.style.top || "0") * -1;
+    document.body.style.position = "";
+    document.body.style.top = "";
+    document.body.style.width = "";
+    window.scrollTo(0, scrollY);
   }
 
   private async _animateToShow() {

--- a/src/components/Subnav/subnav.css
+++ b/src/components/Subnav/subnav.css
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  position: relative;
   z-index: var(--sgds-z-index-sticky);
 }
 


### PR DESCRIPTION
## :open_book: Description

1. Apply position relative to `:host` to activate z-index on subnav
2. Prevent `overflow: hidden` to break the subnav stickiness when expanding the menu

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules