### PR TITLE
feat(Dropdown): close prop to control menu closing for interactive dropdown behaviour [skip-cd][run-chromatic]

### DIFF
--- a/src/base/dropdown-list-element.ts
+++ b/src/base/dropdown-list-element.ts
@@ -46,12 +46,15 @@ export class DropdownListElement extends DropdownElement {
 
   protected handleSelectSlot(e: KeyboardEvent | MouseEvent) {
     const items = this._getActiveMenuItems();
-    const currentItemNo = items.indexOf(e.target as SgdsDropdownItem);
+
+    const selectedItem = items.find(item => e.composedPath().includes(item));
+    if (!selectedItem) return;
+
+    const currentItemNo = items.indexOf(selectedItem);
     this.nextDropdownItemNo = currentItemNo + 1;
     this.prevDropdownItemNo = currentItemNo <= 0 ? items.length - 1 : currentItemNo - 1;
 
     /** Emitted event from SgdsDropdown element when a slot item is selected */
-    const selectedItem = e.target as SgdsDropdownItem;
     if (!selectedItem.disabled) {
       this.emit("sgds-select", { detail: { item: selectedItem } });
       if (this.close !== "outside") {
@@ -93,11 +96,13 @@ export class DropdownListElement extends DropdownElement {
           this._setMenuItem(this.nextDropdownItemNo);
         }
         break;
-      case ENTER:
-        if (menuItems.includes(e.target as SgdsDropdownItem)) {
+      case ENTER: {
+        const target = menuItems.find(item => e.composedPath().includes(item));
+        if (target) {
           this.handleSelectSlot(e);
         }
         break;
+      }
       default:
         break;
     }

--- a/src/components/Dropdown/sgds-dropdown-item.ts
+++ b/src/components/Dropdown/sgds-dropdown-item.ts
@@ -29,7 +29,7 @@ export class SgdsDropdownItem extends SgdsElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener("keydown", (e: KeyboardEvent) => {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && this.anchor.length > 0) {
         this.anchor[0].click();
       }
     });

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -7,15 +7,6 @@ import dropdownMenuStyle from "./dropdown-menu.css";
 import dropdownStyle from "./dropdown.css";
 
 export type DropDirection = "left" | "right" | "up" | "down";
-export type DropdownButtonVariant =
-  | "primary"
-  | "secondary"
-  | "success"
-  | "danger"
-  | "warning"
-  | "info"
-  | "light"
-  | "dark";
 
 /**
  * @summary `SgdsDropdown` toggles contextual overlays for displaying lists of links.

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -34,6 +34,10 @@ export class SgdsDropdown extends DropdownListElement {
   @property({ type: String, reflect: true, state: false })
   drop: DropDirection = "down";
 
+  /** Controls the close behaviour of dropdown menu. By default menu auto-closes when SgdsDropdownItem or area outside dropdown is clicked */
+  @property({ type: String, reflect: true, state: false })
+  close: "outside" | "default" | "inside" = "default";
+
   @queryAssignedElements({ slot: "toggler", flatten: true })
   private _toggler: Array<HTMLElement>;
 

--- a/stories/component-templates/Dropdown/additional.mdx
+++ b/stories/component-templates/Dropdown/additional.mdx
@@ -15,3 +15,11 @@ Disabled items do not emit `sgds-select`.
 <Canvas of={DropdownStories.SgdsSelectEvent}>
   <Story of={DropdownStories.SgdsSelectEvent} />
 </Canvas>
+
+## SGDS Dropdown Item Customisation
+
+Using SGDS utility classes, the layout of `SgdsDropdownItem` can be customised as needed.
+
+<Canvas of={DropdownStories.SgdsSelectDropdownItem}>
+  <Story of={DropdownStories.SgdsSelectDropdownItem} />
+</Canvas>

--- a/stories/component-templates/Dropdown/additional.mdx
+++ b/stories/component-templates/Dropdown/additional.mdx
@@ -1,3 +1,11 @@
+## Close
+
+The close behaviour of `sgds-dropdown` can be modified using the `close` attribute
+
+<Canvas of={DropdownStories.SgdsSelectClose}>
+  <Story of={DropdownStories.SgdsSelectClose} />
+</Canvas>
+
 ## sgds-select event
 
 The `sgds-select` event is emitted on `sgds-dropdown` whenever a non-disabled item is clicked. Use `event.detail.item` to access the selected `SgdsDropdownItem` element.

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -1,5 +1,49 @@
 import { html } from "lit";
 
+const SgdsSelectCloseTemplate = args => {
+  return html`
+    <sgds-dropdown close="default">
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+        Default Close
+        <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+      </sgds-button>
+      <sgds-dropdown-item>Item #1</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #2</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #3</sgds-dropdown-item>
+    </sgds-dropdown>
+    <br />
+    <sgds-dropdown close="outside">
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+        Close Outside
+        <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+      </sgds-button>
+      <sgds-dropdown-item>Item #1</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #2</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #3</sgds-dropdown-item>
+    </sgds-dropdown>
+    <br />
+    <sgds-dropdown close="inside">
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+        Close Inside
+        <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+      </sgds-button>
+      <sgds-dropdown-item>Item #1</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #2</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #3</sgds-dropdown-item>
+    </sgds-dropdown>
+  `;
+};
+
+export const SgdsSelectClose = {
+  render: SgdsSelectCloseTemplate.bind({}),
+  name: "sgds-select close",
+  args: {},
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
+  tags: ["!dev"]
+};
+
 const SgdsSelectEventTemplate = args => {
   return html`
     <sgds-dropdown id="select-event-dropdown">

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -47,24 +47,22 @@ export const SgdsSelectClose = {
 const SgdsSelectEventTemplate = args => {
   return html`
     <sgds-dropdown id="select-event-dropdown">
-      <sgds-button slot="toggler" role="button">
-        Dropdown
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+        <span id="select-toggler-text">Dynamic Text</span>
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>
-      <sgds-dropdown-item>item #1</sgds-dropdown-item>
-      <sgds-dropdown-item>item #2</sgds-dropdown-item>
-      <sgds-dropdown-item>item #3</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #1</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #2</sgds-dropdown-item>
+      <sgds-dropdown-item>Item #3</sgds-dropdown-item>
       <sgds-dropdown-item disabled>item #4 (disabled)</sgds-dropdown-item>
     </sgds-dropdown>
 
-    <div class="sgds:mt-md">Selected item: <strong id="selected-output">—</strong></div>
-
     <script>
       const dropdown = document.querySelector("#select-event-dropdown");
-      const output = document.querySelector("#selected-output");
+      const togglerText = document.querySelector("#select-toggler-text");
 
       dropdown.addEventListener("sgds-select", e => {
-        output.textContent = e.detail.item.textContent.trim();
+        togglerText.textContent = e.detail.item.textContent.trim();
       });
     </script>
   `;

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -79,3 +79,78 @@ export const SgdsSelectEvent = {
   },
   tags: ["!dev"]
 };
+
+const SgdsSelectDropdownItemTemplate = args => {
+  return html`
+    <sgds-dropdown close="outside">
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+        Dropdown
+        <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+      </sgds-button>
+      <sgds-dropdown-item>
+        <div class="sgds:grow sgds:items-center">
+          <sgds-icon name="placeholder" size="2-xl"></sgds-icon>
+          <div class="sgds:flex sgds:flex-col sgds:gap-text-2-xs">
+            <span class="sgds:text-label-sm sgds:leading-2-xs sgds:font-regular sgds:tracking-normal">Label</span>
+            <span class="sgds:text-label-xs sgds:leading-3-xs sgds:font-regular sgds:tracking-normal sgds:text-subtle"
+              >Secondary text</span
+            >
+          </div>
+          <sgds-icon name="placeholder"></sgds-icon>
+        </div>
+      </sgds-dropdown-item>
+      <sgds-dropdown-item>
+        <div class="sgds:grow sgds:items-center">
+          <sgds-icon name="placeholder"></sgds-icon>
+          <span class="sgds:text-label-sm sgds:leading-2-xs sgds:font-regular sgds:tracking-normal sgds:grow"
+            >Label</span
+          >
+          <span class="sgds:text-label-xs sgds:leading-3-xs sgds:font-regular sgds:tracking-normal sgds:text-subtle"
+            >Secondary text</span
+          >
+        </div>
+      </sgds-dropdown-item>
+      <sgds-dropdown-item>
+        <div class="sgds:grow sgds:items-center sgds:justify-between">
+          <div class="sgds:flex sgds:flex-col sgds:gap-text-2-xs">
+            <span class="sgds:text-label-sm sgds:leading-2-xs sgds:font-regular sgds:tracking-normal">Label</span>
+            <span class="sgds:text-label-xs sgds:leading-3-xs sgds:font-regular sgds:tracking-normal sgds:text-subtle"
+              >Secondary text</span
+            >
+          </div>
+          <sgds-badge variant="white" outlined>Badge</sgds-badge>
+        </div>
+      </sgds-dropdown-item>
+      <sgds-dropdown-item>
+        <div class="sgds:grow sgds:items-center">
+          <sgds-icon name="placeholder"></sgds-icon>
+          <span class="sgds:text-label-sm sgds:leading-2-xs sgds:font-regular sgds:tracking-normal sgds:grow"
+            >Label</span
+          >
+          <sgds-switch size="sm"></sgds-switch>
+        </div>
+      </sgds-dropdown-item>
+      <sgds-dropdown-item>
+        <div class="sgds:grow sgds:items-center sgds:justify-between">
+          <div class="sgds:flex sgds:flex-col sgds:gap-text-2-xs">
+            <span class="sgds:text-label-sm sgds:leading-2-xs sgds:font-regular sgds:tracking-normal">Label</span>
+            <span class="sgds:text-label-xs sgds:leading-3-xs sgds:font-regular sgds:tracking-normal sgds:text-subtle"
+              >Secondary text</span
+            >
+          </div>
+          <sgds-button variant="outline" tone="neutral" size="xs">Action</sgds-button>
+        </div>
+      </sgds-dropdown-item>
+    </sgds-dropdown>
+  `;
+};
+
+export const SgdsSelectDropdownItem = {
+  render: SgdsSelectDropdownItemTemplate.bind({}),
+  name: "sgds-dropdown-item customisation",
+  args: {},
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
+  tags: ["!dev"]
+};

--- a/stories/component-templates/Dropdown/basic.js
+++ b/stories/component-templates/Dropdown/basic.js
@@ -7,7 +7,6 @@ export const Template = ({
   menuAlignRight,
   drop,
   floatingOpts,
-  variant,
   active,
   href,
   close,
@@ -21,7 +20,6 @@ export const Template = ({
       drop=${ifDefined(drop)}
       ?menuAlignRight=${menuAlignRight}
       floatingOpts=${ifDefined(floatingOpts)}
-      variant=${ifDefined(variant)}
       close=${ifDefined(close)}
       ?menuIsOpen=${menuIsOpen}
       ?disabled=${disabled}
@@ -48,7 +46,6 @@ export const Template = ({
 };
 
 export const args = {
-  variant: "secondary",
   href: "#"
 };
 

--- a/stories/component-templates/Dropdown/basic.js
+++ b/stories/component-templates/Dropdown/basic.js
@@ -24,7 +24,7 @@ export const Template = ({
       ?menuIsOpen=${menuIsOpen}
       ?disabled=${disabled}
     >
-      <sgds-button slot="toggler" role="button">
+      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
         Dropdown
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -722,3 +722,109 @@ describe("sgds-dropdown-item", () => {
     window.location.hash = "";
   });
 });
+
+describe("handleSelectSlot with nested elements", () => {
+  it("finds SgdsDropdownItem when clicking on nested anchor element", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item><a href="#">Nested Link</a></sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const anchor = el.querySelector("sgds-dropdown-item a") as HTMLAnchorElement;
+    anchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.be.instanceOf(SgdsDropdownItem);
+  });
+
+  it("finds SgdsDropdownItem when clicking on deeply nested content", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>
+          <a href="#"
+            ><span><strong>Deep content</strong></span></a
+          >
+        </sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const strong = el.querySelector("sgds-dropdown-item strong") as HTMLElement;
+    strong.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.equal(el.querySelector("sgds-dropdown-item"));
+  });
+
+  it("returns correct SgdsDropdownItem when multiple items exist and nested content is clicked", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>Item 1</sgds-dropdown-item>
+        <sgds-dropdown-item><a href="#">Item 2 Link</a></sgds-dropdown-item>
+        <sgds-dropdown-item>Item 3</sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const secondItemAnchor = el.querySelectorAll("sgds-dropdown-item")[1].querySelector("a") as HTMLAnchorElement;
+    secondItemAnchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.equal(el.querySelectorAll("sgds-dropdown-item")[1]);
+  });
+
+  it("does not emit sgds-select when disabled item's nested content is clicked", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item disabled><a href="#">Disabled Link</a></sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const anchor = el.querySelector("sgds-dropdown-item a") as HTMLAnchorElement;
+    anchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).not.to.be.called;
+  });
+
+  it("emits sgds-select on Enter keypress when menu item is focused via keyboard navigation", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>Item 1</sgds-dropdown-item>
+        <sgds-dropdown-item><a href="#">Item 2 Link</a></sgds-dropdown-item>
+        <sgds-dropdown-item>Item 3</sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sgdsButton = el.querySelector("sgds-button")!;
+    expect(sgdsButton).to.be.not.null;
+
+    sgdsButton.shadowRoot?.querySelector("button")?.focus();
+    await waitUntil(() => sgdsButton.shadowRoot?.querySelector("button:focus"));
+    await sendKeys({ press: "ArrowUp" });
+    await el.updateComplete;
+    await sendKeys({ press: "Enter" });
+    await el.updateComplete;
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.be.instanceOf(SgdsDropdownItem);
+  }).retries(1);
+});

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -726,3 +726,109 @@ describe("sgds-dropdown-item", () => {
     window.location.hash = "";
   });
 });
+
+describe("handleSelectSlot with nested elements", () => {
+  it("finds SgdsDropdownItem when clicking on nested anchor element", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item><a href="#">Nested Link</a></sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const anchor = el.querySelector("sgds-dropdown-item a") as HTMLAnchorElement;
+    anchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.be.instanceOf(SgdsDropdownItem);
+  });
+
+  it("finds SgdsDropdownItem when clicking on deeply nested content", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>
+          <a href="#"
+            ><span><strong>Deep content</strong></span></a
+          >
+        </sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const strong = el.querySelector("sgds-dropdown-item strong") as HTMLElement;
+    strong.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.equal(el.querySelector("sgds-dropdown-item"));
+  });
+
+  it("returns correct SgdsDropdownItem when multiple items exist and nested content is clicked", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>Item 1</sgds-dropdown-item>
+        <sgds-dropdown-item><a href="#">Item 2 Link</a></sgds-dropdown-item>
+        <sgds-dropdown-item>Item 3</sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const secondItemAnchor = el.querySelectorAll("sgds-dropdown-item")[1].querySelector("a") as HTMLAnchorElement;
+    secondItemAnchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.equal(el.querySelectorAll("sgds-dropdown-item")[1]);
+  });
+
+  it("does not emit sgds-select when disabled item's nested content is clicked", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item disabled><a href="#">Disabled Link</a></sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    const anchor = el.querySelector("sgds-dropdown-item a") as HTMLAnchorElement;
+    anchor.click();
+    await el.updateComplete;
+
+    expect(selectHandler).not.to.be.called;
+  });
+
+  it("emits sgds-select on Enter keypress when menu item is focused via keyboard navigation", async () => {
+    const el = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown menuIsOpen>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>Item 1</sgds-dropdown-item>
+        <sgds-dropdown-item><a href="#">Item 2 Link</a></sgds-dropdown-item>
+        <sgds-dropdown-item>Item 3</sgds-dropdown-item>
+      </sgds-dropdown>`
+    );
+
+    const selectHandler = sinon.spy();
+    el.addEventListener("sgds-select", selectHandler);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sgdsButton = el.querySelector("sgds-button")!;
+    expect(sgdsButton).to.be.not.null;
+
+    sgdsButton.shadowRoot?.querySelector("button")?.focus();
+    await waitUntil(() => sgdsButton.shadowRoot?.querySelector("button:focus"));
+    await sendKeys({ press: "ArrowUp" });
+    await el.updateComplete;
+    await sendKeys({ press: "Enter" });
+    await el.updateComplete;
+    expect(selectHandler).to.be.calledOnce;
+    expect(selectHandler.firstCall.args[0].detail.item).to.be.instanceOf(SgdsDropdownItem);
+  }).retries(1);
+});

--- a/test/mainnav.test.ts
+++ b/test/mainnav.test.ts
@@ -311,6 +311,7 @@ describe("sgds-mainnav-dropdown", () => {
       dropdown as SgdsMainnavDropdown,
       `
       <sgds-dropdown
+        close="default"
         drop="down"
       >
         <a

--- a/test/mainnav.test.ts
+++ b/test/mainnav.test.ts
@@ -312,6 +312,7 @@ describe("sgds-mainnav-dropdown", () => {
       dropdown as SgdsMainnavDropdown,
       `
       <sgds-dropdown
+        close="default"
         drop="down"
       >
         <a

--- a/test/overflow-menu.test.ts
+++ b/test/overflow-menu.test.ts
@@ -8,7 +8,10 @@ describe("<sgds-overflow-menu>", () => {
     assert.shadowDom.equal(
       el,
       `
-      <sgds-dropdown drop="down">
+      <sgds-dropdown
+        close="default"
+        drop="down"
+      >
         <button aria-expanded="false" aria-haspopup="menu" aria-label="More options" slot="toggler" class="overflow-btn">
             <sgds-icon name="three-dots" size="md"></sgds-icon>
         </button>

--- a/test/overflow-menu.test.ts
+++ b/test/overflow-menu.test.ts
@@ -8,7 +8,10 @@ describe("<sgds-overflow-menu>", () => {
     assert.shadowDom.equal(
       el,
       `
-      <sgds-dropdown drop="down">
+      <sgds-dropdown
+        close="default"
+        drop="down"
+      >
         <button slot="toggler" class="overflow-btn">
             <sgds-icon name="three-dots" size="md"></sgds-icon>
         </button>


### PR DESCRIPTION
## :open_book: Description

- Bugfix for `sgds-dropdown` `sgds-select` event directly returning `event.target` which will return the wrong `HTMLElement` if user inserts nested elements into the `default` slot.
- Removed unused `variant` attribute from `sgds-dropdown`. Motivating factor was to clarify to users that `sgds-dropdown` doesn't implement the `variant` attribute meaningfully and to better signal to users to style the `sgds-button` directly to change the `toggler` styling
- Added new story to illustrate to users how to customise `sgds-dropdown-item` using SGDS utility classes
- Tweaked `sgds-select` story to illustrate how users may implement dynamic text changing of the `toggler` text
- Exposed `close` attribute for users to customise `sgds-dropdown` close behaviour. **[Clarification required]**

## :pencil2: Type of change
- [x] Bug fix
- [x] New documentation

## :question: Clarification required
- With regards to the exposing of the `close` attribute to users, this was done in reference to the [Figma link](https://www.figma.com/design/Vo3uhyJjdYjL70FdfSrbfY/Dropdown-2?node-id=32781-4432&m=dev) provided which implements `sgds-button` and `sgds-switch` inside the `sgds-dropdown-item`. It didn't make sense to me to provide use case stories showing users how the may insert such interactive elements into the `sgds-dropdown-item` while forcing the default close behaviour which closes the `sgds-dropdown` menu when a `sgds-dropdown-item` is selected. If it is intended to keep the `close` attribute hidden from users, I will probably remove the `sgds-dropdown-item` examples that have interactive elements inside them.
- What are the error handling/logging conventions for SGDS? Because for the element traversal algorithm that I use, I put in place a failsafe which returns the original `event.target` instead of `null` if the algorithm was unable to find the root `sgds-element` but there should never be a case in which this is supposed to happen so some form of logging/error handling should be put in place for error diagnosis.

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
