### PR TITLE
fix(dropdown menu): allow slotted element to fill parent width via flex grow [skip-cd] [run-chromatic]

### DIFF
--- a/src/components/Dropdown/dropdown.css
+++ b/src/components/Dropdown/dropdown.css
@@ -1,5 +1,14 @@
 .dropdown {
   position: relative;
-  display: flex; 
+  display: flex;
   height: inherit;
+}
+
+.toggler-container {
+  flex: 1;
+  pointer-events: none;
+}
+
+.toggler-container ::slotted(*) {
+  pointer-events: auto;
 }

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -48,11 +48,26 @@ export class SgdsDropdown extends DropdownListElement {
 
   protected menuRef;
 
-  private async _handleClick() {
-    if (this.disabled) {
+  private async _handleClick(e: MouseEvent) {
+    if (this.disabled) return;
+
+    const slottedToggler = this._toggler[0];
+
+    if (!slottedToggler) {
+      this.toggleMenu();
       return;
     }
-    this.toggleMenu();
+
+    if (e.composedPath().includes(slottedToggler)) {
+      this.toggleMenu();
+      return;
+    }
+
+    // Click landed in the toggler-container's empty area (passed through pointer-events: none)
+    if (!this.menuIsOpen) return;
+    const menu = this.menuRef.value;
+    if (menu && e.composedPath().includes(menu)) return;
+    this.hideMenu();
   }
 
   private _handleCloseMenu() {
@@ -91,11 +106,10 @@ export class SgdsDropdown extends DropdownListElement {
 
   render() {
     return html`
-      <div class="dropdown">
+      <div class="dropdown" @click=${this._handleClick}>
         <div
           class="toggler-container"
           ${ref(this.myDropdown)}
-          @click=${this._handleClick}
           aria-expanded="${this.menuIsOpen}"
           aria-haspopup="menu"
         >

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -552,6 +552,67 @@ describe("sgds-dropdown", () => {
     await el.updateComplete;
     expect(getComputedStyle(menuEl).display).to.equal("none");
   });
+  it("clicking the slotted toggler opens the menu when closed", async () => {
+    const el = await fixture<SgdsDropdown>(html`<sgds-dropdown>
+      <sgds-button slot="toggler">Dropdown</sgds-button>
+      <sgds-dropdown-item>item 1</sgds-dropdown-item>
+    </sgds-dropdown>`);
+    expect(el.menuIsOpen).to.be.false;
+    const button = el.querySelector("sgds-button") as HTMLElement;
+    button.click();
+    await el.updateComplete;
+    expect(el.menuIsOpen).to.be.true;
+  });
+
+  it("clicking the slotted toggler closes the menu when open", async () => {
+    const el = await fixture<SgdsDropdown>(html`<sgds-dropdown menuIsOpen>
+      <sgds-button slot="toggler">Dropdown</sgds-button>
+      <sgds-dropdown-item>item 1</sgds-dropdown-item>
+    </sgds-dropdown>`);
+    expect(el.menuIsOpen).to.be.true;
+    const button = el.querySelector("sgds-button") as HTMLElement;
+    button.click();
+    await el.updateComplete;
+    expect(el.menuIsOpen).to.be.false;
+  });
+
+  it("clicking the empty toggler-container area closes an open menu", async () => {
+    const el = await fixture<SgdsDropdown>(html`<sgds-dropdown menuIsOpen>
+      <sgds-button slot="toggler">Dropdown</sgds-button>
+      <sgds-dropdown-item>item 1</sgds-dropdown-item>
+    </sgds-dropdown>`);
+    expect(el.menuIsOpen).to.be.true;
+    // Simulate the click that falls through pointer-events:none on .toggler-container to .dropdown
+    const dropdownDiv = el.shadowRoot?.querySelector(".dropdown") as HTMLElement;
+    dropdownDiv.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(el.menuIsOpen).to.be.false;
+  });
+
+  it("clicking the empty toggler-container area does not open a closed menu", async () => {
+    const el = await fixture<SgdsDropdown>(html`<sgds-dropdown>
+      <sgds-button slot="toggler">Dropdown</sgds-button>
+      <sgds-dropdown-item>item 1</sgds-dropdown-item>
+    </sgds-dropdown>`);
+    expect(el.menuIsOpen).to.be.false;
+    const dropdownDiv = el.shadowRoot?.querySelector(".dropdown") as HTMLElement;
+    dropdownDiv.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(el.menuIsOpen).to.be.false;
+  });
+
+  it("clicking a menu item does not prevent the menu from closing", async () => {
+    const el = await fixture<SgdsDropdown>(html`<sgds-dropdown menuIsOpen>
+      <sgds-button slot="toggler">Dropdown</sgds-button>
+      <sgds-dropdown-item>item 1</sgds-dropdown-item>
+    </sgds-dropdown>`);
+    expect(el.menuIsOpen).to.be.true;
+    const item = el.querySelector("sgds-dropdown-item") as HTMLElement;
+    item.click();
+    await el.updateComplete;
+    expect(el.menuIsOpen).to.be.false;
+  });
+
   // // tests _handleClickOutOfElement & blur event listener
   it("click outside of component, closes the dropdown by default", async () => {
     const el = await fixture<SgdsDropdown>(


### PR DESCRIPTION
## :open_book: Description

set flex group on toggler container to allow the slotted element to be able to fill the parent full width

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
