### PR TITLE
Fix/dropdown menu max width [skip-cd] [run-chromatic]

### DIFF
--- a/src/components/Dropdown/dropdown-menu.css
+++ b/src/components/Dropdown/dropdown-menu.css
@@ -12,7 +12,6 @@
   list-style: none;
   margin: 0;
   min-width: var(--sgds-dimension-192);
-  max-width: var(--sgds-dimension-320);
   max-height: var(--sgds-dimension-480);
   padding: var(--sgds-padding-xs) 0;
   position: absolute;

--- a/src/components/Dropdown/dropdown.css
+++ b/src/components/Dropdown/dropdown.css
@@ -4,6 +4,10 @@
   height: inherit;
 }
 
+.dropdown-menu {
+  max-width: var(--sgds-dimension-320);
+}
+
 .toggler-container {
   flex: 1;
   pointer-events: none;

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -107,12 +107,7 @@ export class SgdsDropdown extends DropdownListElement {
   render() {
     return html`
       <div class="dropdown" @click=${this._handleClick}>
-        <div
-          class="toggler-container"
-          ${ref(this.myDropdown)}
-          aria-expanded="${this.menuIsOpen}"
-          aria-haspopup="menu"
-        >
+        <div class="toggler-container" ${ref(this.myDropdown)} aria-expanded="${this.menuIsOpen}" aria-haspopup="menu">
           <slot name="toggler"></slot>
         </div>
         <div class="dropdown-menu" role="menu" ${ref(this.menuRef)}>


### PR DESCRIPTION
## :open_book: Description

move away the max width style from `dropdown-menu.css` to `dropdown.css` to isolate the style on dropdown only

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
