### PR TITLE
Style/update accordion discrepancy [run-chromatic]

### DIFF
--- a/src/components/Accordion/accordion-item.css
+++ b/src/components/Accordion/accordion-item.css
@@ -7,15 +7,23 @@
   font-size: var(--sgds-font-size-subtitle-sm);
   line-height: var(--sgds-line-height-2-xs);
 }
-:host([density="spacious"]) .accordion-btn {
-  padding: var(--sgds-padding-xl) var(--sgds-padding-xl);
-  font-size: var(--sgds-font-size-heading-sm);
-  line-height: var(--sgds-line-height-sm);
+
+:host([density="compact"]) .accordion-body {
+  font-size: var(--sgds-font-size-body-sm);
+  line-height: var(--sgds-line-height-2-xs);
 }
 
 :host([density="compact"]) .content {
   padding: var(--sgds-padding-xs) var(--sgds-padding-md) var(--sgds-padding-md);
 }
+
+:host([density="spacious"]) .accordion-btn {
+  padding: var(--sgds-padding-xl);
+  font-size: var(--sgds-font-size-heading-sm);
+  line-height: var(--sgds-line-height-sm);
+  letter-spacing: var(--sgds-letter-spacing-tight);
+}
+
 :host([density="spacious"]) .content {
   padding: var(--sgds-padding-xs) var(--sgds-padding-xl) var(--sgds-padding-xl);
 }
@@ -29,7 +37,7 @@
   display: flex;
   align-items: center;
   gap: var(--sgds-gap-md);
-  padding: var(--sgds-padding-lg) var(--sgds-padding-lg);
+  padding: var(--sgds-padding-lg);
   background-color: var(--sgds-bg-transparent);
   text-align: left;
   border: 0;
@@ -77,11 +85,12 @@ slot[name="badge"]::slotted(*) {
   margin-left: auto;
 }
 
-.accordion-header__trailing{
+.accordion-header__trailing {
   margin-left:auto;
   display:flex;
   gap: var(--sgds-gap-md);
 }
+
 slot[name="caret"]::slotted(*),
 slot[name="caret"] sgds-icon {
   transition: transform 0.2s ease-in-out;
@@ -96,8 +105,9 @@ slot[name="caret"] sgds-icon {
 .accordion-body {
   padding: 0;
   overflow: hidden;
-  font-size: var(--sgds-font-size-body-sm);
-  line-height: var(--sgds-line-height-2-xs);
+  font-size: var(--sgds-font-size-body-md);
+  line-height: var(--sgds-line-height-xs);
+  color: var(--sgds-body-color-subtle);
 }
 
 .content {

--- a/src/components/Accordion/sgds-accordion-item.ts
+++ b/src/components/Accordion/sgds-accordion-item.ts
@@ -157,7 +157,10 @@ export class SgdsAccordionItem extends SgdsElement {
           <div class="accordion-header__trailing">
             <slot name="badge"></slot>
             <slot name="caret">
-              <sgds-icon name="chevron-down" size=${this.density === "compact" ? "md" : "lg"}></sgds-icon>
+              <sgds-icon
+                name="chevron-down"
+                size=${this.density === "compact" ? "md" : this.density === "spacious" ? "xl" : "lg"}
+              ></sgds-icon>
             </slot>
           </div>
         </button>


### PR DESCRIPTION
## :open_book: Description

Update discrepancy for accordion according to figma design:
1. Font sizes and letter spacing for `compact` and `spacious` density
2. Color for accordion content
3. Caret icon size for `spacious` density

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
