### PR TITLE
refactor(CloseButton): remove unused style and set close icon size to be sm [run-chromatic][skip-cd]

### DIFF
--- a/src/components/CloseButton/close-button.css
+++ b/src/components/CloseButton/close-button.css
@@ -51,13 +51,3 @@
   outline: var(--sgds-outline-focus);
   outline-offset: var(--sgds-outline-offset-focus);
 }
-
-.btn-close-sm {
-  width: var(--sgds-dimension-24);
-  height: var(--sgds-dimension-24);
-}
-
-.btn-close.btn-close-sm {
-  width: var(--sgds-icon-size-sm);
-  height: var(--sgds-icon-size-sm);
-}

--- a/src/components/CloseButton/sgds-close-button.ts
+++ b/src/components/CloseButton/sgds-close-button.ts
@@ -33,7 +33,7 @@ export class SgdsCloseButton extends SgdsElement {
   render() {
     return html`
       <button class="btn-close" aria-label="Close button" @click=${this._handleClick}>
-        <sgds-icon name="cross" size=${this.size}></sgds-icon>
+        <sgds-icon name="cross" size="sm"></sgds-icon>
       </button>
     `;
   }

--- a/test/close-button.test.ts
+++ b/test/close-button.test.ts
@@ -12,7 +12,7 @@ describe("<sgds-close-button>", () => {
       el,
       `
       <button class="btn-close" aria-label="Close button">
-        <sgds-icon name="cross" size="md"></sgds-icon>
+        <sgds-icon name="cross" size="sm"></sgds-icon>
       </button>
       `
     );


### PR DESCRIPTION
## :open_book: Description

1. Remove unused css
2. Set close icon to be always in `sm` size

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
