### PR TITLE
fix(Utility): breakpoints can only point to raw value [run-chromatic][skip-cd]

### DIFF
--- a/cypress/apps/next-app/types.d.ts
+++ b/cypress/apps/next-app/types.d.ts
@@ -2,4 +2,3 @@ declare module "@webcomponents/scoped-custom-element-registry";
 import "@govtechsg/sgds-web-component/types/react";
 
 import "react";
-

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.18.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.18.1" async crossorigin="anonymous" integrity="sha384-LSnieof8DIuus7eNqPuZnP0Cww9yHv9w/DUINUmV6TuF1sci2j08MO9D+SkawN6l"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.18.1" async crossorigin="anonymous" integrity="sha384-ewDyP7iuhEi/APW3O4ZFey3S0vb27mI5WsOsGi909tRPhaiVbPrjhr1be+HllmaM"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.18.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-5OKa7RaQpYeIsx/ZOXW2ttNUa7ftAEKXiWuSgFRmlXJUaJ1Bvf3etjlCw2qqjia8"></script>

--- a/playground/utility/breakpoint.html
+++ b/playground/utility/breakpoint.html
@@ -1,0 +1,161 @@
+<script type="module" src="../../src/index.ts"></script>
+<link href="../../src/themes/day.css" rel="stylesheet" type="text/css" />
+<link href="../../src/themes/night.css" rel="stylesheet" type="text/css" />
+<link href="../../src/css/sgds.css" rel="stylesheet" type="text/css" />
+<link href="../css/utility.css" rel="stylesheet" type="text/css" />
+
+<body class="sgds:p-2-xl sgds:bg-default sgds:text-default">
+  <div class="sgds:sticky sgds:top-0 sgds:flex sgds:justify-between sgds:items-center sgds:mb-2-xl sgds:bg-default sgds:py-2-xl">
+    <h1>Breakpoints</h1>
+    <sgds-button id="night-theme" variant="ghost">
+      <sgds-icon name="lightbulb"></sgds-icon>
+      Toggle Theme
+    </sgds-button>
+  </div>
+
+  <section class="sgds:mb-2-xl">
+    <h2>Breakpoint Token Reference</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Syntax: <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:&lt;breakpoint&gt;:&lt;utility&gt;</code> (e.g. <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:sm:hidden</code>)</p>
+    <sgds-table>
+      <sgds-table-row>
+        <sgds-table-head>Prefix</sgds-table-head>
+        <sgds-table-head>CSS Variable</sgds-table-head>
+        <sgds-table-head>Min-width</sgds-table-head>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:xs:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-xs</code></sgds-table-cell>
+        <sgds-table-cell>320px</sgds-table-cell>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:sm:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-sm</code></sgds-table-cell>
+        <sgds-table-cell>512px</sgds-table-cell>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:md:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-md</code></sgds-table-cell>
+        <sgds-table-cell>768px</sgds-table-cell>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:lg:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-lg</code></sgds-table-cell>
+        <sgds-table-cell>1024px</sgds-table-cell>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:xl:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-xl</code></sgds-table-cell>
+        <sgds-table-cell>1280px</sgds-table-cell>
+      </sgds-table-row>
+      <sgds-table-row>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">sgds:2-xl:</code></sgds-table-cell>
+        <sgds-table-cell><code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm sgds:font-mono">--sgds-breakpoint-2-xl</code></sgds-table-cell>
+        <sgds-table-cell>1440px</sgds-table-cell>
+      </sgds-table-row>
+    </sgds-table>
+  </section>
+
+  <!-- Test 1: Background color changes at each breakpoint -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 1: Background Color Change per Breakpoint</h2>
+    <p class="sgds:mb-md sgds:text-subtle">This box changes background color at each breakpoint. Resize the viewport to verify.</p>
+    <div class="sgds:p-2-xl sgds:rounded-sm sgds:text-fixed-light sgds:font-weight-bold sgds:text-center sgds:bg-neutral-default sgds:xs:bg-primary-default sgds:sm:bg-accent-default sgds:md:bg-success-default sgds:lg:bg-warning-default sgds:xl:bg-danger-default sgds:2-xl:bg-info-default">
+      <p>Default: neutral (below 320px)</p>
+      <p>xs (320px+): primary (blue)</p>
+      <p>sm (512px+): accent (purple)</p>
+      <p>md (768px+): success (green)</p>
+      <p>lg (1024px+): warning (yellow)</p>
+      <p>xl (1280px+): danger (red)</p>
+      <p>2-xl (1440px+): info (teal)</p>
+    </div>
+  </section>
+
+  <!-- Test 2: Grid columns change at breakpoints -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 2: Responsive Grid Columns</h2>
+    <p class="sgds:mb-md sgds:text-subtle">1 col by default, 2 at sm, 3 at md, 4 at lg</p>
+    <div class="sgds:grid sgds:grid-cols-1 sgds:sm:grid-cols-2 sgds:md:grid-cols-3 sgds:lg:grid-cols-4 sgds:gap-md">
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm sgds:text-center">1</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm sgds:text-center">2</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm sgds:text-center">3</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm sgds:text-center">4</div>
+    </div>
+  </section>
+
+  <!-- Test 3: Display/visibility at breakpoints -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 3: Show/Hide at Breakpoints</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Each label appears only at its breakpoint and above.</p>
+    <div class="sgds:flex sgds:flex-wrap sgds:gap-sm">
+      <sgds-badge variant="primary" class="sgds:hidden sgds:xs:inline-flex">xs+ (320px)</sgds-badge>
+      <sgds-badge variant="accent" class="sgds:hidden sgds:sm:inline-flex">sm+ (512px)</sgds-badge>
+      <sgds-badge variant="success" class="sgds:hidden sgds:md:inline-flex">md+ (768px)</sgds-badge>
+      <sgds-badge variant="warning" class="sgds:hidden sgds:lg:inline-flex">lg+ (1024px)</sgds-badge>
+      <sgds-badge variant="danger" class="sgds:hidden sgds:xl:inline-flex">xl+ (1280px)</sgds-badge>
+      <sgds-badge variant="cyan" class="sgds:hidden sgds:2-xl:inline-flex">2-xl+ (1440px)</sgds-badge>
+    </div>
+  </section>
+
+  <!-- Test 4: Padding changes at breakpoints -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 4: Responsive Padding</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Padding increases at each breakpoint. Observe the inner spacing grow.</p>
+    <div class="sgds:bg-surface-raised sgds:rounded-sm sgds:border sgds:border-default">
+      <div class="sgds:p-xs sgds:sm:p-sm sgds:md:p-md sgds:lg:p-lg sgds:xl:p-xl sgds:2-xl:p-2-xl sgds:bg-primary-default sgds:text-fixed-light sgds:rounded-sm">
+        <p>p-xs by default</p>
+        <p>sm: p-sm | md: p-md | lg: p-lg | xl: p-xl | 2-xl: p-2-xl</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Test 5: Flex direction change -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 5: Responsive Flex Direction</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Stacks vertically on mobile, switches to horizontal row at md breakpoint.</p>
+    <div class="sgds:flex sgds:flex-col sgds:md:flex-row sgds:gap-md">
+      <div class="sgds:bg-primary-default sgds:p-lg sgds:text-fixed-light sgds:rounded-sm sgds:flex-1 sgds:text-center">Item A</div>
+      <div class="sgds:bg-accent-default sgds:p-lg sgds:text-fixed-light sgds:rounded-sm sgds:flex-1 sgds:text-center">Item B</div>
+      <div class="sgds:bg-success-default sgds:p-lg sgds:text-fixed-light sgds:rounded-sm sgds:flex-1 sgds:text-center">Item C</div>
+    </div>
+  </section>
+
+  <!-- Test 6: Responsive gap -->
+  <section class="sgds:mb-2-xl">
+    <h2>Test 6: Responsive Gap</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Gap between items increases at larger breakpoints.</p>
+    <div class="sgds:flex sgds:flex-wrap sgds:gap-2-xs sgds:sm:gap-xs sgds:md:gap-sm sgds:lg:gap-md sgds:xl:gap-xl">
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm">A</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm">B</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm">C</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm">D</div>
+      <div class="sgds:bg-primary-default sgds:p-md sgds:text-fixed-light sgds:rounded-sm">E</div>
+    </div>
+  </section>
+
+  <!-- Test 7: Hide/show with width utility -->
+  <section>
+    <h2>Test 7: Responsive Width</h2>
+    <p class="sgds:mb-md sgds:text-subtle">Sidebar takes full width on mobile, fixed width at lg+.</p>
+    <div class="sgds:flex sgds:flex-col sgds:lg:flex-row sgds:gap-md">
+      <aside class="sgds:w-full sgds:lg:w-[240px] sgds:bg-surface-raised sgds:p-md sgds:rounded-sm sgds:shrink-0">
+        Sidebar (full width &rarr; 240px at lg)
+      </aside>
+      <main class="sgds:flex-1 sgds:bg-primary-default sgds:text-fixed-light sgds:p-md sgds:rounded-sm">
+        Main content area
+      </main>
+    </div>
+  </section>
+
+  <script>
+    const nightBtn = document.querySelector("#night-theme");
+    nightBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      const html = document.querySelector("html");
+      if (html.classList.contains("sgds-night-theme")) {
+        html.classList.remove("sgds-night-theme");
+      } else {
+        html.classList.add("sgds-night-theme");
+      }
+    });
+  </script>
+</body>

--- a/skills/sgds-utilities/SKILL.md
+++ b/skills/sgds-utilities/SKILL.md
@@ -158,6 +158,7 @@ Not listed? See the full list at https://tailwindcss.com/docs/installation/frame
 | **Typography** | Font size, weight, line height, letter spacing, font family                      | No                   | [→ reference/typography.md](reference/typography.md)               |
 | **Visual**     | Opacity (`sgds:opacity-*`)                                                       | No                   | [→ reference/opacity.md](reference/opacity.md)                     |
 | **Visual**     | Elevation / box shadows (`sgds:shadow-*`, `sgds:shadow-edge-*`)                  | No                   | [→ reference/elevation.md](reference/elevation.md)                 |
+| **Responsive** | Breakpoint prefixes (`sgds:xs:`, `sgds:sm:`, `sgds:md:`, `sgds:lg:`, `sgds:xl:`, `sgds:2-xl:`) | No                   | [→ reference/breakpoint.md](reference/breakpoint.md)               |
 | **Patterns**   | Cross-category component patterns (card, alert, form, modal)                     | —                    | [→ reference/overview-patterns.md](reference/overview-patterns.md) |
 
 ---
@@ -174,6 +175,7 @@ Not listed? See the full list at https://tailwindcss.com/docs/installation/frame
 **Headings, body text, font sizes** → [reference/typography.md](reference/typography.md)
 **Transparent overlays, disabled states** → [reference/opacity.md](reference/opacity.md)
 **Card shadows, modal depth, sticky header/footer edges** → [reference/elevation.md](reference/elevation.md)
+**Responsive breakpoints, show/hide at viewport sizes** → [reference/breakpoint.md](reference/breakpoint.md)
 
 ---
 

--- a/skills/sgds-utilities/reference/breakpoint.md
+++ b/skills/sgds-utilities/reference/breakpoint.md
@@ -1,0 +1,51 @@
+# SGDS Breakpoint Utilities
+
+Helps developers apply responsive styles using SGDS breakpoint prefixes.
+
+## Syntax
+
+With the `sgds` Tailwind prefix, responsive variants go **after** the prefix:
+
+```
+sgds:<breakpoint>:<utility>
+```
+
+**Correct:** `sgds:sm:hidden`, `sgds:lg:flex-row`, `sgds:md:grid-cols-3`
+
+**Wrong:** `sm:sgds:hidden`, `lg:sgds:flex-row` (variant before prefix does NOT work)
+
+## Available Breakpoints
+
+| Prefix | CSS Variable | Min-width |
+|--------|-------------|-----------|
+| `sgds:xs:` | `--sgds-breakpoint-xs` | 320px |
+| `sgds:sm:` | `--sgds-breakpoint-sm` | 512px |
+| `sgds:md:` | `--sgds-breakpoint-md` | 768px |
+| `sgds:lg:` | `--sgds-breakpoint-lg` | 1024px |
+| `sgds:xl:` | `--sgds-breakpoint-xl` | 1280px |
+| `sgds:2-xl:` | `--sgds-breakpoint-2-xl` | 1440px |
+
+## How It Works
+
+Breakpoints are mobile-first (`min-width`). A class like `sgds:md:hidden` applies `display: none` at 768px and above.
+
+Stack breakpoints from smallest to largest — each overrides the previous:
+
+```html
+<div class="sgds:grid sgds:grid-cols-1 sgds:sm:grid-cols-2 sgds:lg:grid-cols-4">
+```
+
+## Common Patterns
+
+| Pattern | Example |
+|---------|---------|
+| Responsive columns | `sgds:grid sgds:grid-cols-1 sgds:sm:grid-cols-2 sgds:lg:grid-cols-4` |
+| Stack to row | `sgds:flex sgds:flex-col sgds:md:flex-row` |
+| Show at breakpoint | `sgds:hidden sgds:md:inline-flex` |
+| Hide at breakpoint | `sgds:block sgds:lg:hidden` |
+| Responsive padding | `sgds:p-sm sgds:md:p-lg sgds:xl:p-2-xl` |
+| Responsive gap | `sgds:gap-xs sgds:md:gap-md sgds:xl:gap-xl` |
+
+---
+
+**For AI Agents**: Always place the breakpoint variant after the `sgds:` prefix (`sgds:md:flex-row`), never before it. This is a Tailwind v4 prefix requirement. All standard Tailwind utilities support responsive variants with this syntax.

--- a/src/css/utility.css
+++ b/src/css/utility.css
@@ -243,19 +243,6 @@
   --border-width-form-default: var(--sgds-form-border-width-default);
   --border-width-form-thick: var(--sgds-form-border-width-thick);
 
-  /* Breakpoint */
-  --breakpoint-xs: var(--sgds-breakpoint-xs);
-  --breakpoint-sm: var(--sgds-breakpoint-sm);
-  --breakpoint-md: var(--sgds-breakpoint-md);
-  --breakpoint-lg: var(--sgds-breakpoint-lg);
-  --breakpoint-xl: var(--sgds-breakpoint-xl);
-  --breakpoint-2-xl: var(--sgds-breakpoint-2-xl);
-
-  /* Breakpoint with Sidebar */
-  --breakpoint-sbar-md: var(--sgds-breakpoint-sbar-md);
-  --breakpoint-sbar-lg: var(--sgds-breakpoint-sbar-lg);
-  --breakpoint-sbar-xl: var(--sgds-breakpoint-sbar-xl);
-  --breakpoint-sbar-2-xl: var(--sgds-breakpoint-sbar-2-xl);
 
   /* Font Family */
   --font-display: var(--sgds-font-family-brand);

--- a/stories/utilities/breakpoint.stories.js
+++ b/stories/utilities/breakpoint.stories.js
@@ -1,0 +1,153 @@
+import { html } from "lit";
+
+export default {
+  title: "Utilities/Breakpoint",
+  tags: ["!autodocs"]
+};
+
+const copyToClipboard = (token, buttonEl) => {
+  navigator.clipboard.writeText(token);
+  const icon = buttonEl.querySelector("sgds-icon");
+  icon.setAttribute("name", "check");
+  setTimeout(() => {
+    icon.setAttribute("name", "files");
+  }, 3000);
+};
+
+export const Breakpoints = () => html`
+  <p class="sgds:mb-md sgds:text-body-md">
+    Responsive breakpoints use the syntax
+    <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:&lt;breakpoint&gt;:&lt;utility&gt;</code>
+    (e.g. <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:sm:hidden</code>).
+  </p>
+  <sgds-table>
+    <sgds-table-row>
+      <sgds-table-head>Responsive Prefix</sgds-table-head>
+      <sgds-table-head>CSS Variable</sgds-table-head>
+      <sgds-table-head>Min-width</sgds-table-head>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:xs:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:xs:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-xs</code>
+      </sgds-table-cell>
+      <sgds-table-cell>320px</sgds-table-cell>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:sm:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:sm:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-sm</code>
+      </sgds-table-cell>
+      <sgds-table-cell>512px</sgds-table-cell>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:md:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:md:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-md</code>
+      </sgds-table-cell>
+      <sgds-table-cell>768px</sgds-table-cell>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:lg:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:lg:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-lg</code>
+      </sgds-table-cell>
+      <sgds-table-cell>1024px</sgds-table-cell>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:xl:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:xl:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-xl</code>
+      </sgds-table-cell>
+      <sgds-table-cell>1280px</sgds-table-cell>
+    </sgds-table-row>
+    <sgds-table-row>
+      <sgds-table-cell>
+        <div class="sgds:flex sgds:items-center sgds:gap-xs">
+          <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:2-xl:</code>
+          <button
+            class="sgds:flex sgds:items-center sgds:justify-center sgds:w-8 sgds:h-8 sgds:cursor-pointer sgds:opacity-60 sgds:bg-transparent sgds:border-none sgds:p-0"
+            @click="${e => copyToClipboard("sgds:2-xl:", e.target.closest("button"))}"
+            aria-label="Copy token"
+          >
+            <sgds-icon name="files"></sgds-icon>
+          </button>
+        </div>
+      </sgds-table-cell>
+      <sgds-table-cell>
+        <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">--sgds-breakpoint-2-xl</code>
+      </sgds-table-cell>
+      <sgds-table-cell>1440px</sgds-table-cell>
+    </sgds-table-row>
+  </sgds-table>
+
+  <div class="sgds:mb-2-xl"></div>
+  <h3 class="sgds:mb-md">Example: Responsive Visibility</h3>
+  <p class="sgds:mb-md sgds:text-body-md">
+    Each badge below appears only when the viewport reaches its breakpoint.
+    Resize the browser to see them appear or disappear.
+  </p>
+  <div class="sgds:flex sgds:flex-wrap sgds:gap-sm">
+    <sgds-badge variant="primary" class="sgds:hidden sgds:xs:inline-flex">xs+ (320px)</sgds-badge>
+    <sgds-badge variant="accent" class="sgds:hidden sgds:sm:inline-flex">sm+ (512px)</sgds-badge>
+    <sgds-badge variant="success" class="sgds:hidden sgds:md:inline-flex">md+ (768px)</sgds-badge>
+    <sgds-badge variant="warning" class="sgds:hidden sgds:lg:inline-flex">lg+ (1024px)</sgds-badge>
+    <sgds-badge variant="danger" class="sgds:hidden sgds:xl:inline-flex">xl+ (1280px)</sgds-badge>
+    <sgds-badge variant="cyan" class="sgds:hidden sgds:2-xl:inline-flex">2-xl+ (1440px)</sgds-badge>
+  </div>
+`;

--- a/stories/utilities/breakpoint.stories.js
+++ b/stories/utilities/breakpoint.stories.js
@@ -17,7 +17,9 @@ const copyToClipboard = (token, buttonEl) => {
 export const Breakpoints = () => html`
   <p class="sgds:mb-md sgds:text-body-md">
     Responsive breakpoints use the syntax
-    <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:&lt;breakpoint&gt;:&lt;utility&gt;</code>
+    <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm"
+      >sgds:&lt;breakpoint&gt;:&lt;utility&gt;</code
+    >
     (e.g. <code class="sgds:bg-surface-raised sgds:px-xs sgds:py-3-xs sgds:rounded-sm">sgds:sm:hidden</code>).
   </p>
   <sgds-table>
@@ -139,8 +141,8 @@ export const Breakpoints = () => html`
   <div class="sgds:mb-2-xl"></div>
   <h3 class="sgds:mb-md">Example: Responsive Visibility</h3>
   <p class="sgds:mb-md sgds:text-body-md">
-    Each badge below appears only when the viewport reaches its breakpoint.
-    Resize the browser to see them appear or disappear.
+    Each badge below appears only when the viewport reaches its breakpoint. Resize the browser to see them appear or
+    disappear.
   </p>
   <div class="sgds:flex sgds:flex-wrap sgds:gap-sm">
     <sgds-badge variant="primary" class="sgds:hidden sgds:xs:inline-flex">xs+ (320px)</sgds-badge>


### PR DESCRIPTION
## :open_book: Description

1) breakpoint utility not working because of the existing ones that pointing to css variables. only can do raw values on media queries 

2) Add misisng documentation on using breakpoint


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
