### PR TITLE
fix(modal): add margin to fullscreen mobile view for alignment

### DIFF
--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -22,6 +22,10 @@
   background-color: var(--sgds-surface-default);
 }
 
+:host([size="fullscreen"]) .modal-panel {
+  margin: var(--sgds-margin-xl) var(--sgds-margin-lg);
+}
+
 .modal {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## :open_book: Description

The alignment of fullscreen modal in mobile is off, the container fill the full viewport without the margin

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
