### PR TITLE
fix(system-banner): vertical center align icon on desktop [skip-cd][run-chromatic]

### DIFF
--- a/src/components/SystemBanner/system-banner-item.css
+++ b/src/components/SystemBanner/system-banner-item.css
@@ -100,4 +100,8 @@ slot[name="action"]::slotted(a) {
     -webkit-box-orient: vertical;
     max-height: calc(2 * var(--sgds-line-height-20, 20px)); /* 2 lines */
   }
+  /* Vertically center icon on desktop */
+  ::slotted(sgds-icon) {
+    align-self: center;
+  }
 }


### PR DESCRIPTION
## :open_book: Description
Icon is misaligned if banner item text is only a single line with a button in action slot. Center aligned icon would still be consistent with vertical align of badge on desktop. Alignment of icon on tablet and smaller is unchanged

Fixes #674

## :pencil2: Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## :test_tube: How Has This Been Tested?

No testing added

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
