### PR TITLE
fix(Badge): truncation is controlled by CSS not JS [run-chromatic]

### DIFF
--- a/src/components/Badge/badge.css
+++ b/src/components/Badge/badge.css
@@ -100,7 +100,7 @@ sgds-tooltip {
   line-height: var(--sgds-line-height-3-xs);
   height: var(--sgds-dimension-24, 24px);
   min-width: var(--sgds-dimension-24);
-  max-width: var(--sgds-dimension-192);
+  max-width: var(--sgds-dimension-192, 192px);
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -118,6 +118,9 @@ sgds-tooltip {
 
 .badge-label {
   padding: var(--sgds-padding-none) var(--sgds-padding-3-xs);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .badge-dismissible {
@@ -126,12 +129,6 @@ sgds-tooltip {
 
 .badge-dimissible sgds-close-button {
   --sgds-close-btn-border-radius: var(--sgds-border-radius-sm);
-}
-
-.badge.truncated .badge-label {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }
 
 slot::slotted(*) {

--- a/src/components/Badge/sgds-badge.ts
+++ b/src/components/Badge/sgds-badge.ts
@@ -97,17 +97,12 @@ export class SgdsBadge extends SgdsElement {
   }
 
   /**@internal */
-  @watch("text")
+  @watch("text", { waitUntilFirstUpdate: true })
   _handleTruncation() {
-    // checking of text height if its exceeding parent, it needs to be truncated
-    const badge = this.shadowRoot.querySelector(".badge");
-    const badgeLabel = this.shadowRoot.querySelector(".badge-label");
-
-    if (badge && badgeLabel) {
-      const labelHeight = badgeLabel.getBoundingClientRect().height;
-      const badgeHeight = badge.getBoundingClientRect().height;
-
-      this.truncated = labelHeight > badgeHeight;
+    // check scroll width if its exceeding parent, it reflects truncation has happened
+    const badgeLabel = this.shadowRoot?.querySelector(".badge-label");
+    if (badgeLabel) {
+      this.truncated = badgeLabel.scrollWidth > badgeLabel.clientWidth;
     }
   }
 
@@ -125,7 +120,6 @@ export class SgdsBadge extends SgdsElement {
         [`badge-dismissible`]: this.dismissible,
         badge: true,
         outlined: this.outlined,
-        truncated: this.truncated,
         "full-width": this.fullWidth
       })}"
       aria-hidden=${this.show ? "false" : "true"}

--- a/src/styles/form-text-control.css
+++ b/src/styles/form-text-control.css
@@ -51,6 +51,7 @@
   min-width: 0;
   width: 100%;
   color: var(--sgds-form-color-default);
+  font-family: var(--sgds-font-family-brand);
   font-size: var(--sgds-font-size-label-md);
   line-height: var(--sgds-line-height-xs);
 }

--- a/test/badge.test.ts
+++ b/test/badge.test.ts
@@ -129,27 +129,20 @@ describe("SgdsBadge component", () => {
 
     const tooltip = el.shadowRoot?.querySelector("sgds-tooltip");
     expect(tooltip).to.not.exist;
-    expect(el.querySelector(".truncated")).to.not.exist;
   });
 
-  it("should render with the 'truncated' class when badge content exceeds parent width", async () => {
-    const parentNode = document.createElement("div");
-    parentNode.style.width = "100px";
-
+  it("should render with the sgds-tooltip when badge content exceeds max width", async () => {
     const el = await fixture<SgdsBadge>(
-      html`<sgds-badge> A very long badge name without limitation of parent width </sgds-badge>`,
-      { parentNode }
+      html`<sgds-badge> A very long badge name without limitation of parent width </sgds-badge>`
     );
 
-    await elementUpdated(el);
+    await el.updateComplete;
 
     const badge = el.shadowRoot?.querySelector(".badge");
     expect(badge).to.exist;
 
     const tooltip = el.shadowRoot?.querySelector("sgds-tooltip");
-
     expect(tooltip).to.exist;
-    expect(tooltip?.querySelector(".truncated")).to.exist;
   });
 
   it("should not trigger sgds-hide when tooltip is hidden", async () => {
@@ -173,7 +166,6 @@ describe("SgdsBadge component", () => {
     const tooltip = el.shadowRoot?.querySelector("sgds-tooltip");
 
     expect(tooltip).to.exist;
-    expect(tooltip?.querySelector(".truncated")).to.exist;
 
     await sendMouse({ type: "move", position: [50, 50] });
     await el.updateComplete;


### PR DESCRIPTION
<img width="360" height="87" alt="Screenshot 2026-05-22 at 3 38 47 PM" src="https://github.com/user-attachments/assets/9d36de2f-332a-4ae9-a4b5-72f7741ce831" />

timing issue compliations in apps that have hydration mismatches because:
calculate whether truncate (false) 
 text prop gets from slot --> re-rendering. the re-rendering and the hydration complicates 

1) Since badge will truncate regardless 192px or limited by parent width , i  let truncation be handled by default by CSS only . 



2) tooltip logic remains determined by truncated state. 

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
