### PR TITLE
fix(Input): explicitly set form control fonts [run-chromatic]

### DIFF
--- a/src/styles/form-text-control.css
+++ b/src/styles/form-text-control.css
@@ -51,6 +51,7 @@
   min-width: 0;
   width: 100%;
   color: var(--sgds-form-color-default);
+  font-family: var(--sgds-font-family-brand);
   font-size: var(--sgds-font-size-label-md);
   line-height: var(--sgds-line-height-xs);
 }


### PR DESCRIPTION
## :open_book: Description

1. Set form control fonts 

Problem 
1) placeholder font and typiing font is inconsistent (Inter vs Arial) 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
