### PR TITLE
feat(Icon, Dropdown, Button): oobee testing support, new ariaLabel for Icon [run-chromatic]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1" async crossorigin="anonymous" integrity="sha384-agFBBBRTySU0P49PgQNK4GWlah0F112dd6Ol7WZPqeTOT9IjWGAfPHxo6YBauJvh"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1" async crossorigin="anonymous" integrity="sha384-axfN2gNM6IycM+ekHY24fCAfjQccHxRySFcqjFiARtogBDrw2L/lqFRppMFJCkva"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-5OKa7RaQpYeIsx/ZOXW2ttNUa7ftAEKXiWuSgFRmlXJUaJ1Bvf3etjlCw2qqjia8"></script>

--- a/playground/Button.html
+++ b/playground/Button.html
@@ -22,7 +22,7 @@
     <sgds-table-cell>brand</sgds-table-cell>
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
-    <sgds-table-cell><sgds-button>Primary</sgds-button></sgds-table-cell>
+    <sgds-table-cell><sgds-button ariaLabel="Primary">Primary</sgds-button></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
     <sgds-table-cell>outline</sgds-table-cell>
@@ -30,7 +30,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="outline">Outline</sgds-button></sgds-table-cell
+      ><sgds-button variant="outline" ariaLabel="Outline">Outline</sgds-button></sgds-table-cell
     >
   </sgds-table-row>
   <sgds-table-row>
@@ -39,7 +39,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="ghost">Ghost</sgds-button></sgds-table-cell
+      ><sgds-button variant="ghost" ariaLabel="Ghost">Ghost</sgds-button></sgds-table-cell
     >
   </sgds-table-row>
   <sgds-table-row>
@@ -48,7 +48,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="primary" tone="danger"
+      ><sgds-button variant="primary" tone="danger" ariaLabel="Primary"
         >Primary</sgds-button
       ></sgds-table-cell
     >
@@ -59,7 +59,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="outline" tone="danger"
+      ><sgds-button variant="outline" tone="danger" ariaLabel="Outline"
         >Outline</sgds-button
       ></sgds-table-cell
     >
@@ -70,7 +70,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="ghost" tone="danger"
+      ><sgds-button variant="ghost" tone="danger" ariaLabel="Ghost"
         >Ghost</sgds-button
       ></sgds-table-cell
     >
@@ -81,7 +81,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button variant="primary" tone="fixed-light"
+      ><sgds-button variant="primary" tone="fixed-light" ariaLabel="Primary"
         >Primary</sgds-button
       ></sgds-table-cell
     >
@@ -92,7 +92,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button variant="outline" tone="fixed-light"
+      ><sgds-button variant="outline" tone="fixed-light" ariaLabel="Outline"
         >Outline</sgds-button
       ></sgds-table-cell
     >
@@ -103,7 +103,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button variant="ghost" tone="fixed-light"
+      ><sgds-button variant="ghost" tone="fixed-light" ariaLabel="Ghost"
         >Ghost</sgds-button
       ></sgds-table-cell
     >
@@ -114,7 +114,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="primary" tone="neutral"
+      ><sgds-button variant="primary" tone="neutral" ariaLabel="Primary"
         >Primary</sgds-button
       ></sgds-table-cell
     >
@@ -125,7 +125,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="outline" tone="neutral"
+      ><sgds-button variant="outline" tone="neutral" ariaLabel="Outline"
         >Outline</sgds-button
       ></sgds-table-cell
     >
@@ -136,7 +136,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="ghost" tone="neutral"
+      ><sgds-button variant="ghost" tone="neutral" ariaLabel="Ghost"
         >Ghost</sgds-button
       ></sgds-table-cell
     >
@@ -147,7 +147,7 @@
     <sgds-table-cell>md</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button variant="danger"
+      ><sgds-button variant="danger" ariaLabel="Deprecated danger"
         >Deprecated Danger</sgds-button
       ></sgds-table-cell
     >
@@ -158,7 +158,7 @@
     <sgds-table-cell>xs</sgds-table-cell>
     <sgds-table-cell>false</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button size="xs">Extra Small</sgds-button></sgds-table-cell
+      ><sgds-button size="xs" ariaLabel="Extra small">Extra Small</sgds-button></sgds-table-cell
     >
   </sgds-table-row>
   <sgds-table-row>
@@ -166,7 +166,7 @@
     <sgds-table-cell>brand</sgds-table-cell>
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
-    <sgds-table-cell><sgds-button loading></sgds-button></sgds-table-cell>
+    <sgds-table-cell><sgds-button loading ariaLabel="Loading"></sgds-button></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
     <sgds-table-cell>primary</sgds-table-cell>
@@ -174,7 +174,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="danger"></sgds-button
+      ><sgds-button loading tone="danger" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -183,7 +183,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="neutral"></sgds-button
+      ><sgds-button loading tone="neutral" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -192,7 +192,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button loading tone="fixed-light"></sgds-button
+      ><sgds-button loading tone="fixed-light" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -201,7 +201,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading variant="ghost"></sgds-button
+      ><sgds-button loading variant="ghost" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -210,7 +210,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="danger" variant="ghost"></sgds-button
+      ><sgds-button loading tone="danger" variant="ghost" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -219,7 +219,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="neutral" variant="ghost"></sgds-button
+      ><sgds-button loading tone="neutral" variant="ghost" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -228,7 +228,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button loading tone="fixed-light" variant="ghost"></sgds-button
+      ><sgds-button loading tone="fixed-light" variant="ghost" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -237,7 +237,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading variant="outline"></sgds-button
+      ><sgds-button loading variant="outline" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -246,7 +246,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="danger" variant="outline"></sgds-button
+      ><sgds-button loading tone="danger" variant="outline" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -255,7 +255,7 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell
-      ><sgds-button loading tone="neutral" variant="outline"></sgds-button
+      ><sgds-button loading tone="neutral" variant="outline" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
   <sgds-table-row>
@@ -264,13 +264,13 @@
     <sgds-table-cell>loading</sgds-table-cell>
     <sgds-table-cell>true</sgds-table-cell>
     <sgds-table-cell class="fixed-light-cell"
-      ><sgds-button loading tone="fixed-light" variant="outline"></sgds-button
+      ><sgds-button loading tone="fixed-light" variant="outline" ariaLabel="Loading"></sgds-button
     ></sgds-table-cell>
   </sgds-table-row>
 </sgds-table>
 
-<sgds-button disabled>disabled</sgds-button>
-<sgds-button loading id="test-loading-disabled">Loading</sgds-button>
+<sgds-button disabled ariaLabel="Disabled">disabled</sgds-button>
+<sgds-button loading id="test-loading-disabled" ariaLabel="Loading">Loading</sgds-button>
 
 
 <script>

--- a/playground/Dropdown.html
+++ b/playground/Dropdown.html
@@ -9,7 +9,7 @@
   there are ton
   <br>
 <sgds-dropdown id="dropdown-select" menuIsOpen disabled>
-  <sgds-button slot="toggler" role="button">
+  <sgds-button slot="toggler" ariaLabel="Dropdown">
     Dropdown
     <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
   </sgds-button>
@@ -41,7 +41,7 @@
 <br>
 <br>
 <sgds-dropdown id="dropdown-select" menuIsOpen>
-  <sgds-button slot="toggler" role="button">
+  <sgds-button slot="toggler" ariaLabel="Dropdown">
     Dropdown
     <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
   </sgds-button>

--- a/playground/Icon.html
+++ b/playground/Icon.html
@@ -38,31 +38,31 @@
         <h2>Sizes</h2>
         <div class="icon-grid">
           <div class="icon-item">
-            <sgds-icon name="announcement" size="xs"></sgds-icon>
+            <sgds-icon name="announcement" size="xs" ariaLabel="Announcement"></sgds-icon>
             <span>xs</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="sm"></sgds-icon>
+            <sgds-icon name="announcement" size="sm" ariaLabel="Announcement"></sgds-icon>
             <span>sm</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="md"></sgds-icon>
+            <sgds-icon name="announcement" size="md" ariaLabel="Announcement"></sgds-icon>
             <span>md</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="lg"></sgds-icon>
+            <sgds-icon name="announcement" size="lg" ariaLabel="Announcement"></sgds-icon>
             <span>lg</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="xl"></sgds-icon>
+            <sgds-icon name="announcement" size="xl" ariaLabel="Announcement"></sgds-icon>
             <span>xl</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="2-xl"></sgds-icon>
+            <sgds-icon name="announcement" size="2-xl" ariaLabel="Announcement"></sgds-icon>
             <span>2-xl</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="announcement" size="3-xl"></sgds-icon>
+            <sgds-icon name="announcement" size="3-xl" ariaLabel="Announcement"></sgds-icon>
             <span>3-xl</span>
           </div>
         </div>
@@ -72,35 +72,35 @@
         <h2>Sample Icons</h2>
         <div class="icon-grid">
           <div class="icon-item">
-            <sgds-icon name="arrow-right" size="lg"></sgds-icon>
+            <sgds-icon name="arrow-right" size="lg" ariaLabel="Arrow-right"></sgds-icon>
             <span>arrow-right</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="check-circle" size="lg"></sgds-icon>
+            <sgds-icon name="check-circle" size="lg" ariaLabel="Check-circle"></sgds-icon>
             <span>check-circle</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="exclamation-triangle" size="lg"></sgds-icon>
+            <sgds-icon name="exclamation-triangle" size="lg" ariaLabel="Exclamation-triangle"></sgds-icon>
             <span>exclamation-triangle</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="gear" size="lg"></sgds-icon>
+            <sgds-icon name="gear" size="lg" ariaLabel="Gear"></sgds-icon>
             <span>gear</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="search" size="lg"></sgds-icon>
+            <sgds-icon name="search" size="lg" ariaLabel="Search"></sgds-icon>
             <span>search</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="star" size="lg"></sgds-icon>
+            <sgds-icon name="star" size="lg" ariaLabel="Star"></sgds-icon>
             <span>star</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="download" size="lg"></sgds-icon>
+            <sgds-icon name="download" size="lg" ariaLabel="Download"></sgds-icon>
             <span>download</span>
           </div>
           <div class="icon-item">
-            <sgds-icon name="person" size="lg"></sgds-icon>
+            <sgds-icon name="person" size="lg" ariaLabel="Person"></sgds-icon>
             <span>person</span>
           </div>
         </div>

--- a/playground/Tooltip.html
+++ b/playground/Tooltip.html
@@ -26,19 +26,19 @@
         <h2>Placements</h2>
         <div class="tooltip-row">
           <sgds-tooltip content="Top tooltip" placement="top">
-            <sgds-button>Top</sgds-button>
+            <sgds-button ariaLabel="Top">Top</sgds-button>
           </sgds-tooltip>
 
           <sgds-tooltip content="Bottom tooltip" placement="bottom">
-            <sgds-button>Bottom</sgds-button>
+            <sgds-button ariaLabel="Bottom">Bottom</sgds-button>
           </sgds-tooltip>
 
           <sgds-tooltip content="Left tooltip" placement="left">
-            <sgds-button>Left</sgds-button>
+            <sgds-button ariaLabel="Left">Left</sgds-button>
           </sgds-tooltip>
 
           <sgds-tooltip content="Right tooltip" placement="right">
-            <sgds-button>Right</sgds-button>
+            <sgds-button ariaLabel="Right">Right</sgds-button>
           </sgds-tooltip>
         </div>
       </div>
@@ -46,21 +46,21 @@
       <div>
         <h2>Hover Trigger (default)</h2>
         <sgds-tooltip content="Hover to see this" trigger="hover">
-          <sgds-button>Hover me</sgds-button>
+          <sgds-button ariaLabel="Hover me">Hover me</sgds-button>
         </sgds-tooltip>
       </div>
 
       <div>
         <h2>Click Trigger</h2>
         <sgds-tooltip content="Clicked!" trigger="click">
-          <sgds-button>Click me</sgds-button>
+          <sgds-button ariaLabel="Click me">Click me</sgds-button>
         </sgds-tooltip>
       </div>
 
       <div>
         <h2>Focus Trigger</h2>
         <sgds-tooltip content="Focused!" trigger="focus">
-          <sgds-button>Focus me</sgds-button>
+          <sgds-button ariaLabel="Focus me">Focus me</sgds-button>
         </sgds-tooltip>
       </div>
     </div>

--- a/skills/sgds-components/reference/button.md
+++ b/skills/sgds-components/reference/button.md
@@ -122,7 +122,7 @@ For framework-specific event syntax (React 19+ vs ≤18, Vue, Angular), see the 
 
 ---
 
-**For AI agents**: Default to `<sgds-button>` for all interactive buttons — do not suggest `<button>` with raw utility classes. Use `variant="danger" tone="danger"` for destructive actions. Set `type="submit"` for form submission buttons. For icon-only buttons, prefer `<sgds-icon-button>` and mention it to the user.
+**For AI agents**: Default to `<sgds-button>` for all interactive buttons — do not suggest `<button>` with raw utility classes. **Always add `ariaLabel`** to every `<sgds-button>` — this is required for accessibility (value should match the visible label text). Use `variant="danger" tone="danger"` for destructive actions. Set `type="submit"` for form submission buttons. For icon-only buttons, prefer `<sgds-icon-button>` and mention it to the user.
 
 # Button Component — Attributes Reference
 

--- a/skills/sgds-components/reference/dropdown.md
+++ b/skills/sgds-components/reference/dropdown.md
@@ -34,7 +34,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 ## Component Composition
 
-**`toggler` slot (`<sgds-dropdown>`)** — the element that opens the menu. Standard pattern: `<sgds-button slot="toggler" role="button">` with a label and `<sgds-icon name="chevron-down" slot="rightIcon">`. Always provide toggler content — without it, the dropdown has no visible trigger.
+**`toggler` slot (`<sgds-dropdown>`)** — the element that opens the menu. Standard pattern: `<sgds-button slot="toggler">` with a label and `<sgds-icon name="chevron-down" slot="rightIcon">`. Always provide toggler content — without it, the dropdown has no visible trigger.
 
 **Default slot (`<sgds-dropdown>`)** — only `<sgds-dropdown-item>` elements. Do not place raw `<a>` or `<li>` tags directly.
 
@@ -80,7 +80,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 ```html
 <!-- Basic navigation dropdown -->
 <sgds-dropdown>
-  <sgds-button slot="toggler" role="button">
+  <sgds-button slot="toggler" ariaLabel="Options">
     Options
     <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
   </sgds-button>
@@ -91,7 +91,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 <!-- Action dropdown (no navigation) -->
 <sgds-dropdown>
-  <sgds-button slot="toggler" role="button">
+  <sgds-button slot="toggler" ariaLabel="Actions">
     Actions <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
   </sgds-button>
   <sgds-dropdown-item>View</sgds-dropdown-item>
@@ -101,7 +101,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 <!-- React to selection -->
 <sgds-dropdown id="my-dropdown">
-  <sgds-button slot="toggler" role="button">Choose <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon></sgds-button>
+  <sgds-button slot="toggler" ariaLabel="Choose">Choose <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon></sgds-button>
   <sgds-dropdown-item>Option A</sgds-dropdown-item>
   <sgds-dropdown-item>Option B</sgds-dropdown-item>
   <sgds-dropdown-item>Option C</sgds-dropdown-item>
@@ -115,7 +115,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 <!-- Dropdown opens upward -->
 <sgds-dropdown drop="up">
-  <sgds-button slot="toggler" role="button">Menu above <sgds-icon name="chevron-up" slot="rightIcon"></sgds-icon></sgds-button>
+  <sgds-button slot="toggler" ariaLabel="Menu above">Menu above <sgds-icon name="chevron-up" slot="rightIcon"></sgds-icon></sgds-button>
   <sgds-dropdown-item>Item 1</sgds-dropdown-item>
   <sgds-dropdown-item>Item 2</sgds-dropdown-item>
 </sgds-dropdown>
@@ -171,7 +171,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 **For AI agents**:
 1. Always place the toggler element in the `toggler` slot — it can be any element but `<sgds-button>` is typical.
-2. For navigation, slot an `<a>` tag inside `<sgds-dropdown-item>`. For actions (no navigation), slot plain text directly.
-3. `sgds-select` fires on `<sgds-dropdown>` when any item is clicked — `event.detail.item` is the clicked `<sgds-dropdown-item>`.
-4. Disabled items do not fire `sgds-select`.
-5. For a three-dot overflow menu, use `<sgds-overflow-menu>` which is a pre-built convenience wrapper.
+2. **Always add `ariaLabel`** to the `<sgds-button>` toggler — this is required for accessibility.
+3. For navigation, slot an `<a>` tag inside `<sgds-dropdown-item>`. For actions (no navigation), slot plain text directly.
+4. `sgds-select` fires on `<sgds-dropdown>` when any item is clicked — `event.detail.item` is the clicked `<sgds-dropdown-item>`.
+5. Disabled items do not fire `sgds-select`.
+6. For a three-dot overflow menu, use `<sgds-overflow-menu>` which is a pre-built convenience wrapper.

--- a/skills/sgds-components/reference/icon.md
+++ b/skills/sgds-components/reference/icon.md
@@ -55,22 +55,28 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 > When used inside `<sgds-link>`, icon sizing is managed automatically — do not set `size` manually.
 
 ```html
-<!-- Basic icon -->
-<sgds-icon name="announcement"></sgds-icon>
+<!-- Standalone informative icon (add ariaLabel) -->
+<sgds-icon name="announcement" ariaLabel="Announcement"></sgds-icon>
 
 <!-- Specific size -->
-<sgds-icon name="arrow-right" size="sm"></sgds-icon>
+<sgds-icon name="arrow-right" size="sm" ariaLabel="Arrow right"></sgds-icon>
 
-<!-- Large decorative icon -->
-<sgds-icon name="star" size="xl"></sgds-icon>
+<!-- Large standalone icon -->
+<sgds-icon name="star" size="xl" ariaLabel="Star"></sgds-icon>
 
-<!-- Icon inside a link (size managed automatically) -->
+<!-- Icon inside a link (decorative - no ariaLabel needed, parent provides context) -->
 <sgds-link>
   <a href="#">
     <sgds-icon name="arrow-right"></sgds-icon>
     Next page
   </a>
 </sgds-link>
+
+<!-- Icon inside a button (decorative - no ariaLabel needed) -->
+<sgds-button ariaLabel="Download">
+  <sgds-icon name="download" slot="leftIcon"></sgds-icon>
+  Download
+</sgds-button>
 ```
 
 ## API Summary
@@ -79,6 +85,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 |---|---|---|---|
 | `name` | string | — | **Required.** Icon name from the SGDS icon registry |
 | `size` | `xs \| sm \| md \| lg \| xl \| 2-xl \| 3-xl` | `lg` | Rendered size of the icon |
+| `ariaLabel` | string | — | Accessible label. When set, the SVG is informative (announces to screen readers). When omitted, the SVG is decorative (`aria-hidden="true"`) |
 
 ## Slots
 
@@ -156,4 +163,5 @@ xcircle, xcircle-fill, youtube, zoom-in, zoom-out
 4. Icons render from the internal SGDS SVG registry — they are not `<img>` tags and do not accept `src`.
 5. Default size is `lg` — if a user needs a smaller inline icon, explicitly set `size="sm"` or `size="md"`.
 6. Inside `<sgds-link>`, `<sgds-badge>`, and similar components, icon size is managed automatically; do not override it with `size`.
-7. There are no slots, events, or public methods on this component.
+7. **Accessibility**: by default, the SVG is decorative (`aria-hidden="true"`). When the icon IS the content (standalone, no surrounding text label), add `ariaLabel` to make it informative. When used inside a labelled parent (e.g. `<sgds-button>`, `<sgds-icon-button>`), omit `ariaLabel` — the parent provides the accessible name.
+8. There are no slots, events, or public methods on this component.

--- a/skills/sgds-components/reference/tooltip.md
+++ b/skills/sgds-components/reference/tooltip.md
@@ -60,12 +60,12 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 ```html
 <!-- Basic tooltip on an icon -->
 <sgds-tooltip content="More information about this field" placement="bottom">
-  <sgds-icon name="info-circle" tabindex="0"></sgds-icon>
+  <sgds-icon name="info-circle" ariaLabel="Information" tabindex="0"></sgds-icon>
 </sgds-tooltip>
 
 <!-- Tooltip triggered only on click -->
 <sgds-tooltip content="Copied to clipboard!" trigger="click" placement="top">
-  <sgds-button>Copy</sgds-button>
+  <sgds-button ariaLabel="Copy">Copy</sgds-button>
 </sgds-tooltip>
 
 <!-- Tooltip with focus trigger only (keyboard accessible) -->

--- a/src/components/Icon/sgds-icon.ts
+++ b/src/components/Icon/sgds-icon.ts
@@ -16,6 +16,9 @@ export class SgdsIcon extends SgdsElement {
   /** Specifies a small, medium or large icon, the size is medium by default. */
   @property({ type: String, reflect: true }) size: "xs" | "sm" | "md" | "lg" | "xl" | "2-xl" | "3-xl" = "lg";
 
+  /** An accessible label for the icon. When set, the SVG is treated as informative. When omitted, the SVG is marked as decorative with aria-hidden="true". */
+  @property({ type: String }) ariaLabel: string;
+
   private _getIconByName(name: string) {
     if (!name) return;
 
@@ -27,6 +30,19 @@ export class SgdsIcon extends SgdsElement {
     }
 
     return svg;
+  }
+
+  updated() {
+    const svg = this.shadowRoot?.querySelector("svg");
+    if (!svg) return;
+
+    if (this.ariaLabel) {
+      svg.removeAttribute("aria-hidden");
+      svg.setAttribute("aria-label", this.ariaLabel);
+    } else {
+      svg.removeAttribute("aria-label");
+      svg.setAttribute("aria-hidden", "true");
+    }
   }
 
   render() {

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -35,8 +35,12 @@ const ToneTemplate = args => {
         <sgds-button tone="neutral" variant="ghost" ariaLabel="Neutral Ghost">Neutral Ghost</sgds-button>
       </div>
       <div class="d-flex-row" style="padding: 12px; background-color: #333;">
-        <sgds-button tone="fixed-light" variant="primary" ariaLabel="Fixed Light Primary">Fixed Light Primary</sgds-button>
-        <sgds-button tone="fixed-light" variant="outline" ariaLabel="Fixed Light Outline">Fixed Light Outline</sgds-button>
+        <sgds-button tone="fixed-light" variant="primary" ariaLabel="Fixed Light Primary"
+          >Fixed Light Primary</sgds-button
+        >
+        <sgds-button tone="fixed-light" variant="outline" ariaLabel="Fixed Light Outline"
+          >Fixed Light Outline</sgds-button
+        >
         <sgds-button tone="fixed-light" variant="ghost" ariaLabel="Fixed Light Ghost">Fixed Light Ghost</sgds-button>
       </div>
     </div>
@@ -110,7 +114,9 @@ export const Disabled = {
 
 export const ButtonWithIcon = {
   render: () => html`
-    <sgds-button ariaLabel="Leading icon"><sgds-icon name="placeholder" slot="leftIcon"></sgds-icon>Leading icon</sgds-button>
+    <sgds-button ariaLabel="Leading icon"
+      ><sgds-icon name="placeholder" slot="leftIcon"></sgds-icon>Leading icon</sgds-button
+    >
     <sgds-button ariaLabel="Trailing icon">
       <sgds-icon name="placeholder" slot="rightIcon"></sgds-icon>
       Trailing icon

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -2,10 +2,10 @@ import { html } from "lit";
 
 const VariantTemplate = args => {
   return html`
-    <sgds-button variant="primary">Primary button</sgds-button>
-    <sgds-button variant="outline">Outline button</sgds-button>
-    <sgds-button variant="danger">Danger button</sgds-button>
-    <sgds-button variant="ghost">Ghost button</sgds-button>
+    <sgds-button variant="primary" ariaLabel="Primary button">Primary button</sgds-button>
+    <sgds-button variant="outline" ariaLabel="Outline button">Outline button</sgds-button>
+    <sgds-button variant="danger" ariaLabel="Danger button">Danger button</sgds-button>
+    <sgds-button variant="ghost" ariaLabel="Ghost button">Ghost button</sgds-button>
   `;
 };
 
@@ -20,24 +20,24 @@ const ToneTemplate = args => {
   return html`
     <div class="d-flex-column">
       <div class="d-flex-row">
-        <sgds-button tone="brand" variant="primary">Brand Primary</sgds-button>
-        <sgds-button tone="brand" variant="outline">Brand Outline</sgds-button>
-        <sgds-button tone="brand" variant="ghost">Brand Ghost</sgds-button>
+        <sgds-button tone="brand" variant="primary" ariaLabel="Brand Primary">Brand Primary</sgds-button>
+        <sgds-button tone="brand" variant="outline" ariaLabel="Brand Outline">Brand Outline</sgds-button>
+        <sgds-button tone="brand" variant="ghost" ariaLabel="Brand Ghost">Brand Ghost</sgds-button>
       </div>
       <div class="d-flex-row">
-        <sgds-button tone="danger" variant="primary">Danger Primary</sgds-button>
-        <sgds-button tone="danger" variant="outline">Danger Outline</sgds-button>
-        <sgds-button tone="danger" variant="ghost">Danger Ghost</sgds-button>
+        <sgds-button tone="danger" variant="primary" ariaLabel="Danger Primary">Danger Primary</sgds-button>
+        <sgds-button tone="danger" variant="outline" ariaLabel="Danger Outline">Danger Outline</sgds-button>
+        <sgds-button tone="danger" variant="ghost" ariaLabel="Danger Ghost">Danger Ghost</sgds-button>
       </div>
       <div class="d-flex-row">
-        <sgds-button tone="neutral" variant="primary">Neutral Primary</sgds-button>
-        <sgds-button tone="neutral" variant="outline">Neutral Outline</sgds-button>
-        <sgds-button tone="neutral" variant="ghost">Neutral Ghost</sgds-button>
+        <sgds-button tone="neutral" variant="primary" ariaLabel="Neutral Primary">Neutral Primary</sgds-button>
+        <sgds-button tone="neutral" variant="outline" ariaLabel="Neutral Outline">Neutral Outline</sgds-button>
+        <sgds-button tone="neutral" variant="ghost" ariaLabel="Neutral Ghost">Neutral Ghost</sgds-button>
       </div>
       <div class="d-flex-row" style="padding: 12px; background-color: #333;">
-        <sgds-button tone="fixed-light" variant="primary">Fixed Light Primary</sgds-button>
-        <sgds-button tone="fixed-light" variant="outline">Fixed Light Outline</sgds-button>
-        <sgds-button tone="fixed-light" variant="ghost">Fixed Light Ghost</sgds-button>
+        <sgds-button tone="fixed-light" variant="primary" ariaLabel="Fixed Light Primary">Fixed Light Primary</sgds-button>
+        <sgds-button tone="fixed-light" variant="outline" ariaLabel="Fixed Light Outline">Fixed Light Outline</sgds-button>
+        <sgds-button tone="fixed-light" variant="ghost" ariaLabel="Fixed Light Ghost">Fixed Light Ghost</sgds-button>
       </div>
     </div>
   `;
@@ -52,7 +52,7 @@ export const Tone = {
 };
 
 const FullWidthTemplate = () => {
-  return html`<sgds-button fullWidth>Full width button</sgds-button>`;
+  return html`<sgds-button fullWidth ariaLabel="Full width button">Full width button</sgds-button>`;
 };
 
 export const FullWidth = {
@@ -64,10 +64,10 @@ export const FullWidth = {
 };
 
 const SizeTemplate = () => {
-  return html` <sgds-button size="xs"> extra small button </sgds-button>
-    <sgds-button size="sm"> small button </sgds-button>
-    <sgds-button> medium button </sgds-button>
-    <sgds-button size="lg"> large button </sgds-button>`;
+  return html` <sgds-button size="xs" ariaLabel="Extra small button"> Extra small button </sgds-button>
+    <sgds-button size="sm" ariaLabel="Small button"> Small button </sgds-button>
+    <sgds-button ariaLabel="Medium button"> Medium button </sgds-button>
+    <sgds-button size="lg" ariaLabel="Large button"> Large button </sgds-button>`;
 };
 
 export const Sizes = {
@@ -80,10 +80,10 @@ export const Sizes = {
 
 const ActiveTemplate = () => {
   return html`
-    <sgds-button variant="primary" active> Hover / Active </sgds-button>
-    <sgds-button variant="outline" active> Hover / Active </sgds-button>
-    <sgds-button variant="danger" active> Hover / Active </sgds-button>
-    <sgds-button variant="ghost" active> Hover / Active </sgds-button>
+    <sgds-button variant="primary" active ariaLabel="Hover / Active"> Hover / Active </sgds-button>
+    <sgds-button variant="outline" active ariaLabel="Hover / Active"> Hover / Active </sgds-button>
+    <sgds-button variant="danger" active ariaLabel="Hover / Active"> Hover / Active </sgds-button>
+    <sgds-button variant="ghost" active ariaLabel="Hover / Active"> Hover / Active </sgds-button>
   `;
 };
 
@@ -97,10 +97,10 @@ export const Active = {
 
 export const Disabled = {
   render: () => html`
-    <sgds-button variant="primary" disabled> Disabled </sgds-button>
-    <sgds-button variant="outline" disabled> Disabled </sgds-button>
-    <sgds-button variant="ghost" disabled> Disabled </sgds-button>
-    <sgds-button variant="danger" disabled> Disabled </sgds-button>
+    <sgds-button variant="primary" disabled ariaLabel="Disabled"> Disabled </sgds-button>
+    <sgds-button variant="outline" disabled ariaLabel="Disabled"> Disabled </sgds-button>
+    <sgds-button variant="ghost" disabled ariaLabel="Disabled"> Disabled </sgds-button>
+    <sgds-button variant="danger" disabled ariaLabel="Disabled"> Disabled </sgds-button>
   `,
   name: "Disabled state",
   args: {},
@@ -110,8 +110,8 @@ export const Disabled = {
 
 export const ButtonWithIcon = {
   render: () => html`
-    <sgds-button><sgds-icon name="placeholder" slot="leftIcon"></sgds-icon>Leading icon</sgds-button>
-    <sgds-button>
+    <sgds-button ariaLabel="Leading icon"><sgds-icon name="placeholder" slot="leftIcon"></sgds-icon>Leading icon</sgds-button>
+    <sgds-button ariaLabel="Trailing icon">
       <sgds-icon name="placeholder" slot="rightIcon"></sgds-icon>
       Trailing icon
     </sgds-button>
@@ -126,24 +126,24 @@ export const Loading = {
   render: () => html`
     <div class="d-flex-column">
       <div class="d-flex-row">
-        <sgds-button variant="primary" loading> Loading... </sgds-button>
-        <sgds-button variant="outline" loading> Loading... </sgds-button>
-        <sgds-button variant="ghost" loading> Loading... </sgds-button>
+        <sgds-button variant="primary" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="outline" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="ghost" loading ariaLabel="Loading"> Loading... </sgds-button>
       </div>
       <div class="d-flex-row">
-        <sgds-button variant="primary" tone="danger" loading> Loading... </sgds-button>
-        <sgds-button variant="outline" tone="danger" loading> Loading... </sgds-button>
-        <sgds-button variant="ghost" tone="danger" loading> Loading... </sgds-button>
+        <sgds-button variant="primary" tone="danger" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="outline" tone="danger" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="ghost" tone="danger" loading ariaLabel="Loading"> Loading... </sgds-button>
       </div>
       <div class="d-flex-row">
-        <sgds-button variant="primary" tone="neutral" loading> Loading... </sgds-button>
-        <sgds-button variant="outline" tone="neutral" loading> Loading... </sgds-button>
-        <sgds-button variant="ghost" tone="neutral" loading> Loading... </sgds-button>
+        <sgds-button variant="primary" tone="neutral" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="outline" tone="neutral" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="ghost" tone="neutral" loading ariaLabel="Loading"> Loading... </sgds-button>
       </div>
       <div class="d-flex-row" style="padding: 12px; background-color: #333;">
-        <sgds-button variant="primary" tone="fixed-light" loading> Loading... </sgds-button>
-        <sgds-button variant="outline" tone="fixed-light" loading> Loading... </sgds-button>
-        <sgds-button variant="ghost" tone="fixed-light" loading> Loading... </sgds-button>
+        <sgds-button variant="primary" tone="fixed-light" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="outline" tone="fixed-light" loading ariaLabel="Loading"> Loading... </sgds-button>
+        <sgds-button variant="ghost" tone="fixed-light" loading ariaLabel="Loading"> Loading... </sgds-button>
       </div>
     </div>
   `,

--- a/stories/component-templates/Button/basic.js
+++ b/stories/component-templates/Button/basic.js
@@ -18,6 +18,7 @@ export const Template = args =>
       ?formNoValidate=${args.formNoValidate}
       formTarget=${ifDefined(args.formTarget)}
       ?loading=${args.loading}
+      ariaLabel="Button"
     >
       Button
     </sgds-button>

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -3,7 +3,7 @@ import { html } from "lit";
 const SgdsSelectCloseTemplate = args => {
   return html`
     <sgds-dropdown close="default">
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Default Close">
         Default Close
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>
@@ -13,7 +13,7 @@ const SgdsSelectCloseTemplate = args => {
     </sgds-dropdown>
     <br />
     <sgds-dropdown close="outside">
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Close Outside">
         Close Outside
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>
@@ -23,7 +23,7 @@ const SgdsSelectCloseTemplate = args => {
     </sgds-dropdown>
     <br />
     <sgds-dropdown close="inside">
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Close Inside">
         Close Inside
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>
@@ -47,7 +47,7 @@ export const SgdsSelectClose = {
 const SgdsSelectEventTemplate = args => {
   return html`
     <sgds-dropdown id="select-event-dropdown">
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Dynamic Text">
         <span id="select-toggler-text">Dynamic Text</span>
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>
@@ -81,7 +81,7 @@ export const SgdsSelectEvent = {
 const SgdsSelectDropdownItemTemplate = args => {
   return html`
     <sgds-dropdown close="outside">
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Dropdown">
         Dropdown
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>

--- a/stories/component-templates/Dropdown/basic.js
+++ b/stories/component-templates/Dropdown/basic.js
@@ -24,7 +24,7 @@ export const Template = ({
       ?menuIsOpen=${menuIsOpen}
       ?disabled=${disabled}
     >
-      <sgds-button slot="toggler" role="button" variant="primary" tone="brand">
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Dropdown">
         Dropdown
         <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
       </sgds-button>

--- a/stories/component-templates/Icon/basic.js
+++ b/stories/component-templates/Icon/basic.js
@@ -6,7 +6,7 @@ export const Template = args => {
     ${Object.keys(iconRegistry).map(
       i => html`
         <sgds-tooltip content=${i}>
-          <sgds-icon name=${i} size=${args.size}></sgds-icon>
+          <sgds-icon name=${i} size=${args.size} ariaLabel=${i}></sgds-icon>
         </sgds-tooltip>
       `
     )}
@@ -19,395 +19,396 @@ export const parameters = {
   docs: {
     source: {
       code: `
-          <sgds-icon name="announcement"></sgds-icon>
+          <!-- Standalone informative icon (add ariaLabel) -->
+          <sgds-icon name="announcement" ariaLabel="Announcement"></sgds-icon>
 
-          <sgds-icon name="archive"></sgds-icon>
-      
-          <sgds-icon name="arrow-bar-down"></sgds-icon>
-      
-          <sgds-icon name="arrow-bar-left"></sgds-icon>
-      
-          <sgds-icon name="arrow-bar-right"></sgds-icon>
-      
-          <sgds-icon name="arrow-bar-up"></sgds-icon>
-      
-          <sgds-icon name="arrow-circle-down"></sgds-icon>
-      
-          <sgds-icon name="arrow-circle-left"></sgds-icon>
-      
-          <sgds-icon name="arrow-circle-right"></sgds-icon>
-      
-          <sgds-icon name="arrow-circle-up"></sgds-icon>
-      
-          <sgds-icon name="arrow-clockwise"></sgds-icon>
-      
-          <sgds-icon name="arrow-down"></sgds-icon>
-      
-          <sgds-icon name="arrow-left"></sgds-icon>
-      
-          <sgds-icon name="arrow-repeat"></sgds-icon>
-      
-          <sgds-icon name="arrow-right"></sgds-icon>
-      
-          <sgds-icon name="arrow-square-down"></sgds-icon>
-      
-          <sgds-icon name="arrow-square-left"></sgds-icon>
-      
-          <sgds-icon name="arrow-square-right"></sgds-icon>
-      
-          <sgds-icon name="arrow-square-up"></sgds-icon>
-      
-          <sgds-icon name="arrow-up"></sgds-icon>
-      
-          <sgds-icon name="bank-fill"></sgds-icon>
-      
-          <sgds-icon name="bell-slash"></sgds-icon>
-          
-          <sgds-icon name="bell"></sgds-icon>
-      
-          <sgds-icon name="bi-funnel"></sgds-icon>
-      
-          <sgds-icon name="bookmark-fill"></sgds-icon>
-          
-          <sgds-icon name="bookmark"></sgds-icon>
-      
-          <sgds-icon name="box-arrow-up-right"></sgds-icon>
-      
-          <sgds-icon name="box-seam"></sgds-icon>
-      
-          <sgds-icon name="building"></sgds-icon>
-      
-          <sgds-icon name="bus"></sgds-icon>
-      
-          <sgds-icon name="calculator"></sgds-icon>
-      
-          <sgds-icon name="calendar-check"></sgds-icon>
-          
-          <sgds-icon name="calendar-x"></sgds-icon>
-          
-          <sgds-icon name="calendar"></sgds-icon>
-      
-          <sgds-icon name="camera"></sgds-icon>
+          <sgds-icon name="archive" ariaLabel="Archive"></sgds-icon>
 
-          <sgds-icon name="car"></sgds-icon>
+          <sgds-icon name="arrow-bar-down" ariaLabel="Arrow bar down"></sgds-icon>
 
-          <sgds-icon name="chat-dots"></sgds-icon>
-      
-          <sgds-icon name="chat-left-text"></sgds-icon>
-      
-          <sgds-icon name="chat"></sgds-icon>
-      
-          <sgds-icon name="check-circle-fill"></sgds-icon>
-          
-          <sgds-icon name="check-circle"></sgds-icon>
-          
-          <sgds-icon name="check"></sgds-icon>
-      
-          <sgds-icon name="chevron-down"></sgds-icon>
-      
-          <sgds-icon name="chevron-left"></sgds-icon>
-      
-          <sgds-icon name="chevron-right"></sgds-icon>
-      
-          <sgds-icon name="chevron-selector-vertical"></sgds-icon>
-      
-          <sgds-icon name="chevron-up"></sgds-icon>
-      
-          <sgds-icon name="clock"></sgds-icon>
-      
-          <sgds-icon name="cloud-check"></sgds-icon>
-          
-          <sgds-icon name="cloud-download"></sgds-icon>
-          
-          <sgds-icon name="cloud-upload"></sgds-icon>
-          
-          <sgds-icon name="cloud"></sgds-icon>
-      
-          <sgds-icon name="compass"></sgds-icon>
-      
-          <sgds-icon name="copy"></sgds-icon>
-      
-          <sgds-icon name="cross"></sgds-icon>
-      
-          <sgds-icon name="cursor-fill"></sgds-icon>
-          
-          <sgds-icon name="cursor"></sgds-icon>
-          
-          <sgds-icon name="dash-circle"></sgds-icon>
-          
-          <sgds-icon name="dash-square"></sgds-icon>
-          
-          <sgds-icon name="dash"></sgds-icon>
-          
-          <sgds-icon name="download"></sgds-icon>
-          
-          <sgds-icon name="edit"></sgds-icon>
-      
-          <sgds-icon name="exclamation-circle-fill"></sgds-icon>
-          
-          <sgds-icon name="exclamation-circle"></sgds-icon>
-          
-          <sgds-icon name="exclamation-triangle-fill"></sgds-icon>
-          
-          <sgds-icon name="exclamation-triangle"></sgds-icon>
-          
-          <sgds-icon name="exclamation"></sgds-icon>
-          
-          <sgds-icon name="eye-fill"></sgds-icon>
-          
-          <sgds-icon name="eye-slash-fill"></sgds-icon>
-          
-          <sgds-icon name="eye-slash"></sgds-icon>
-          
-          <sgds-icon name="eye"></sgds-icon>
-      
-          <sgds-icon name="facebook"></sgds-icon>
-      
-          <sgds-icon name="file-earmark-text"></sgds-icon>
-          
-          <sgds-icon name="file-pdf"></sgds-icon>
-          
-          <sgds-icon name="file-plus"></sgds-icon>
-          
-          <sgds-icon name="file-text"></sgds-icon>
-          
-          <sgds-icon name="file"></sgds-icon>
-          
-          <sgds-icon name="files"></sgds-icon>
-      
-          <sgds-icon name="folder-check"></sgds-icon>
-          
-          <sgds-icon name="folder-minus"></sgds-icon>
-          
-          <sgds-icon name="folder-plus"></sgds-icon>
-          
-          <sgds-icon name="folder"></sgds-icon>
-      
-          <sgds-icon name="gear"></sgds-icon>
-      
-          <sgds-icon name="geo-alt"></sgds-icon>
-          
-          <sgds-icon name="geo-fill"></sgds-icon>
-          
-          <sgds-icon name="geo"></sgds-icon>
-      
-          <sgds-icon name="google"></sgds-icon>
-      
-          <sgds-icon name="grid-fill"></sgds-icon>
-      
-          <sgds-icon name="hand-thumbs-down"></sgds-icon>
-      
-          <sgds-icon name="hand-thumbs-up"></sgds-icon>
-      
-          <sgds-icon name="hard-drive"></sgds-icon>
-      
-          <sgds-icon name="heart"></sgds-icon>
-      
-          <sgds-icon name="house-door"></sgds-icon>
+          <sgds-icon name="arrow-bar-left" ariaLabel="Arrow bar left"></sgds-icon>
 
-          <sgds-icon name="house"></sgds-icon>
-      
-          <sgds-icon name="image"></sgds-icon>
-      
-          <sgds-icon name="in-box"></sgds-icon>
-      
-          <sgds-icon name="info-circle-fill"></sgds-icon>
-          
-          <sgds-icon name="info-circle"></sgds-icon>
-      
-          <sgds-icon name="instagram"></sgds-icon>
-      
-          <sgds-icon name="laptop"></sgds-icon>
-      
-          <sgds-icon name="layers"></sgds-icon>
-      
-          <sgds-icon name="layout-text-window-reverse"></sgds-icon>
-          
-          <sgds-icon name="layout-text-window"></sgds-icon>
-          
-          <sgds-icon name="layout"></sgds-icon>
-      
-          <sgds-icon name="lightbulb"></sgds-icon>
-      
-          <sgds-icon name="link"></sgds-icon>
-      
-          <sgds-icon name="linkedin"></sgds-icon>
-      
-          <sgds-icon name="list"></sgds-icon>
-      
-          <sgds-icon name="lock-fill"></sgds-icon>
-      
-          <sgds-icon name="lock"></sgds-icon>
-      
-          <sgds-icon name="login"></sgds-icon>
-      
-          <sgds-icon name="logout"></sgds-icon>
-      
-          <sgds-icon name="luggage"></sgds-icon>
-      
-          <sgds-icon name="mail"></sgds-icon>
-      
-          <sgds-icon name="map"></sgds-icon>
-      
-          <sgds-icon name="meetup"></sgds-icon>
+          <sgds-icon name="arrow-bar-right" ariaLabel="Arrow bar right"></sgds-icon>
 
-          <sgds-icon name="menu"></sgds-icon>
+          <sgds-icon name="arrow-bar-up" ariaLabel="Arrow bar up"></sgds-icon>
 
-          <sgds-icon name="microphone"></sgds-icon>
+          <sgds-icon name="arrow-circle-down" ariaLabel="Arrow circle down"></sgds-icon>
 
-          <sgds-icon name="monitor"></sgds-icon>
+          <sgds-icon name="arrow-circle-left" ariaLabel="Arrow circle left"></sgds-icon>
 
-          <sgds-icon name="moon"></sgds-icon>
+          <sgds-icon name="arrow-circle-right" ariaLabel="Arrow circle right"></sgds-icon>
 
-          <sgds-icon name="move"></sgds-icon>
+          <sgds-icon name="arrow-circle-up" ariaLabel="Arrow circle up"></sgds-icon>
+
+          <sgds-icon name="arrow-clockwise" ariaLabel="Arrow clockwise"></sgds-icon>
+
+          <sgds-icon name="arrow-down" ariaLabel="Arrow down"></sgds-icon>
+
+          <sgds-icon name="arrow-left" ariaLabel="Arrow left"></sgds-icon>
+
+          <sgds-icon name="arrow-repeat" ariaLabel="Arrow repeat"></sgds-icon>
+
+          <sgds-icon name="arrow-right" ariaLabel="Arrow right"></sgds-icon>
+
+          <sgds-icon name="arrow-square-down" ariaLabel="Arrow square down"></sgds-icon>
+
+          <sgds-icon name="arrow-square-left" ariaLabel="Arrow square left"></sgds-icon>
+
+          <sgds-icon name="arrow-square-right" ariaLabel="Arrow square right"></sgds-icon>
+
+          <sgds-icon name="arrow-square-up" ariaLabel="Arrow square up"></sgds-icon>
+
+          <sgds-icon name="arrow-up" ariaLabel="Arrow up"></sgds-icon>
       
-          <sgds-icon name="paperclip"></sgds-icon>
+          <sgds-icon name="bank-fill" ariaLabel="Bank fill"></sgds-icon>
       
-          <sgds-icon name="passport"></sgds-icon>
-      
-          <sgds-icon name="pause"></sgds-icon>
-      
-          <sgds-icon name="pencil"></sgds-icon>
-      
-          <sgds-icon name="pending-circle"></sgds-icon>
-      
-          <sgds-icon name="person-dash"></sgds-icon>
+          <sgds-icon name="bell-slash" ariaLabel="Bell slash"></sgds-icon>
           
-          <sgds-icon name="person-plus"></sgds-icon>
+          <sgds-icon name="bell" ariaLabel="Bell"></sgds-icon>
+      
+          <sgds-icon name="bi-funnel" ariaLabel="Bi funnel"></sgds-icon>
+      
+          <sgds-icon name="bookmark-fill" ariaLabel="Bookmark fill"></sgds-icon>
           
-          <sgds-icon name="person-x"></sgds-icon>
+          <sgds-icon name="bookmark" ariaLabel="Bookmark"></sgds-icon>
+      
+          <sgds-icon name="box-arrow-up-right" ariaLabel="Box arrow up right"></sgds-icon>
+      
+          <sgds-icon name="box-seam" ariaLabel="Box seam"></sgds-icon>
+      
+          <sgds-icon name="building" ariaLabel="Building"></sgds-icon>
+      
+          <sgds-icon name="bus" ariaLabel="Bus"></sgds-icon>
+      
+          <sgds-icon name="calculator" ariaLabel="Calculator"></sgds-icon>
+      
+          <sgds-icon name="calendar-check" ariaLabel="Calendar check"></sgds-icon>
           
-          <sgds-icon name="person"></sgds-icon>
+          <sgds-icon name="calendar-x" ariaLabel="Calendar x"></sgds-icon>
           
-          <sgds-icon name="phone"></sgds-icon>
+          <sgds-icon name="calendar" ariaLabel="Calendar"></sgds-icon>
       
-          <sgds-icon name="pin-map-fill"></sgds-icon>
+          <sgds-icon name="camera" ariaLabel="Camera"></sgds-icon>
+
+          <sgds-icon name="car" ariaLabel="Car"></sgds-icon>
+
+          <sgds-icon name="chat-dots" ariaLabel="Chat dots"></sgds-icon>
+      
+          <sgds-icon name="chat-left-text" ariaLabel="Chat left text"></sgds-icon>
+      
+          <sgds-icon name="chat" ariaLabel="Chat"></sgds-icon>
+      
+          <sgds-icon name="check-circle-fill" ariaLabel="Check circle fill"></sgds-icon>
           
-          <sgds-icon name="pin"></sgds-icon>
-      
-          <sgds-icon name="placeholder"></sgds-icon>
-      
-          <sgds-icon name="plane"></sgds-icon>
-      
-          <sgds-icon name="play"></sgds-icon>
-      
-          <sgds-icon name="plus-circle"></sgds-icon>
-      
-          <sgds-icon name="plus-square"></sgds-icon>
+          <sgds-icon name="check-circle" ariaLabel="Check circle"></sgds-icon>
           
-          <sgds-icon name="plus"></sgds-icon>
+          <sgds-icon name="check" ariaLabel="Check"></sgds-icon>
       
-          <sgds-icon name="printer"></sgds-icon>
+          <sgds-icon name="chevron-down" ariaLabel="Chevron down"></sgds-icon>
       
-          <sgds-icon name="question-circle"></sgds-icon>
+          <sgds-icon name="chevron-left" ariaLabel="Chevron left"></sgds-icon>
       
-          <sgds-icon name="rocket"></sgds-icon>
+          <sgds-icon name="chevron-right" ariaLabel="Chevron right"></sgds-icon>
       
-          <sgds-icon name="save"></sgds-icon>
+          <sgds-icon name="chevron-selector-vertical" ariaLabel="Chevron selector vertical"></sgds-icon>
       
-          <sgds-icon name="search"></sgds-icon>
+          <sgds-icon name="chevron-up" ariaLabel="Chevron up"></sgds-icon>
       
-          <sgds-icon name="send"></sgds-icon>
+          <sgds-icon name="clock" ariaLabel="Clock"></sgds-icon>
       
-          <sgds-icon name="sg-crest"></sgds-icon>
-      
-          <sgds-icon name="share"></sgds-icon>
-      
-          <sgds-icon name="slash-circle"></sgds-icon>
-      
-          <sgds-icon name="slash-divider"></sgds-icon>
-      
-          <sgds-icon name="sliders"></sgds-icon>
-      
-          <sgds-icon name="speedometer"></sgds-icon>
-      
-          <sgds-icon name="star-fill"></sgds-icon>
+          <sgds-icon name="cloud-check" ariaLabel="Cloud check"></sgds-icon>
           
-          <sgds-icon name="star"></sgds-icon>
-      
-          <sgds-icon name="stoplights"></sgds-icon>
-      
-          <sgds-icon name="sun"></sgds-icon>
-      
-          <sgds-icon name="switch-horizontal"></sgds-icon>
-      
-          <sgds-icon name="switch-vertical"></sgds-icon>
-      
-          <sgds-icon name="tablet"></sgds-icon>
-      
-          <sgds-icon name="telegram"></sgds-icon>
-      
-          <sgds-icon name="telephone"></sgds-icon>
-      
-          <sgds-icon name="three-dots-vertical"></sgds-icon>
+          <sgds-icon name="cloud-download" ariaLabel="Cloud download"></sgds-icon>
           
-          <sgds-icon name="three-dots"></sgds-icon>
+          <sgds-icon name="cloud-upload" ariaLabel="Cloud upload"></sgds-icon>
           
-          <sgds-icon name="ticket"></sgds-icon>
+          <sgds-icon name="cloud" ariaLabel="Cloud"></sgds-icon>
       
-          <sgds-icon name="toggle-off"></sgds-icon>
+          <sgds-icon name="compass" ariaLabel="Compass"></sgds-icon>
       
-          <sgds-icon name="toggle-on"></sgds-icon>
+          <sgds-icon name="copy" ariaLabel="Copy"></sgds-icon>
       
-          <sgds-icon name="train"></sgds-icon>
+          <sgds-icon name="cross" ariaLabel="Cross"></sgds-icon>
       
-          <sgds-icon name="translate"></sgds-icon>
-      
-          <sgds-icon name="trash"></sgds-icon>
-      
-          <sgds-icon name="trend-down"></sgds-icon>
-      
-          <sgds-icon name="trend-up"></sgds-icon>
-      
-          <sgds-icon name="truck"></sgds-icon>
-      
-          <sgds-icon name="twitter-x"></sgds-icon>
-      
-          <sgds-icon name="unlock"></sgds-icon>
-      
-          <sgds-icon name="upload"></sgds-icon>
-      
-          <sgds-icon name="user-circle"></sgds-icon>
-      
-          <sgds-icon name="user-square"></sgds-icon>
-      
-          <sgds-icon name="users"></sgds-icon>
-      
-          <sgds-icon name="video-recorder"></sgds-icon>
-      
-          <sgds-icon name="volume-max"></sgds-icon>
-      
-          <sgds-icon name="volume-x"></sgds-icon>
-      
-          <sgds-icon name="window-dash"></sgds-icon>
+          <sgds-icon name="cursor-fill" ariaLabel="Cursor fill"></sgds-icon>
           
-          <sgds-icon name="window-desktop"></sgds-icon>
+          <sgds-icon name="cursor" ariaLabel="Cursor"></sgds-icon>
           
-          <sgds-icon name="window-dock"></sgds-icon>
+          <sgds-icon name="dash-circle" ariaLabel="Dash circle"></sgds-icon>
           
-          <sgds-icon name="window-fullscreen"></sgds-icon>
+          <sgds-icon name="dash-square" ariaLabel="Dash square"></sgds-icon>
           
-          <sgds-icon name="window-plus"></sgds-icon>
+          <sgds-icon name="dash" ariaLabel="Dash"></sgds-icon>
           
-          <sgds-icon name="window-sidebar"></sgds-icon>
+          <sgds-icon name="download" ariaLabel="Download"></sgds-icon>
           
-          <sgds-icon name="window-split"></sgds-icon>
-          
-          <sgds-icon name="window-stack"></sgds-icon>
-          
-          <sgds-icon name="window-x"></sgds-icon>
-          
-          <sgds-icon name="window"></sgds-icon>
-          
-          <sgds-icon name="x-circle-fill"></sgds-icon>
-          
-          <sgds-icon name="x-circle"></sgds-icon>
+          <sgds-icon name="edit" ariaLabel="Edit"></sgds-icon>
       
-          <sgds-icon name="youtube"></sgds-icon>
+          <sgds-icon name="exclamation-circle-fill" ariaLabel="Exclamation circle fill"></sgds-icon>
+          
+          <sgds-icon name="exclamation-circle" ariaLabel="Exclamation circle"></sgds-icon>
+          
+          <sgds-icon name="exclamation-triangle-fill" ariaLabel="Exclamation triangle fill"></sgds-icon>
+          
+          <sgds-icon name="exclamation-triangle" ariaLabel="Exclamation triangle"></sgds-icon>
+          
+          <sgds-icon name="exclamation" ariaLabel="Exclamation"></sgds-icon>
+          
+          <sgds-icon name="eye-fill" ariaLabel="Eye fill"></sgds-icon>
+          
+          <sgds-icon name="eye-slash-fill" ariaLabel="Eye slash fill"></sgds-icon>
+          
+          <sgds-icon name="eye-slash" ariaLabel="Eye slash"></sgds-icon>
+          
+          <sgds-icon name="eye" ariaLabel="Eye"></sgds-icon>
       
-          <sgds-icon name="zoom-in"></sgds-icon>
+          <sgds-icon name="facebook" ariaLabel="Facebook"></sgds-icon>
       
-          <sgds-icon name="zoom-out"></sgds-icon>
+          <sgds-icon name="file-earmark-text" ariaLabel="File earmark text"></sgds-icon>
+          
+          <sgds-icon name="file-pdf" ariaLabel="File pdf"></sgds-icon>
+          
+          <sgds-icon name="file-plus" ariaLabel="File plus"></sgds-icon>
+          
+          <sgds-icon name="file-text" ariaLabel="File text"></sgds-icon>
+          
+          <sgds-icon name="file" ariaLabel="File"></sgds-icon>
+          
+          <sgds-icon name="files" ariaLabel="Files"></sgds-icon>
+      
+          <sgds-icon name="folder-check" ariaLabel="Folder check"></sgds-icon>
+          
+          <sgds-icon name="folder-minus" ariaLabel="Folder minus"></sgds-icon>
+          
+          <sgds-icon name="folder-plus" ariaLabel="Folder plus"></sgds-icon>
+          
+          <sgds-icon name="folder" ariaLabel="Folder"></sgds-icon>
+      
+          <sgds-icon name="gear" ariaLabel="Gear"></sgds-icon>
+      
+          <sgds-icon name="geo-alt" ariaLabel="Geo alt"></sgds-icon>
+          
+          <sgds-icon name="geo-fill" ariaLabel="Geo fill"></sgds-icon>
+          
+          <sgds-icon name="geo" ariaLabel="Geo"></sgds-icon>
+      
+          <sgds-icon name="google" ariaLabel="Google"></sgds-icon>
+      
+          <sgds-icon name="grid-fill" ariaLabel="Grid fill"></sgds-icon>
+      
+          <sgds-icon name="hand-thumbs-down" ariaLabel="Hand thumbs down"></sgds-icon>
+      
+          <sgds-icon name="hand-thumbs-up" ariaLabel="Hand thumbs up"></sgds-icon>
+      
+          <sgds-icon name="hard-drive" ariaLabel="Hard drive"></sgds-icon>
+      
+          <sgds-icon name="heart" ariaLabel="Heart"></sgds-icon>
+      
+          <sgds-icon name="house-door" ariaLabel="House door"></sgds-icon>
+
+          <sgds-icon name="house" ariaLabel="House"></sgds-icon>
+      
+          <sgds-icon name="image" ariaLabel="Image"></sgds-icon>
+      
+          <sgds-icon name="in-box" ariaLabel="In box"></sgds-icon>
+      
+          <sgds-icon name="info-circle-fill" ariaLabel="Info circle fill"></sgds-icon>
+          
+          <sgds-icon name="info-circle" ariaLabel="Info circle"></sgds-icon>
+      
+          <sgds-icon name="instagram" ariaLabel="Instagram"></sgds-icon>
+      
+          <sgds-icon name="laptop" ariaLabel="Laptop"></sgds-icon>
+      
+          <sgds-icon name="layers" ariaLabel="Layers"></sgds-icon>
+      
+          <sgds-icon name="layout-text-window-reverse" ariaLabel="Layout text window reverse"></sgds-icon>
+          
+          <sgds-icon name="layout-text-window" ariaLabel="Layout text window"></sgds-icon>
+          
+          <sgds-icon name="layout" ariaLabel="Layout"></sgds-icon>
+      
+          <sgds-icon name="lightbulb" ariaLabel="Lightbulb"></sgds-icon>
+      
+          <sgds-icon name="link" ariaLabel="Link"></sgds-icon>
+      
+          <sgds-icon name="linkedin" ariaLabel="Linkedin"></sgds-icon>
+      
+          <sgds-icon name="list" ariaLabel="List"></sgds-icon>
+      
+          <sgds-icon name="lock-fill" ariaLabel="Lock fill"></sgds-icon>
+      
+          <sgds-icon name="lock" ariaLabel="Lock"></sgds-icon>
+      
+          <sgds-icon name="login" ariaLabel="Login"></sgds-icon>
+      
+          <sgds-icon name="logout" ariaLabel="Logout"></sgds-icon>
+      
+          <sgds-icon name="luggage" ariaLabel="Luggage"></sgds-icon>
+      
+          <sgds-icon name="mail" ariaLabel="Mail"></sgds-icon>
+      
+          <sgds-icon name="map" ariaLabel="Map"></sgds-icon>
+      
+          <sgds-icon name="meetup" ariaLabel="Meetup"></sgds-icon>
+
+          <sgds-icon name="menu" ariaLabel="Menu"></sgds-icon>
+
+          <sgds-icon name="microphone" ariaLabel="Microphone"></sgds-icon>
+
+          <sgds-icon name="monitor" ariaLabel="Monitor"></sgds-icon>
+
+          <sgds-icon name="moon" ariaLabel="Moon"></sgds-icon>
+
+          <sgds-icon name="move" ariaLabel="Move"></sgds-icon>
+      
+          <sgds-icon name="paperclip" ariaLabel="Paperclip"></sgds-icon>
+      
+          <sgds-icon name="passport" ariaLabel="Passport"></sgds-icon>
+      
+          <sgds-icon name="pause" ariaLabel="Pause"></sgds-icon>
+      
+          <sgds-icon name="pencil" ariaLabel="Pencil"></sgds-icon>
+      
+          <sgds-icon name="pending-circle" ariaLabel="Pending circle"></sgds-icon>
+      
+          <sgds-icon name="person-dash" ariaLabel="Person dash"></sgds-icon>
+          
+          <sgds-icon name="person-plus" ariaLabel="Person plus"></sgds-icon>
+          
+          <sgds-icon name="person-x" ariaLabel="Person x"></sgds-icon>
+          
+          <sgds-icon name="person" ariaLabel="Person"></sgds-icon>
+          
+          <sgds-icon name="phone" ariaLabel="Phone"></sgds-icon>
+      
+          <sgds-icon name="pin-map-fill" ariaLabel="Pin map fill"></sgds-icon>
+          
+          <sgds-icon name="pin" ariaLabel="Pin"></sgds-icon>
+      
+          <sgds-icon name="placeholder" ariaLabel="Placeholder"></sgds-icon>
+      
+          <sgds-icon name="plane" ariaLabel="Plane"></sgds-icon>
+      
+          <sgds-icon name="play" ariaLabel="Play"></sgds-icon>
+      
+          <sgds-icon name="plus-circle" ariaLabel="Plus circle"></sgds-icon>
+      
+          <sgds-icon name="plus-square" ariaLabel="Plus square"></sgds-icon>
+          
+          <sgds-icon name="plus" ariaLabel="Plus"></sgds-icon>
+      
+          <sgds-icon name="printer" ariaLabel="Printer"></sgds-icon>
+      
+          <sgds-icon name="question-circle" ariaLabel="Question circle"></sgds-icon>
+      
+          <sgds-icon name="rocket" ariaLabel="Rocket"></sgds-icon>
+      
+          <sgds-icon name="save" ariaLabel="Save"></sgds-icon>
+      
+          <sgds-icon name="search" ariaLabel="Search"></sgds-icon>
+      
+          <sgds-icon name="send" ariaLabel="Send"></sgds-icon>
+      
+          <sgds-icon name="sg-crest" ariaLabel="Sg crest"></sgds-icon>
+      
+          <sgds-icon name="share" ariaLabel="Share"></sgds-icon>
+      
+          <sgds-icon name="slash-circle" ariaLabel="Slash circle"></sgds-icon>
+      
+          <sgds-icon name="slash-divider" ariaLabel="Slash divider"></sgds-icon>
+      
+          <sgds-icon name="sliders" ariaLabel="Sliders"></sgds-icon>
+      
+          <sgds-icon name="speedometer" ariaLabel="Speedometer"></sgds-icon>
+      
+          <sgds-icon name="star-fill" ariaLabel="Star fill"></sgds-icon>
+          
+          <sgds-icon name="star" ariaLabel="Star"></sgds-icon>
+      
+          <sgds-icon name="stoplights" ariaLabel="Stoplights"></sgds-icon>
+      
+          <sgds-icon name="sun" ariaLabel="Sun"></sgds-icon>
+      
+          <sgds-icon name="switch-horizontal" ariaLabel="Switch horizontal"></sgds-icon>
+      
+          <sgds-icon name="switch-vertical" ariaLabel="Switch vertical"></sgds-icon>
+      
+          <sgds-icon name="tablet" ariaLabel="Tablet"></sgds-icon>
+      
+          <sgds-icon name="telegram" ariaLabel="Telegram"></sgds-icon>
+      
+          <sgds-icon name="telephone" ariaLabel="Telephone"></sgds-icon>
+      
+          <sgds-icon name="three-dots-vertical" ariaLabel="Three dots vertical"></sgds-icon>
+          
+          <sgds-icon name="three-dots" ariaLabel="Three dots"></sgds-icon>
+          
+          <sgds-icon name="ticket" ariaLabel="Ticket"></sgds-icon>
+      
+          <sgds-icon name="toggle-off" ariaLabel="Toggle off"></sgds-icon>
+      
+          <sgds-icon name="toggle-on" ariaLabel="Toggle on"></sgds-icon>
+      
+          <sgds-icon name="train" ariaLabel="Train"></sgds-icon>
+      
+          <sgds-icon name="translate" ariaLabel="Translate"></sgds-icon>
+      
+          <sgds-icon name="trash" ariaLabel="Trash"></sgds-icon>
+      
+          <sgds-icon name="trend-down" ariaLabel="Trend down"></sgds-icon>
+      
+          <sgds-icon name="trend-up" ariaLabel="Trend up"></sgds-icon>
+      
+          <sgds-icon name="truck" ariaLabel="Truck"></sgds-icon>
+      
+          <sgds-icon name="twitter-x" ariaLabel="Twitter x"></sgds-icon>
+      
+          <sgds-icon name="unlock" ariaLabel="Unlock"></sgds-icon>
+      
+          <sgds-icon name="upload" ariaLabel="Upload"></sgds-icon>
+      
+          <sgds-icon name="user-circle" ariaLabel="User circle"></sgds-icon>
+      
+          <sgds-icon name="user-square" ariaLabel="User square"></sgds-icon>
+      
+          <sgds-icon name="users" ariaLabel="Users"></sgds-icon>
+      
+          <sgds-icon name="video-recorder" ariaLabel="Video recorder"></sgds-icon>
+      
+          <sgds-icon name="volume-max" ariaLabel="Volume max"></sgds-icon>
+      
+          <sgds-icon name="volume-x" ariaLabel="Volume x"></sgds-icon>
+      
+          <sgds-icon name="window-dash" ariaLabel="Window dash"></sgds-icon>
+          
+          <sgds-icon name="window-desktop" ariaLabel="Window desktop"></sgds-icon>
+          
+          <sgds-icon name="window-dock" ariaLabel="Window dock"></sgds-icon>
+          
+          <sgds-icon name="window-fullscreen" ariaLabel="Window fullscreen"></sgds-icon>
+          
+          <sgds-icon name="window-plus" ariaLabel="Window plus"></sgds-icon>
+          
+          <sgds-icon name="window-sidebar" ariaLabel="Window sidebar"></sgds-icon>
+          
+          <sgds-icon name="window-split" ariaLabel="Window split"></sgds-icon>
+          
+          <sgds-icon name="window-stack" ariaLabel="Window stack"></sgds-icon>
+          
+          <sgds-icon name="window-x" ariaLabel="Window x"></sgds-icon>
+          
+          <sgds-icon name="window" ariaLabel="Window"></sgds-icon>
+          
+          <sgds-icon name="x-circle-fill" ariaLabel="X circle fill"></sgds-icon>
+          
+          <sgds-icon name="x-circle" ariaLabel="X circle"></sgds-icon>
+      
+          <sgds-icon name="youtube" ariaLabel="Youtube"></sgds-icon>
+      
+          <sgds-icon name="zoom-in" ariaLabel="Zoom in"></sgds-icon>
+      
+          <sgds-icon name="zoom-out" ariaLabel="Zoom out"></sgds-icon>
         `
     }
   }

--- a/stories/component-templates/Tooltip/additional.stories.js
+++ b/stories/component-templates/Tooltip/additional.stories.js
@@ -8,18 +8,7 @@ const PlacementTemplate = args => {
       ${placements.map(
         p => html` <div class="d-flex-row">
         <sgds-tooltip content="${p}" placement="${p}">
-          <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M11 1.6C5.80855 1.6 1.60002 5.80852 1.60002 11C1.60002 16.1915 5.80855 20.4 11 20.4C16.1915 20.4 20.4 16.1915 20.4 11C20.4 5.80852 16.1915 1.6 11 1.6ZM0.400024 11C0.400024 5.14578 5.14581 0.4 11 0.4C16.8542 0.4 21.6 5.14578 21.6 11C21.6 16.8542 16.8542 21.6 11 21.6C5.14581 21.6 0.400024 16.8542 0.400024 11ZM11 9.4C11.3314 9.4 11.6 9.66863 11.6 10V15C11.6 15.3314 11.3314 15.6 11 15.6C10.6687 15.6 10.4 15.3314 10.4 15V10C10.4 9.66863 10.6687 9.4 11 9.4Z"
-              fill="#0E0E0E"
-            />
-            <path
-              d="M11 6.15002C10.5306 6.15002 10.15 6.53058 10.15 7.00002C10.15 7.46947 10.5306 7.85002 11 7.85002H11.01C11.4795 7.85002 11.8601 7.46947 11.8601 7.00002C11.8601 6.53058 11.4795 6.15002 11.01 6.15002H11Z"
-              fill="#0E0E0E"
-            />
-          </svg>
+          <sgds-icon name="info-circle" ariaLabel="Information" tabindex="0"></sgds-icon>
         </sgds-tooltip>
       </div>
       </div>
@@ -36,18 +25,7 @@ const TriggerTemplate = args => {
         t => html` <div class="d-flex-row">
             ${t} to invoke the tooltip
         <sgds-tooltip content="${t}" trigger=${t}>
-          <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M11 1.6C5.80855 1.6 1.60002 5.80852 1.60002 11C1.60002 16.1915 5.80855 20.4 11 20.4C16.1915 20.4 20.4 16.1915 20.4 11C20.4 5.80852 16.1915 1.6 11 1.6ZM0.400024 11C0.400024 5.14578 5.14581 0.4 11 0.4C16.8542 0.4 21.6 5.14578 21.6 11C21.6 16.8542 16.8542 21.6 11 21.6C5.14581 21.6 0.400024 16.8542 0.400024 11ZM11 9.4C11.3314 9.4 11.6 9.66863 11.6 10V15C11.6 15.3314 11.3314 15.6 11 15.6C10.6687 15.6 10.4 15.3314 10.4 15V10C10.4 9.66863 10.6687 9.4 11 9.4Z"
-              fill="#0E0E0E"
-            />
-            <path
-              d="M11 6.15002C10.5306 6.15002 10.15 6.53058 10.15 7.00002C10.15 7.46947 10.5306 7.85002 11 7.85002H11.01C11.4795 7.85002 11.8601 7.46947 11.8601 7.00002C11.8601 6.53058 11.4795 6.15002 11.01 6.15002H11Z"
-              fill="#0E0E0E"
-            />
-          </svg>
+          <sgds-icon name="info-circle" ariaLabel="Information" tabindex="0"></sgds-icon>
         </sgds-tooltip>
       </div>
       </div>

--- a/stories/component-templates/Tooltip/basic.js
+++ b/stories/component-templates/Tooltip/basic.js
@@ -6,18 +6,7 @@ export const Template = ({ content, trigger, placement }) => {
     <div class="d-flex-row">
       Hover over the icon
       <sgds-tooltip content=${ifDefined(content)} trigger=${ifDefined(trigger)} placement=${ifDefined(placement)}>
-        <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
-          <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
-            d="M11 1.6C5.80855 1.6 1.60002 5.80852 1.60002 11C1.60002 16.1915 5.80855 20.4 11 20.4C16.1915 20.4 20.4 16.1915 20.4 11C20.4 5.80852 16.1915 1.6 11 1.6ZM0.400024 11C0.400024 5.14578 5.14581 0.4 11 0.4C16.8542 0.4 21.6 5.14578 21.6 11C21.6 16.8542 16.8542 21.6 11 21.6C5.14581 21.6 0.400024 16.8542 0.400024 11ZM11 9.4C11.3314 9.4 11.6 9.66863 11.6 10V15C11.6 15.3314 11.3314 15.6 11 15.6C10.6687 15.6 10.4 15.3314 10.4 15V10C10.4 9.66863 10.6687 9.4 11 9.4Z"
-            fill="#0E0E0E"
-          />
-          <path
-            d="M11 6.15002C10.5306 6.15002 10.15 6.53058 10.15 7.00002C10.15 7.46947 10.5306 7.85002 11 7.85002H11.01C11.4795 7.85002 11.8601 7.46947 11.8601 7.00002C11.8601 6.53058 11.4795 6.15002 11.01 6.15002H11Z"
-            fill="#0E0E0E"
-          />
-        </svg>
+        <sgds-icon name="info-circle" ariaLabel="Information" tabindex="0"></sgds-icon>
       </sgds-tooltip>
     </div>
   `;

--- a/test/a11y/oobee/button.html
+++ b/test/a11y/oobee/button.html
@@ -5,9 +5,9 @@
     <link href="/src/css/sgds.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
-    <sgds-button>Click me</sgds-button>
+    <sgds-button ariaLabel="Click me">Click me</sgds-button>
 
-    <sgds-button href="https://example.com">Visit site</sgds-button>
+    <sgds-button href="https://example.com" ariaLabel="Visit site">Visit site</sgds-button>
 
     <sgds-button disabled>Disabled</sgds-button>
 

--- a/test/a11y/oobee/dropdown.html
+++ b/test/a11y/oobee/dropdown.html
@@ -6,19 +6,19 @@
   </head>
   <body>
     <sgds-dropdown>
-<sgds-button slot="toggler">Actions</sgds-button>
+<sgds-button slot="toggler" ariaLabel="Actions">Actions</sgds-button>
 <sgds-dropdown-item>Option 1</sgds-dropdown-item>
 <sgds-dropdown-item>Option 2</sgds-dropdown-item>
 <sgds-dropdown-item>Option 3</sgds-dropdown-item>
 </sgds-dropdown>
 
     <sgds-dropdown>
-<sgds-button slot="toggler">Actions</sgds-button>
+<sgds-button slot="toggler" ariaLabel="Actions">Actions</sgds-button>
 <sgds-dropdown-item>Option 1</sgds-dropdown-item>
 </sgds-dropdown>
 
     <sgds-dropdown menuIsOpen>
-<sgds-button slot="toggler">Actions</sgds-button>
+<sgds-button slot="toggler" ariaLabel="Actions">Actions</sgds-button>
 <sgds-dropdown-item>Option 1</sgds-dropdown-item>
 </sgds-dropdown>
 

--- a/test/a11y/oobee/tooltip.html
+++ b/test/a11y/oobee/tooltip.html
@@ -6,7 +6,11 @@
   </head>
   <body>
     <sgds-tooltip content="Helpful tooltip text">
-<sgds-button>Hover me</sgds-button>
-</sgds-tooltip>
+      <sgds-button ariaLabel="Hover me">Hover me</sgds-button>
+    </sgds-tooltip>
+
+    <sgds-tooltip content="This is a tooltip" placement="bottom">
+      <sgds-icon name="info-circle" ariaLabel="Information" tabindex="0"></sgds-icon>
+    </sgds-tooltip>
   </body>
 </html>


### PR DESCRIPTION
## :open_book: Description

1.  sgds-icon accessibility behaviour                                                                                                                                 
                                                                                                                                                                    
  Added an ariaLabel property to <sgds-icon> that controls the SVG's accessibility semantics via the updated() lifecycle:                                         
                                                                                                                                                                    
  When ariaLabel is NOT set (decorative):                                                                                                                           
  - SVG gets aria-hidden="true"                                                                                                                                     
  - Hidden from assistive technologies                                                                                                                              
  - Use when the icon is inside a labelled parent (e.g. <sgds-button>, <sgds-icon-button>) where the parent provides the accessible name                          
                                                                                                                                                                    
  <!-- Decorative: parent button provides the label -->                                                                                                             
```
  <sgds-button ariaLabel="Download">                                                                                                                                
    <sgds-icon name="download" slot="leftIcon"></sgds-icon>                                                                                                         
    Download                                                                                                                                                        
  </sgds-button>                                                                                                                                                  
                                                                                                                                                                    
```
  When ariaLabel IS set (informative):                                                                                                                              
  - SVG gets aria-label="..."
  - Announced by screen readers                                                                                                                                     
  - Relies on SVG's default graphics-document role (no explicit role="img" needed)                                                                                
  - Use when the icon IS the content with no surrounding text label                                                                                                 
                                                                                                                                                                    
  <!-- Informative: icon is the content -->                                                                                                                         
  <sgds-icon name="info-circle" ariaLabel="Information"></sgds-icon>                                                                                                
                                                                                                                                                                    
  Why this approach?                                                                                                                                                
  - SVG is not an image — it has an implicit graphics-document role that's already exposed to the accessibility tree                                                
  - Adding aria-label alone is sufficient for assistive technologies to announce it                                                                                 
  - aria-hidden="true" fully hides decorative icons, which is more reliable than role="presentation"                                                              
  - This fixes the oobee oobee-accessible-label violations where icon SVGs inside clickable elements were flagged as unlabelled interactive elements                
                                                                                                                                                                    
  ---            


2. Dropdown and Button --> update stories and skills to ensure examples are accessible 


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
