### PR TITLE
fix(ComboBox): input prematurely expand in height for multiselect [run-chromatic]

### DIFF
--- a/playground/Combobox.html
+++ b/playground/Combobox.html
@@ -29,6 +29,52 @@
 <body>
   <div class="container">
     <div class="small-container"></div>
+     <sgds-combo-box required hasFeedback multiselect clearable id="combobox-example" label="Items"
+          value="option1;option2" placeholder="ComboBox">
+          <sgds-combo-box-option disabled value="option1">Apple</sgds-combo-box-option>
+          <sgds-combo-box-option value="option2">Apricot</sgds-combo-box-option>
+          <sgds-combo-box-option value="option3">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option4">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option5">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option6">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option7">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option8">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option9">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option10">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option11">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option12">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option13">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option14">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option15">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option16">Dua skfh isudh fksjdh rian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option17">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option18">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option19">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option20">Durian</sgds-combo-box-option>
+          </sgds-combo-box>
+     <sgds-combo-box required hasFeedback  clearable id="combobox-example" label="Items"
+          value="option1;option2" placeholder="ComboBox">
+          <sgds-combo-box-option disabled value="option1">Apple</sgds-combo-box-option>
+          <sgds-combo-box-option value="option2">Apricot</sgds-combo-box-option>
+          <sgds-combo-box-option value="option3">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option4">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option5">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option6">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option7">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option8">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option9">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option10">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option11">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option12">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option13">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option14">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option15">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option16">Dua skfh isudh fksjdh rian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option17">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option18">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option19">Durian</sgds-combo-box-option>
+          <sgds-combo-box-option value="option20">Durian</sgds-combo-box-option>
+          </sgds-combo-box>
     <h4>Empty single select combobox</h4>
     <sgds-combo-box></sgds-combo-box>
     <h4>Empty multi select combobox</h4>

--- a/src/components/ComboBox/combo-box.css
+++ b/src/components/ComboBox/combo-box.css
@@ -39,7 +39,12 @@
   align-items: center;
   width: calc(100% - var(--sgds-icon-size-md, 1.25rem));
   /* deduct 1px from top and bottom padding due to border */
-  padding: calc(var(--sgds-form-padding-y) - var(--sgds-form-border-width-default)) 0; 
+  padding: calc(var(--sgds-form-padding-y) - var(--sgds-form-border-width-default)) 0;
+}
+
+.combobox-input-container .form-control {
+  flex: 1 1 0;
+  min-width: 10ch;
 }
 
 slot[id='default'].d-none::slotted(*),

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -561,6 +561,7 @@ export class SgdsComboBox extends SelectElement {
             class="visually-hidden"
             ?required=${this.required}
             tabindex="-1"
+            aria-hidden="true"
           />`
         : nothing}
     `;

--- a/test/a11y/oobee/combo-box.html
+++ b/test/a11y/oobee/combo-box.html
@@ -1,14 +1,22 @@
 <html>
-  <head>
-    <script type="module" src="/src/index.ts"></script>
-    <link href="/src/themes/day.css" rel="stylesheet" type="text/css" />
-    <link href="/src/css/sgds.css" rel="stylesheet" type="text/css" />
-  </head>
-  <body>
-    <sgds-combo-box label="Select a fruit">
-<sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
-<sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
-<sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>
-</sgds-combo-box>
-  </body>
+
+<head>
+  <script type="module" src="/src/index.ts"></script>
+  <link href="/src/themes/day.css" rel="stylesheet" type="text/css" />
+  <link href="/src/css/sgds.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+  <sgds-combo-box label="Select a fruit" value="apple" placeholder="Select a fruit">
+    <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
+    <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
+    <sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>
+  </sgds-combo-box>
+  <sgds-combo-box label="Select a fruit" value="apple;banana" multiselect placeholder="Select fruits">
+    <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
+    <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
+    <sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>
+  </sgds-combo-box>
+</body>
+
 </html>


### PR DESCRIPTION
## :open_book: Description

<img width="562" height="149" alt="Screenshot 2026-06-05 at 11 51 30 PM" src="https://github.com/user-attachments/assets/c34d27ce-dffc-4d3e-b3a2-4d9976758a89" />

  - Fix multiselect input sizing: Changed the input's flex strategy from flex-grow: 1 to flex: 1 1 0; min-width: 10ch so the input no
   longer prematurely wraps to the next line when badges are present — it stays inline as long as there's space available          
  - Fix a11y: Added aria-hidden="true" to the hidden #multi-select-input-tracker input (used only for constraint validation) to      
  resolve axe "form element has no label" violation                                                                                  
  - Updated a11y test page: Added multiselect combobox variant to test/a11y/oobee/combo-box.html for coverage
  - Playground demos: Added multiselect and single-select combobox examples with many options 
  
  
Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
