### PR TITLE
[Tab] Add support for `tone`

### DIFF
--- a/src/components/Tab/sgds-tab-group.ts
+++ b/src/components/Tab/sgds-tab-group.ts
@@ -33,12 +33,15 @@ export class SgdsTabGroup extends SgdsElement {
   private _tabs: SgdsTab[] = [];
 
   private _panels: SgdsTabPanel[] = [];
-  /** The variant of tabs. Controls the visual styles of all `sgds-tabs` in its slot. It also sets the variant atttribute of `sgds-tab` */
+  /** The variant of tabs. Controls the visual styles of all `sgds-tabs` in its slot. It also sets the variant atttribute of `sgds-tab` and `sgds-tab-panel`. */
   @property({ type: String, reflect: true }) variant: "underlined" | "solid" = "underlined";
-  /** The orientation of tabs. Controls the orientation of all `sgds-tabs` in its slot. It also sets the orientation attribute of `sgds-tab` */
+  /** The orientation of tabs. Controls the orientation of all `sgds-tabs` in its slot. It also sets the orientation attribute of `sgds-tab` and `sgds-tab-panel`. */
   @property({ type: String, reflect: true }) orientation: "horizontal" | "vertical" = "horizontal";
-  /** The density of tabs. Controls the density of all `sgds-tabs` in its slot. It also sets the density attribute of `sgds-tab` */
+  /** The density of tabs. Controls the density of all `sgds-tabs` in its slot. It also sets the density attribute of `sgds-tab` and `sgds-tab-panel`. */
   @property({ type: String, reflect: true }) density: "compact" | "default" = "default";
+  /** The tone of tabs. Controls the tone of all `sgds-tabs` in its slot. It also sets the tone attribute of `sgds-tab` and `sgds-tab-panel`. */
+  @property({ type: String, reflect: true }) tone: "brand" | "neutral" | "inverse" | "fixed-light" | "fixed-dark" =
+    "brand";
 
   connectedCallback() {
     const whenAllDefined = Promise.all([
@@ -223,18 +226,31 @@ export class SgdsTabGroup extends SgdsElement {
   @queryAssignedElements({ slot: "nav", flatten: true })
   private _navSlot: SgdsTab[];
 
+  @queryAssignedElements({ slot: "", flatten: true })
+  private _panelSlot: SgdsTab[];
+
   private _updateTabsAttribute(name: string) {
-    if (!this._navSlot) return;
     const tabs = this._navSlot;
-    tabs.forEach(tab => {
-      tab.setAttribute(name, this[name]);
-    });
+    const panels = this._panelSlot;
+
+    if (tabs) {
+      tabs.forEach(tab => {
+        tab.setAttribute(name, this[name]);
+      });
+    }
+
+    if (panels) {
+      panels.forEach(panel => {
+        panel.setAttribute(name, this[name]);
+      });
+    }
   }
 
   private _handleSlotChange() {
     this._updateTabsAttribute("variant");
     this._updateTabsAttribute("orientation");
     this._updateTabsAttribute("density");
+    this._updateTabsAttribute("tone");
     this._syncTabsAndPanels();
   }
 
@@ -248,6 +264,9 @@ export class SgdsTabGroup extends SgdsElement {
     }
     if (_changedProperties.has("density")) {
       this._updateTabsAttribute("density");
+    }
+    if (_changedProperties.has("tone")) {
+      this._updateTabsAttribute("tone");
     }
   }
 

--- a/src/components/Tab/tab-panel.css
+++ b/src/components/Tab/tab-panel.css
@@ -5,3 +5,15 @@
 .tab-panel:not(.tab-panel--active) {
   display: none;
 }
+
+:host([tone="inverse"]) .tab-panel {
+  color: var(--sgds-color-inverse);
+}
+
+:host([tone="fixed-dark"]) .tab-panel {
+  color: var(--sgds-color-fixed-dark);
+}
+
+:host([tone="fixed-light"]) .tab-panel {
+  color: var(--sgds-color-fixed-light);
+}

--- a/src/components/Tab/tab.css
+++ b/src/components/Tab/tab.css
@@ -12,14 +12,68 @@
   border-radius: var(--sgds-border-radius-md);
 }
 
-:host([variant="solid"][active]) .tab {
+:host([variant="solid"][tone="inverse"]) .tab {
+  background-color: var(--sgds-bg-translucent-inverse);
+}
+
+:host([variant="solid"][tone="fixed-light"]) .tab {
+  background-color: var(--sgds-bg-translucent-fixed-dark);
+}
+
+:host([variant="solid"][active][tone="brand"]) .tab {
   background-color: var(--sgds-primary-surface-default);
+  color: var(--sgds-color-fixed-light);
+}
+
+:host([variant="solid"][active][tone="neutral"]) .tab {
+  background-color: var(--sgds-neutral-surface-default);
+  color: var(--sgds-color-fixed-light);
+}
+
+:host([variant="solid"]:not([active])[tone="inverse"]) .tab {
+  color: var(--sgds-surface-inverse);
+}
+
+:host([variant="solid"][active][tone="inverse"]) .tab {
+  background-color: var(--sgds-surface-inverse);
+  color: var(--sgds-color-inverse);
+}
+
+:host([variant="solid"]:not([active])[tone="fixed-light"]) .tab {
+  color: var(--sgds-color-fixed-light);
+}
+
+:host([variant="solid"][active][tone="fixed-light"]) .tab {
+  background-color: var(--sgds-surface-fixed-light);
+  color: var(--sgds-color-fixed-dark);
+}
+
+:host([variant="solid"]:not([active])[tone="fixed-dark"]) .tab {
+  background-color: var(--sgds-bg-translucent-fixed-light);
+  color: var(--sgds-color-fixed-dark);
+}
+
+:host([variant="solid"][active][tone="fixed-dark"]) .tab {
+  background-color: var(--sgds-surface-fixed-dark);
   color: var(--sgds-color-fixed-light);
 }
 
 :host([variant="solid"]:not([active]):not([disabled])) .tab:focus,
 :host([variant="solid"]:not([active]):not([disabled])) .tab:focus-visible {
   background-color: var(--sgds-bg-translucent);
+}
+:host([variant="solid"][tone="inverse"]:not([active]):not([disabled])) .tab:focus,
+:host([variant="solid"][tone="inverse"]:not([active]):not([disabled])) .tab:focus-visible {
+  background-color: var(--sgds-bg-translucent-inverse-emphasis);
+}
+:host([variant="solid"][tone="fixed-light"]:not([active]):not([disabled])) .tab:focus,
+:host([variant="solid"][tone="fixed-light"]:not([active]):not([disabled])) .tab:focus-visible {
+  background-color: var(--sgds-bg-translucent-fixed-dark-emphasis);
+}
+
+:host([variant="solid"][tone="fixed-dark"]:not([active]):not([disabled])) .tab:focus,
+:host([variant="solid"][tone="fixed-dark"]:not([active]):not([disabled])) .tab:focus-visible {
+  background-color: var(--sgds-bg-translucent-fixed-light-emphasis);
 }
 
 :host([variant="solid"]:not([active]):not([disabled])) .tab:focus-visible {
@@ -31,13 +85,40 @@
   background-color: var(--sgds-bg-translucent);
 }
 
+:host([variant="solid"][tone="inverse"]:not([active]):not([disabled])) .tab:hover {
+  background-color: var(--sgds-bg-translucent-inverse-emphasis);
+
+}
+:host([variant="solid"][tone="fixed-dark"]:not([active]):not([disabled])) .tab:hover {
+  background-color: var(--sgds-bg-translucent-fixed-light-emphasis);
+}
+:host([variant="solid"][tone="fixed-light"]:not([active]):not([disabled])) .tab:hover {
+  background-color: var(--sgds-bg-translucent-fixed-dark-emphasis);
+}
+
 :host([disabled]) .tab {
   opacity: var(--sgds-opacity-40);
   cursor: not-allowed;
 }
 
-:host([variant="underlined"][active]) .tab {
+:host([variant="underlined"][active][tone="brand"]) .tab {
   color: var(--sgds-primary-color-default);
+}
+
+:host([variant="underlined"][active][tone="neutral"]) .tab {
+  color: var(--sgds-neutral-color-default);
+}
+
+:host([variant="underlined"][tone="fixed-dark"]) .tab {
+  color: var(--sgds-color-fixed-dark);
+}
+
+:host([variant="underlined"][tone="inverse"]) .tab {
+  color: var(--sgds-color-inverse);
+}
+
+:host([variant="underlined"][tone="fixed-light"]) .tab {
+  color: var(--sgds-color-fixed-light);
 }
 
 :host([variant="underlined"][orientation="vertical"][active]) .tab::after {
@@ -47,7 +128,6 @@
   right: -1px;
   width: var(--sgds-border-width-4);
   height: 100%;
-  background-color: var(--sgds-primary-surface-default);
 }
 
 :host([variant="underlined"][orientation="horizontal"][active]) .tab::after {
@@ -57,7 +137,26 @@
   left: 0;
   height: var(--sgds-border-width-4);
   width: 100%;
+}
+
+:host([variant="underlined"][active][tone="brand"]) .tab::after {
   background-color: var(--sgds-primary-surface-default);
+}
+
+:host([variant="underlined"][active][tone="neutral"]) .tab::after {
+  background-color: var(--sgds-neutral-surface-default);
+}
+
+:host([variant="underlined"][active][tone="inverse"]) .tab::after {
+  background-color: var(--sgds-color-inverse);
+}
+
+:host([variant="underlined"][active][tone="fixed-dark"]) .tab::after {
+  background-color: var(--sgds-surface-fixed-dark);
+}
+
+:host([variant="underlined"][active][tone="fixed-light"]) .tab::after {
+  background-color: var(--sgds-surface-fixed-light);
 }
 
 :host([variant="underlined"]:not([active]):not([disabled])) .tab:focus,
@@ -71,8 +170,20 @@
   outline-offset: var(--sgds-outline-offset-focus);
 }
 
+:host([variant="underlined"][tone="inverse"]:not([active]):not([disabled])) .tab:focus,
+:host([variant="underlined"][tone="inverse"]:not([active]):not([disabled])) .tab:focus-visible,
+:host([variant="underlined"][tone="fixed-light"]:not([active]):not([disabled])) .tab:focus,
+:host([variant="underlined"][tone="fixed-light"]:not([active]):not([disabled])) .tab:focus-visible {
+  background-color: var(--sgds-bg-translucent);
+}
+
 :host([variant="underlined"]:not([active]):not([disabled])) .tab:hover {
   background-color: var(--sgds-bg-translucent-subtle);
+}
+
+:host([variant="underlined"][tone=inverse]:not([active]):not([disabled])) .tab:hover,
+:host([variant="underlined"][tone=fixed-light]:not([active]):not([disabled])) .tab:hover {
+  background-color: var(--sgds-bg-translucent);
 }
 
 .tab {

--- a/src/themes/day.css
+++ b/src/themes/day.css
@@ -13,8 +13,11 @@
   --sgds-bg-translucent-subtle: oklch(from var(--sgds-gray-1100) l c h / 0.05);
   --sgds-bg-transparent: transparent;
   --sgds-bg-translucent-inverse: oklch(from var(--sgds-gray-000) l c h / 0.2);
+  --sgds-bg-translucent-inverse-emphasis: oklch(from var(--sgds-gray-000) l c h / 0.5);
   --sgds-bg-translucent-fixed-dark: oklch(from var(--sgds-gray-1100) l c h / 0.2);
+  --sgds-bg-translucent-fixed-dark-emphasis: oklch(from var(--sgds-gray-1100) l c h / 0.5);
   --sgds-bg-translucent-fixed-light: oklch(from var(--sgds-gray-000) l c h / 0.2);
+  --sgds-bg-translucent-fixed-light-emphasis: oklch(from var(--sgds-gray-000) l c h / 0.5);
   --sgds-surface-default: var(--sgds-gray-000);
   --sgds-surface-raised: var(--sgds-gray-100);
   --sgds-surface-inverse: var(--sgds-gray-900);

--- a/src/themes/night.css
+++ b/src/themes/night.css
@@ -13,8 +13,11 @@
   --sgds-bg-translucent-subtle: oklch(from var(--sgds-gray-000) l c h / 0.1);
   --sgds-bg-transparent: transparent;
   --sgds-bg-translucent-inverse: oklch(from var(--sgds-gray-1100) l c h / 0.2);
+  --sgds-bg-translucent-inverse-emphasis: oklch(from var(--sgds-gray-1100) l c h / 0.5);
   --sgds-bg-translucent-fixed-dark: oklch(from var(--sgds-gray-1100) l c h / 0.2);
+  --sgds-bg-translucent-fixed-dark-emphasis: oklch(from var(--sgds-gray-1100) l c h / 0.5);
   --sgds-bg-translucent-fixed-light: oklch(from var(--sgds-gray-000) l c h / 0.2);
+  --sgds-bg-translucent-fixed-light-emphasis: oklch(from var(--sgds-gray-000) l c h / 0.5);
   --sgds-surface-default: var(--sgds-gray-900);
   --sgds-surface-raised: var(--sgds-gray-800);
   --sgds-surface-inverse: var(--sgds-gray-000);

--- a/stories/component-templates/Spinner/additional.mdx
+++ b/stories/component-templates/Spinner/additional.mdx
@@ -1,18 +1,14 @@
 ## Tone
 
-Spinners come in various tones: brand, neutral, inverse, fixed-light, and fixed-dark.
+Spinners come in various tones: `brand`(default), `neutral`, `inverse`, `fixed-light`, and `fixed-dark`.
 
 <Canvas of={SpinnerStories.Tone}>
   <Story of={SpinnerStories.Tone} />
 </Canvas>
 
-<Canvas of={SpinnerStories.ToneInverseFixedLight}>
-  <Story of={SpinnerStories.ToneInverseFixedLight} parameters={{ backgrounds: { default: "custom-blue" } }} />
-</Canvas>
-
 ## Size
 
-There are three sizes of spinners: extra-small, small, medium(default), large and extra-large.
+There are five sizes of spinners: `xs`, `sm`, `md`(default), `lg`, and `xl`.
 
 <Canvas of={SpinnerStories.Size}>
   <Story of={SpinnerStories.Size} />
@@ -32,4 +28,12 @@ Set the orientation of the label to horizontal with `orientation` prop set to "h
 
 <Canvas of={SpinnerStories.LabelHorizontal}>
   <Story of={SpinnerStories.LabelHorizontal} />
+</Canvas>
+
+## Variant (deprecated)
+
+`variant` has been deprecated in favor of the `tone`.
+
+<Canvas of={SpinnerStories.Variant}>
+  <Story of={SpinnerStories.Variant} />
 </Canvas>

--- a/stories/component-templates/Spinner/additional.stories.js
+++ b/stories/component-templates/Spinner/additional.stories.js
@@ -1,15 +1,17 @@
 import { html } from "lit";
 
-const ToneTemplate = () => html`
+const VariantTemplate = () => html`
   <sgds-spinner variant="primary"></sgds-spinner>
   <sgds-spinner variant="neutral"></sgds-spinner>
-  <sgds-spinner tone="brand"></sgds-spinner>
-  <sgds-spinner tone="neutral"></sgds-spinner>
-  <sgds-spinner tone="fixed-dark"></sgds-spinner>
 `;
 
-const ToneInverseAndFixedLightTemplate = () => html`
-  <div style="padding: 12px; background-color: #222;">
+const ToneTemplate = () => html`
+  <div class="sgds:p-component-xs">
+    <sgds-spinner tone="brand"></sgds-spinner>
+    <sgds-spinner tone="neutral"></sgds-spinner>
+    <sgds-spinner tone="fixed-dark"></sgds-spinner>
+  </div>
+  <div class="sgds:p-component-xs sgds:bg-surface-fixed-dark">
     <sgds-spinner tone="inverse"></sgds-spinner>
     <sgds-spinner tone="fixed-light"></sgds-spinner>
   </div>
@@ -22,6 +24,14 @@ const SizeTemplate = () => html`
   <sgds-spinner size="xl"></sgds-spinner>
 `;
 
+export const Variant = {
+  render: VariantTemplate.bind({}),
+  name: "Variant",
+  args: {},
+  parameters: {},
+  tags: ["!dev"]
+};
+
 export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
@@ -29,13 +39,6 @@ export const Tone = {
   parameters: {
     backgrounds: { default: "custom-blue" }
   },
-  tags: ["!dev"]
-};
-export const ToneInverseFixedLight = {
-  render: ToneInverseAndFixedLightTemplate.bind({}),
-  name: "Tone - inverse and fixed light",
-  args: {},
-  parameters: {},
   tags: ["!dev"]
 };
 

--- a/stories/component-templates/Tab/additional.mdx
+++ b/stories/component-templates/Tab/additional.mdx
@@ -1,7 +1,7 @@
 ## Variants
 
-The variants of tab is controlled by `SgdsTabGroup`
-The default tab variant is `underlined`. Modify the `variant` prop to achieve solid tabs
+The variants of tab is controlled by `SgdsTabGroup`.
+The default tab variant is `underlined`. Modify the `variant` prop to achieve solid tabs.
 
 ### Underlined tabs (default)
 
@@ -13,6 +13,40 @@ The default tab variant is `underlined`. Modify the `variant` prop to achieve so
 
 <Canvas of={TabStories.SolidVariant}>
   <Story of={TabStories.SolidVariant} />
+</Canvas>
+
+## Tone
+The tone of tab is also controlled by `SgdsTabGroup`.
+The available tones of tabs are `brand`(default), `neutral`, `inverse`, `fixed-light`, and `fixed-dark`.
+
+### Brand tone (default)
+
+<Canvas of={TabStories.BrandTone}>
+  <Story of={TabStories.BrandTone} />
+</Canvas>
+
+### Neutral tone
+
+<Canvas of={TabStories.NeutralTone}>
+  <Story of={TabStories.NeutralTone} />
+</Canvas>
+
+### Fixed dark tone
+
+<Canvas of={TabStories.FixedDarkTone}>
+  <Story of={TabStories.FixedDarkTone} />
+</Canvas>
+
+### Inverse tone
+
+<Canvas of={TabStories.InverseTone}>
+  <Story of={TabStories.InverseTone} />
+</Canvas>
+
+### Fixed light tone
+
+<Canvas of={TabStories.FixedLightTone}>
+  <Story of={TabStories.FixedLightTone} />
 </Canvas>
 
 ## Density

--- a/stories/component-templates/Tab/additional.stories.js
+++ b/stories/component-templates/Tab/additional.stories.js
@@ -1,9 +1,92 @@
 import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 export const SolidVariant = {
   render: Template.bind({}),
   name: "Solid variant",
   args: { variant: "solid" },
+  parameters: {},
+  tags: ["!dev"]
+};
+
+export const LightToneTemplate = ({ tone }) => html`
+  <div class="sgds:p-component-xs">
+    <sgds-tab-group variant="underlined" tone="${ifDefined(tone)}">
+      <sgds-tab slot="nav" panel="home">Home</sgds-tab>
+      <sgds-tab slot="nav" panel="profile">Profile</sgds-tab>
+      <sgds-tab slot="nav" panel="contact">Contact</sgds-tab>
+      <sgds-tab-panel name="home">Home information</sgds-tab-panel>
+      <sgds-tab-panel name="profile">Profile information</sgds-tab-panel>
+      <sgds-tab-panel name="contact">Contact information</sgds-tab-panel>
+    </sgds-tab-group>
+  </div>
+  <div class="sgds:p-component-xs">
+    <sgds-tab-group variant="solid" tone="${ifDefined(tone)}">
+      <sgds-tab slot="nav" panel="home">Home</sgds-tab>
+      <sgds-tab slot="nav" panel="profile">Profile</sgds-tab>
+      <sgds-tab slot="nav" panel="contact">Contact</sgds-tab>
+      <sgds-tab-panel name="home">Home information</sgds-tab-panel>
+      <sgds-tab-panel name="profile">Profile information</sgds-tab-panel>
+      <sgds-tab-panel name="contact">Contact information</sgds-tab-panel>
+    </sgds-tab-group>
+  </div>
+`;
+
+export const DarkToneTemplate = ({ tone }) => html`
+  <div class="sgds:p-component-xs sgds:bg-primary-default">
+    <sgds-tab-group variant="underlined" tone="${ifDefined(tone)}">
+      <sgds-tab slot="nav" panel="home">Home</sgds-tab>
+      <sgds-tab slot="nav" panel="profile">Profile</sgds-tab>
+      <sgds-tab slot="nav" panel="contact">Contact</sgds-tab>
+      <sgds-tab-panel name="home">Home information</sgds-tab-panel>
+      <sgds-tab-panel name="profile">Profile information</sgds-tab-panel>
+      <sgds-tab-panel name="contact">Contact information</sgds-tab-panel>
+    </sgds-tab-group>
+  </div>
+  <div class="sgds:p-component-xs sgds:bg-primary-default">
+    <sgds-tab-group variant="solid" tone="${ifDefined(tone)}">
+      <sgds-tab slot="nav" panel="home">Home</sgds-tab>
+      <sgds-tab slot="nav" panel="profile">Profile</sgds-tab>
+      <sgds-tab slot="nav" panel="contact">Contact</sgds-tab>
+      <sgds-tab-panel name="home">Home information</sgds-tab-panel>
+      <sgds-tab-panel name="profile">Profile information</sgds-tab-panel>
+      <sgds-tab-panel name="contact">Contact information</sgds-tab-panel>
+    </sgds-tab-group>
+  </div>
+`;
+
+export const BrandTone = {
+  render: LightToneTemplate.bind({}),
+  name: "Primary tone",
+  args: { tone: "brand" },
+  parameters: {},
+  tags: ["!dev"]
+};
+export const NeutralTone = {
+  render: LightToneTemplate.bind({}),
+  name: "Neutral tone",
+  args: { tone: "neutral" },
+  parameters: {},
+  tags: ["!dev"]
+};
+export const FixedDarkTone = {
+  render: DarkToneTemplate.bind({}),
+  name: "Fixed dark tone",
+  args: { tone: "fixed-dark" },
+  parameters: {},
+  tags: ["!dev"]
+};
+export const InverseTone = {
+  render: DarkToneTemplate.bind({}),
+  name: "Fixed dark tone",
+  args: { tone: "inverse" },
+  parameters: {},
+  tags: ["!dev"]
+};
+export const FixedLightTone = {
+  render: DarkToneTemplate.bind({}),
+  name: "Fixed dark tone",
+  args: { tone: "fixed-light" },
   parameters: {},
   tags: ["!dev"]
 };

--- a/stories/utilities/background-color.stories.js
+++ b/stories/utilities/background-color.stories.js
@@ -47,15 +47,32 @@ export const Grayscales = () =>
     ColorItem("sgds:bg-transparent", "transparent", "sgds:bg-transparent sgds:border sgds:border-default"),
     ColorItem("sgds:bg-translucent-inverse", "--sgds-bg-translucent-inverse", "sgds:bg-translucent-inverse"),
     ColorItem(
+      "sgds:bg-translucent-inverse-emphasis",
+      "--sgds-bg-translucent-inverse-emphasis",
+      "sgds:bg-translucent-inverse-emphasis"
+    ),
+    ColorItem(
       "sgds:bg-translucent-fixed-dark",
       "--sgds-bg-translucent-fixed-dark",
       "sgds:bg-translucent-fixed-dark",
       "sgds:text-fixed-light"
     ),
     ColorItem(
+      "sgds:bg-translucent-fixed-dark-emphasis",
+      "--sgds-bg-translucent-fixed-dark-emphasis",
+      "sgds:bg-translucent-fixed-dark-emphasis",
+      "sgds:text-fixed-light"
+    ),
+    ColorItem(
       "sgds:bg-translucent-fixed-light",
       "--sgds-bg-translucent-fixed-light",
       "sgds:bg-translucent-fixed-light",
+      "sgds:text-fixed-dark"
+    ),
+    ColorItem(
+      "sgds:bg-translucent-fixed-light-emphasis",
+      "--sgds-bg-translucent-fixed-light-emphasis",
+      "sgds:bg-translucent-fixed-light-emphasis",
       "sgds:text-fixed-dark"
     )
   );

--- a/test/tab.test.ts
+++ b/test/tab.test.ts
@@ -160,7 +160,8 @@ describe("<sgds-tab-group>", () => {
   const propsToForwardToChild = [
     { name: "variant", defaultValue: "underlined", changedValue: "solid" },
     { name: "density", defaultValue: "default", changedValue: "compact" },
-    { name: "orientation", defaultValue: "horizontal", changedValue: "vertical" }
+    { name: "orientation", defaultValue: "horizontal", changedValue: "vertical" },
+    { name: "tone", defaultValue: "brand", changedValue: "inverse" }
   ];
   propsToForwardToChild.forEach(({ name, defaultValue, changedValue }) => {
     it(`change of ${name} prop updates its sgds-tab children`, async () => {
@@ -175,10 +176,16 @@ describe("<sgds-tab-group>", () => {
         </sgds-tab-group>
       `);
       const tabs = tabGroup.querySelectorAll("sgds-tab") as NodeListOf<SgdsTab>;
+      const tabPanels = tabGroup.querySelectorAll("sgds-tab-panel") as NodeListOf<SgdsTabPanel>;
+
       tabs.forEach(tab => expect(tab.getAttribute(name)).to.equal(defaultValue));
+      tabPanels.forEach(tab => expect(tab.getAttribute(name)).to.equal(defaultValue));
+
       tabGroup[name] = changedValue;
       await tabGroup.updateComplete;
+
       tabs.forEach(tab => expect(tab.getAttribute(name)).to.equal(changedValue));
+      tabPanels.forEach(tab => expect(tab.getAttribute(name)).to.equal(changedValue));
     });
   });
 });


### PR DESCRIPTION
## :open_book: Description

- Adds to `sgds-tab` the following `tone` variants: `neutral`, `inverse`, `fixed-light`, and `fixed-dark`.
- Expanded color library with the following colors: `--sgds-bg-translucent-inverse-emphasis`, `--sgds-bg-translucent-fixed-light-emphasis`, and `--sgds-bg-translucent-fixed-dark-emphasis`. All `-emphasis` variants are 50% opacity variants of exisiting `--sgds-bg-translucent-*` colors.
- Updated `sgds-spinner` stories to be easier to read.


Implements #697 

## :pencil2: Type of change
- [x] New feature (non-breaking change which adds functionality)

## :test_tube: How Has This Been Tested?

- [x] Updated existing unit test to include `tone` updates

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
