### PR TITLE
fix(Masthead): use tokenise color scheme to switch between day and night [run-chromatic][skip-cd]

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>SGDS Playground - Component Examples</title>
     <script type="module" src="../src/index.ts"></script>
     <link href="./src/themes/day.css" rel="stylesheet" type="text/css" />
+    <link href="./src/themes/night.css" rel="stylesheet" type="text/css" />
     <link href="./src/css/sgds.css" rel="stylesheet" type="text/css" />
     <link href="./playground/css/utility.css" rel="stylesheet" type="text/css" />
 

--- a/playground/Masthead.html
+++ b/playground/Masthead.html
@@ -1,4 +1,6 @@
 <script type="module" src="../src/index.ts"></script>
 <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
+<link href="../src/themes/day.css" rel="stylesheet" type="text/css" />
+<link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
 
 <sgds-masthead></sgds-masthead>

--- a/src/components/Masthead/masthead.css
+++ b/src/components/Masthead/masthead.css
@@ -26,6 +26,7 @@ a:hover {
   line-height: 1.25rem;
   font-size: 0.875rem;
   font-family: "Inter", system-ui, sans-serif;
+  color-scheme: var(--sgds-color-scheme, only light);
 }
 
 .banner {

--- a/src/themes/day.css
+++ b/src/themes/day.css
@@ -1,6 +1,7 @@
 @import "./root.css";
 :root {
   color-scheme: only light;
+  --sgds-color-scheme: only light;
 
   /* Semantic - Default Colors */
   --sgds-bg-default: var(--sgds-gray-000);

--- a/src/themes/night.css
+++ b/src/themes/night.css
@@ -1,6 +1,7 @@
 @import "./root.css";
 :root.sgds-night-theme {
   color-scheme: only dark;
+  --sgds-color-scheme: only dark;
 
   /* Semantic - Default Colors */
   --sgds-bg-default: var(--sgds-gray-1100);


### PR DESCRIPTION
## :open_book: Description

The CSS approach to force masthead to light mode unless .sgds-night-theme and night theme css is loaded -->changes value of --sgds-color-scheme --> masthead becomes dark only --> override light only color-scheme --> light-dark() of css switch approprirately 

by default always light only for masthead. 
https://github.com/GovTechSG/sgds-web-component/issues/692



Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
