### PR TITLE
fix(TabPanel): add inert attr to prevent interactive elements from being reachable when panel hidden [skip-cd]

### DIFF
--- a/oobee/tab.html
+++ b/oobee/tab.html
@@ -1,0 +1,773 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height" />
+    <script type="module" src="../src/index.ts"></script>
+    <link href="../src/themes/day.css" rel="stylesheet" type="text/css" />
+    <link href="../src/themes/night.css" rel="stylesheet" type="text/css" />
+    <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
+    <style>
+      .container {
+        max-width: 900px;
+        margin: 36px auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+
+      <!-- ========================================
+           VARIANT: underlined (default)
+           ORIENTATION: horizontal (default)
+           DENSITY: default
+           Interactive content: buttons, links, inputs
+           ======================================== -->
+      <div>
+        <h2>Underlined / Horizontal / Default Density</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: underlined
+           ORIENTATION: horizontal
+           DENSITY: compact
+           ======================================== -->
+      <div>
+        <h2>Underlined / Horizontal / Compact Density</h2>
+        <sgds-tab-group density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: underlined
+           ORIENTATION: vertical
+           DENSITY: default
+           ======================================== -->
+      <div>
+        <h2>Underlined / Vertical / Default Density</h2>
+        <sgds-tab-group orientation="vertical">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: underlined
+           ORIENTATION: vertical
+           DENSITY: compact
+           ======================================== -->
+      <div>
+        <h2>Underlined / Vertical / Compact Density</h2>
+        <sgds-tab-group orientation="vertical" density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: solid
+           ORIENTATION: horizontal
+           DENSITY: default
+           ======================================== -->
+      <div>
+        <h2>Solid / Horizontal / Default Density</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: solid
+           ORIENTATION: horizontal
+           DENSITY: compact
+           ======================================== -->
+      <div>
+        <h2>Solid / Horizontal / Compact Density</h2>
+        <sgds-tab-group variant="solid" density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: solid
+           ORIENTATION: vertical
+           DENSITY: default
+           ======================================== -->
+      <div>
+        <h2>Solid / Vertical / Default Density</h2>
+        <sgds-tab-group variant="solid" orientation="vertical">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           VARIANT: solid
+           ORIENTATION: vertical
+           DENSITY: compact
+           ======================================== -->
+      <div>
+        <h2>Solid / Vertical / Compact Density</h2>
+        <sgds-tab-group variant="solid" orientation="vertical" density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel with <a href="#">another link</a> and a <button type="button">button</button>.</p>
+            <select><option>Option 1</option><option>Option 2</option></select>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           TAB-LEVEL STATES: active (non-first tab)
+           ======================================== -->
+      <div>
+        <h2>Active on Second Tab (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" active>Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>First panel (hidden) with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Hidden input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel (active) with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel (hidden) with <a href="#">link</a>.</p>
+            <textarea placeholder="Hidden textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Active on Second Tab (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" active>Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>First panel (hidden) with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Hidden input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Second panel (active) with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel (hidden) with <a href="#">link</a>.</p>
+            <textarea placeholder="Hidden textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           TAB-LEVEL STATES: disabled
+           ======================================== -->
+      <div>
+        <h2>Disabled Tab (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" disabled>Tab 2 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Disabled tab panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Unreachable input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Disabled Tab (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" disabled>Tab 2 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Text input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Disabled tab panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+            <input type="text" placeholder="Unreachable input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Third panel with <a href="#">link</a>.</p>
+            <textarea placeholder="Textarea"></textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           TAB-LEVEL STATES: multiple disabled
+           ======================================== -->
+      <div>
+        <h2>Multiple Disabled Tabs (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" disabled>Tab 2 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" disabled>Tab 3 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab4" ariaLabel="Tab 4">Tab 4</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">a link</a> and a <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Disabled panel with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Disabled panel with <button type="button">button</button> and <select><option>select</option></select>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab4">
+            <p>Fourth panel with <a href="#">link</a> and <textarea placeholder="textarea"></textarea>.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           TAB-LEVEL STATES: disabled + active combo
+           ======================================== -->
+      <div>
+        <h2>First Tab Disabled, Active on Third (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" active>Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Disabled panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Unreachable" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Hidden input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>First Tab Disabled, Active on Third (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" active>Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Disabled panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Unreachable" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Hidden input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           COMBINED: variant + orientation + density + disabled + active
+           ======================================== -->
+      <div>
+        <h2>Underlined / Vertical / Compact / Disabled + Active</h2>
+        <sgds-tab-group orientation="vertical" density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" active>Tab 3</sgds-tab>
+          <sgds-tab slot="nav" panel="tab4" ariaLabel="Tab 4">Tab 4</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Disabled panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab4">
+            <p>Hidden panel with <select><option>Option</option></select> and <textarea placeholder="textarea"></textarea>.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Solid / Vertical / Compact / Disabled + Active</h2>
+        <sgds-tab-group variant="solid" orientation="vertical" density="compact">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" active>Tab 3</sgds-tab>
+          <sgds-tab slot="nav" panel="tab4" ariaLabel="Tab 4">Tab 4</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Disabled panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+            <input type="text" placeholder="Visible input" />
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab4">
+            <p>Hidden panel with <select><option>Option</option></select> and <textarea placeholder="textarea"></textarea>.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           EDGE CASE: Two tabs only
+           ======================================== -->
+      <div>
+        <h2>Two Tabs Only (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Two Tabs Only (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Active panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Hidden panel with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           EDGE CASE: Many tabs
+           ======================================== -->
+      <div>
+        <h2>Many Tabs (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab slot="nav" panel="tab4" ariaLabel="Tab 4">Tab 4</sgds-tab>
+          <sgds-tab slot="nav" panel="tab5" ariaLabel="Tab 5">Tab 5</sgds-tab>
+          <sgds-tab slot="nav" panel="tab6" ariaLabel="Tab 6">Tab 6</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Panel 1 with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Panel 2 with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Panel 3 with <select><option>Option</option></select>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab4">
+            <p>Panel 4 with <textarea placeholder="textarea"></textarea>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab5">
+            <p>Panel 5 with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab6">
+            <p>Panel 6 with <input type="checkbox" /> checkbox and <input type="radio" /> radio.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Many Tabs (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab slot="nav" panel="tab4" ariaLabel="Tab 4">Tab 4</sgds-tab>
+          <sgds-tab slot="nav" panel="tab5" ariaLabel="Tab 5">Tab 5</sgds-tab>
+          <sgds-tab slot="nav" panel="tab6" ariaLabel="Tab 6">Tab 6</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Panel 1 with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Panel 2 with <a href="#">link</a> and <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Panel 3 with <select><option>Option</option></select>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab4">
+            <p>Panel 4 with <textarea placeholder="textarea"></textarea>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab5">
+            <p>Panel 5 with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab6">
+            <p>Panel 6 with <input type="checkbox" /> checkbox and <input type="radio" /> radio.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           EDGE CASE: All tabs disabled
+           ======================================== -->
+      <div>
+        <h2>All Tabs Disabled (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" disabled>Tab 2 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" disabled>Tab 3 (disabled)</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Panel with <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Panel with <select><option>Option</option></select>.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>All Tabs Disabled (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1" disabled>Tab 1 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2" disabled>Tab 2 (disabled)</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3" disabled>Tab 3 (disabled)</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <p>Panel with <a href="#">link</a> and <button type="button">button</button>.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <p>Panel with <input type="text" placeholder="input" />.</p>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <p>Panel with <select><option>Option</option></select>.</p>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           PANELS WITH SGDS COMPONENTS (interactive)
+           ======================================== -->
+      <div>
+        <h2>Panels with SGDS Interactive Components (Underlined)</h2>
+        <sgds-tab-group>
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <sgds-button ariaLabel="SGDS Button">SGDS Button</sgds-button>
+            <sgds-input label="Input" placeholder="Type here"></sgds-input>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <sgds-checkbox>Checkbox in hidden panel</sgds-checkbox>
+            <sgds-radio value="1">Radio in hidden panel</sgds-radio>
+            <sgds-link href="#">SGDS Link in hidden panel</sgds-link>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <sgds-select label="Select">
+              <sgds-select-option value="1">Option 1</sgds-select-option>
+              <sgds-select-option value="2">Option 2</sgds-select-option>
+            </sgds-select>
+            <sgds-textarea label="Textarea" placeholder="Type here"></sgds-textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Panels with SGDS Interactive Components (Solid)</h2>
+        <sgds-tab-group variant="solid">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <sgds-button ariaLabel="SGDS Button">SGDS Button</sgds-button>
+            <sgds-input label="Input" placeholder="Type here"></sgds-input>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <sgds-checkbox>Checkbox in hidden panel</sgds-checkbox>
+            <sgds-radio value="1">Radio in hidden panel</sgds-radio>
+            <sgds-link href="#">SGDS Link in hidden panel</sgds-link>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <sgds-select label="Select">
+              <sgds-select-option value="1">Option 1</sgds-select-option>
+              <sgds-select-option value="2">Option 2</sgds-select-option>
+            </sgds-select>
+            <sgds-textarea label="Textarea" placeholder="Type here"></sgds-textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           PANELS WITH SGDS COMPONENTS (Vertical)
+           ======================================== -->
+      <div>
+        <h2>Panels with SGDS Interactive Components (Underlined / Vertical)</h2>
+        <sgds-tab-group orientation="vertical">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <sgds-button ariaLabel="SGDS Button">SGDS Button</sgds-button>
+            <sgds-input label="Input" placeholder="Type here"></sgds-input>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <sgds-checkbox>Checkbox in hidden panel</sgds-checkbox>
+            <sgds-radio value="1">Radio in hidden panel</sgds-radio>
+            <sgds-link href="#">SGDS Link in hidden panel</sgds-link>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <sgds-select label="Select">
+              <sgds-select-option value="1">Option 1</sgds-select-option>
+              <sgds-select-option value="2">Option 2</sgds-select-option>
+            </sgds-select>
+            <sgds-textarea label="Textarea" placeholder="Type here"></sgds-textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <div>
+        <h2>Panels with SGDS Interactive Components (Solid / Vertical)</h2>
+        <sgds-tab-group variant="solid" orientation="vertical">
+          <sgds-tab slot="nav" panel="tab1" ariaLabel="Tab 1">Tab 1</sgds-tab>
+          <sgds-tab slot="nav" panel="tab2" ariaLabel="Tab 2">Tab 2</sgds-tab>
+          <sgds-tab slot="nav" panel="tab3" ariaLabel="Tab 3">Tab 3</sgds-tab>
+          <sgds-tab-panel name="tab1">
+            <sgds-button ariaLabel="SGDS Button">SGDS Button</sgds-button>
+            <sgds-input label="Input" placeholder="Type here"></sgds-input>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab2">
+            <sgds-checkbox>Checkbox in hidden panel</sgds-checkbox>
+            <sgds-radio value="1">Radio in hidden panel</sgds-radio>
+            <sgds-link href="#">SGDS Link in hidden panel</sgds-link>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="tab3">
+            <sgds-select label="Select">
+              <sgds-select-option value="1">Option 1</sgds-select-option>
+              <sgds-select-option value="2">Option 2</sgds-select-option>
+            </sgds-select>
+            <sgds-textarea label="Textarea" placeholder="Type here"></sgds-textarea>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+      <!-- ========================================
+           oobee-flagged pattern: exact DOM from production
+           ======================================== -->
+      <div>
+        <h2>Exact oobee-flagged pattern</h2>
+        <sgds-tab-group variant="underlined" orientation="horizontal" density="default">
+          <sgds-tab slot="nav" panel="npm" active arialabel="npm">npm</sgds-tab>
+          <sgds-tab slot="nav" panel="pnpm" arialabel="pnpm">pnpm</sgds-tab>
+          <sgds-tab slot="nav" panel="yarn" arialabel="yarn">yarn</sgds-tab>
+          <sgds-tab slot="nav" panel="bun" arialabel="bun">bun</sgds-tab>
+          <sgds-tab-panel name="npm">
+            <div class="sgds:bg-surface-default sgds:border sgds:border-muted sgds:rounded-xl sgds:box-border sgds:overflow-hidden sgds:w-full sgds:font-mono">
+              <div class="sgds:flex sgds:items-center sgds:bg-surface-default sgds:border-b sgds:border-muted sgds:gap-md sgds:justify-between sgds:min-h-[2.75rem] sgds:py-0 sgds:pl-[1rem] sgds:pr-[0.75rem]">
+                <span class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:font-regular sgds:tracking-[0.04em] sgds:leading-none sgds:uppercase sgds:select-none">Bash</span>
+                <sgds-button size="xs" variant="ghost" tone="neutral" ariaLabel="Copy code">
+                  <sgds-icon name="files" size="sm" slot="leftIcon"></sgds-icon> Copy
+                </sgds-button>
+              </div>
+              <div class="sgds:overflow-x-auto sgds:py-[1rem]" role="region" aria-label="Code example">
+                <table class="sgds:min-w-full sgds:[border-collapse:collapse]">
+                  <tbody>
+                    <tr class="sgds:leading-[1.6]">
+                      <td class="sgds:bg-surface-default sgds:border-r sgds:border-muted sgds:text-subtle sgds:font-mono sgds:text-body-sm sgds:w-[2rem] sgds:px-[0.75rem] sgds:text-right sgds:select-none sgds:align-top" aria-hidden="true">$</td>
+                      <td class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:pl-[0.75rem] sgds:pr-[1rem] sgds:align-top sgds:whitespace-pre">npm install @govtechsg/sgds-web-component</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="pnpm">
+            <div class="sgds:bg-surface-default sgds:border sgds:border-muted sgds:rounded-xl sgds:box-border sgds:overflow-hidden sgds:w-full sgds:font-mono">
+              <div class="sgds:flex sgds:items-center sgds:bg-surface-default sgds:border-b sgds:border-muted sgds:gap-md sgds:justify-between sgds:min-h-[2.75rem] sgds:py-0 sgds:pl-[1rem] sgds:pr-[0.75rem]">
+                <span class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:font-regular sgds:tracking-[0.04em] sgds:leading-none sgds:uppercase sgds:select-none">Bash</span>
+                <sgds-button size="xs" variant="ghost" tone="neutral" aria-label="Copy code">
+                  <sgds-icon name="files" size="sm" slot="leftIcon"></sgds-icon> Copy
+                </sgds-button>
+              </div>
+              <div class="sgds:overflow-x-auto sgds:py-[1rem]" role="region" aria-label="Code example">
+                <table class="sgds:min-w-full sgds:[border-collapse:collapse]">
+                  <tbody>
+                    <tr class="sgds:leading-[1.6]">
+                      <td class="sgds:bg-surface-default sgds:border-r sgds:border-muted sgds:text-subtle sgds:font-mono sgds:text-body-sm sgds:w-[2rem] sgds:px-[0.75rem] sgds:text-right sgds:select-none sgds:align-top" aria-hidden="true">$</td>
+                      <td class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:pl-[0.75rem] sgds:pr-[1rem] sgds:align-top sgds:whitespace-pre">pnpm add @govtechsg/sgds-web-component</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="yarn">
+            <div class="sgds:bg-surface-default sgds:border sgds:border-muted sgds:rounded-xl sgds:box-border sgds:overflow-hidden sgds:w-full sgds:font-mono">
+              <div class="sgds:flex sgds:items-center sgds:bg-surface-default sgds:border-b sgds:border-muted sgds:gap-md sgds:justify-between sgds:min-h-[2.75rem] sgds:py-0 sgds:pl-[1rem] sgds:pr-[0.75rem]">
+                <span class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:font-regular sgds:tracking-[0.04em] sgds:leading-none sgds:uppercase sgds:select-none">Bash</span>
+                <sgds-button size="xs" variant="ghost" tone="neutral" aria-label="Copy code">
+                  <sgds-icon name="files" size="sm" slot="leftIcon"></sgds-icon> Copy
+                </sgds-button>
+              </div>
+              <div class="sgds:overflow-x-auto sgds:py-[1rem]" role="region" aria-label="Code example">
+                <table class="sgds:min-w-full sgds:[border-collapse:collapse]">
+                  <tbody>
+                    <tr class="sgds:leading-[1.6]">
+                      <td class="sgds:bg-surface-default sgds:border-r sgds:border-muted sgds:text-subtle sgds:font-mono sgds:text-body-sm sgds:w-[2rem] sgds:px-[0.75rem] sgds:text-right sgds:select-none sgds:align-top" aria-hidden="true">$</td>
+                      <td class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:pl-[0.75rem] sgds:pr-[1rem] sgds:align-top sgds:whitespace-pre">yarn add @govtechsg/sgds-web-component</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </sgds-tab-panel>
+          <sgds-tab-panel name="bun">
+            <div class="sgds:bg-surface-default sgds:border sgds:border-muted sgds:rounded-xl sgds:box-border sgds:overflow-hidden sgds:w-full sgds:font-mono">
+              <div class="sgds:flex sgds:items-center sgds:bg-surface-default sgds:border-b sgds:border-muted sgds:gap-md sgds:justify-between sgds:min-h-[2.75rem] sgds:py-0 sgds:pl-[1rem] sgds:pr-[0.75rem]">
+                <span class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:font-regular sgds:tracking-[0.04em] sgds:leading-none sgds:uppercase sgds:select-none">Bash</span>
+                <sgds-button size="xs" variant="ghost" tone="neutral" ariaLabel="Copy code">
+                  <sgds-icon name="files" size="sm" slot="leftIcon"></sgds-icon> Copy
+                </sgds-button>
+              </div>
+              <div class="sgds:overflow-x-auto sgds:py-[1rem]" role="region" aria-label="Code example">
+                <table class="sgds:min-w-full sgds:[border-collapse:collapse]">
+                  <tbody>
+                    <tr class="sgds:leading-[1.6]">
+                      <td class="sgds:bg-surface-default sgds:border-r sgds:border-muted sgds:text-subtle sgds:font-mono sgds:text-body-sm sgds:w-[2rem] sgds:px-[0.75rem] sgds:text-right sgds:select-none sgds:align-top" aria-hidden="true">$</td>
+                      <td class="sgds:text-default sgds:font-mono sgds:text-body-sm sgds:pl-[0.75rem] sgds:pr-[1rem] sgds:align-top sgds:whitespace-pre">bun add @govtechsg/sgds-web-component</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </sgds-tab-panel>
+        </sgds-tab-group>
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/src/components/Tab/sgds-tab-panel.ts
+++ b/src/components/Tab/sgds-tab-panel.ts
@@ -31,6 +31,7 @@ export class SgdsTabPanel extends SgdsElement {
   @watch("active")
   _handleActiveChange() {
     this.setAttribute("aria-hidden", this.active ? "false" : "true");
+    this.inert = !this.active;
   }
 
   render() {

--- a/test/a11y/oobee/tab.html
+++ b/test/a11y/oobee/tab.html
@@ -6,12 +6,21 @@
   </head>
   <body>
     <sgds-tab-group>
-      <sgds-tab slot="nav" ariaLabel="Tab 1">Tab 1</sgds-tab>
-      <sgds-tab slot="nav" ariaLabel="Tab 2">Tab 2</sgds-tab>
-      <sgds-tab slot="nav" ariaLabel="Tab 3">Tab 3</sgds-tab>
-      <sgds-tab-panel>Panel 1 content</sgds-tab-panel>
-      <sgds-tab-panel>Panel 2 content</sgds-tab-panel>
-      <sgds-tab-panel>Panel 3 content</sgds-tab-panel>
+      <sgds-tab slot="nav" panel="npm" ariaLabel="npm">npm</sgds-tab>
+      <sgds-tab slot="nav" panel="pnpm" ariaLabel="pnpm">pnpm</sgds-tab>
+      <sgds-tab slot="nav" panel="yarn" ariaLabel="yarn">yarn</sgds-tab>
+      <sgds-tab-panel name="npm">
+        <p>npm install @govtechsg/sgds-web-component</p>
+        <sgds-button size="xs" variant="ghost" tone="neutral" ariaLabel="Copy code">Copy</sgds-button>
+      </sgds-tab-panel>
+      <sgds-tab-panel name="pnpm">
+        <p>pnpm add @govtechsg/sgds-web-component</p>
+        <sgds-button size="xs" variant="ghost" tone="neutral" ariaLabel="Copy code">Copy</sgds-button>
+      </sgds-tab-panel>
+      <sgds-tab-panel name="yarn">
+        <p>yarn add @govtechsg/sgds-web-component</p>
+        <sgds-button size="xs" variant="ghost" tone="neutral" ariaLabel="Copy code">Copy</sgds-button>
+      </sgds-tab-panel>
     </sgds-tab-group>
   </body>
 </html>


### PR DESCRIPTION
Issue arise when tab panels with aria-hidden have focusible interactible elements like buttons. 

Resolution: Using global inert attribute when tab panels are hidden --> https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert

inert is not a property

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
