### PR TITLE
feat(Button): value and name prop for form use case [run-chromatic][skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.19.1
+npm install @govtechsg/sgds-web-component@3.21.1
 
 ```
 
@@ -53,14 +53,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1" async crossorigin="anonymous" integrity="sha384-xlO5IlgES6fNaI1J+Ys9qAIK+M38Kp5Xv2pO0Iy/UC9tOFqHh9p3x3Cj3W0SkihT"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1" async crossorigin="anonymous" integrity="sha384-rUDf/ZJhJ3pWQW3ysktwBvtgwPDY0RYCZLdO5WlTMIpYuHWInBs4zBRynD5nMt3U"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.19.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-5OKa7RaQpYeIsx/ZOXW2ttNUa7ftAEKXiWuSgFRmlXJUaJ1Bvf3etjlCw2qqjia8"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
 
 ```
 

--- a/skills/sgds-components/reference/button.md
+++ b/skills/sgds-components/reference/button.md
@@ -94,6 +94,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `href` | string | — | Renders as `<a>`, navigates to URL |
 | `target` | string | — | `_blank`, `_self`, etc. (with `href`) |
 | `download` | string | — | Triggers file download (with `href`) |
+| `name` | string | — | Name submitted with form data (only with `type="submit"`) |
+| `value` | string | — | Value submitted with form data (only with `type="submit"`) |
 | `form` | string | — | Associates with a form by id |
 | `formaction` | string | — | Overrides form `action` |
 | `formmethod` | `post \| get` | — | Overrides form `method` |
@@ -221,6 +223,14 @@ When `href` is set, the element renders as `<a role="button">` instead of `<butt
 ```
 
 `target="_blank"` automatically adds `rel="noreferrer noopener"`.
+
+## `name` and `value`
+
+Works identically to the native `<button>` `name`/`value` attributes. Only the clicked submit button's name/value pair is included in FormData.
+
+- Only works with `type="submit"`. Has no effect on `type="button"` or `type="reset"`.
+- Has no effect when the button is rendered as a link (i.e. when `href` is set).
+- The button is **not** a form control — it does not persist state in FormData like `<sgds-input>`. Its value is only submitted when it is the submitter.
 
 ## Form Override Attributes
 

--- a/src/base/button-element.ts
+++ b/src/base/button-element.ts
@@ -16,7 +16,7 @@ export default class ButtonElement extends SgdsElement {
   /** @internal */
   @query(".btn") protected button: HTMLButtonElement | HTMLLinkElement;
 
-  /** Sets the visual variants such as: `primary`, `outline`, `ghost`. `danger` is @deprecated since v3.5.6 */
+  /** Sets the visual variants such as: `primary`, `outline`, `ghost`. The `danger` value is deprecated since v3.5.6 — use `variant="primary"` with `tone="danger"` instead. */
   @property({ reflect: true }) variant: ButtonVariant = "primary";
 
   /** Sets the visual colour of the button: `brand`, `danger`, `fixed-light`, `neutral` */

--- a/src/components/Button/sgds-button.ts
+++ b/src/components/Button/sgds-button.ts
@@ -40,6 +40,12 @@ export class SgdsButton extends ButtonElement {
       return input.closest("form");
     }
   });
+  /** The name of the button, submitted as a name/value pair with form data only when this button is the submitter. Only works with `type="submit"`. Has no effect when the button is rendered as a link (i.e. when `href` is set). */
+  @property({ type: String, reflect: true }) name: string;
+
+  /** The value of the button, submitted as a name/value pair with form data only when this button is the submitter. Only works with `type="submit"`. Has no effect when the button is rendered as a link (i.e. when `href` is set). */
+  @property({ type: String, reflect: true }) value: string;
+
   /** The behavior of the button with default as `type='button', `reset` resets all the controls to their initial values and `submit` submits the form data to the server */
   @property({ type: String, reflect: true }) type: "button" | "submit" | "reset" = "button";
   /**
@@ -118,6 +124,8 @@ export class SgdsButton extends ButtonElement {
         })}"
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         type=${ifDefined(isLink ? undefined : this.type)}
+        name=${ifDefined(isLink ? undefined : this.name)}
+        value=${ifDefined(isLink ? undefined : this.value)}
         href=${ifDefined(isLink ? this.href : undefined)}
         target=${ifDefined(isLink ? this.target : undefined)}
         download=${ifDefined(isLink ? this.download : undefined)}

--- a/src/utils/formSubmitController.ts
+++ b/src/utils/formSubmitController.ts
@@ -52,6 +52,12 @@ export class FormSubmitController implements ReactiveController {
             button.setAttribute(attr, invoker.getAttribute(attr));
           }
         });
+
+        // Forward name/value so the submitter's data is included in FormData
+        if (type === "submit" && invoker.hasAttribute("name")) {
+          button.name = invoker.getAttribute("name");
+          button.value = invoker.getAttribute("value") || "";
+        }
       }
 
       this.form.append(button);

--- a/stories/component-templates/Button/additional.mdx
+++ b/stories/component-templates/Button/additional.mdx
@@ -62,6 +62,14 @@ Add `disabled` prop to the button to apply the disabled state
   <Story of={ButtonStories.Disabled} />
 </Canvas>
 
+## Form submit with name and value
+
+Set `name` and `value` on a submit button to include its value in FormData when clicked. This is useful when a form has multiple submit buttons and you need to identify which one was pressed. Only the clicked button's name/value pair is submitted.
+
+<Canvas of={ButtonStories.FormSubmitValue}>
+  <Story of={ButtonStories.FormSubmitValue} />
+</Canvas>
+
 ## Loading state
 
 To set a button's loading state, set the component's `loading` prop. When loading is true, it shows a spinner and the slotted content gets overridden.

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -128,6 +128,34 @@ export const ButtonWithIcon = {
   tags: ["!dev"]
 };
 
+const FormSubmitTemplate = () => {
+  return html`
+    <form
+      action=""
+      method="get"
+      @submit=${e => {
+        e.preventDefault();
+        const formData = new FormData(e.target, e.submitter);
+        document.getElementById("form-output").textContent = "Selected: " + formData.get("subject");
+      }}
+    >
+      <p>Choose your favourite subject:</p>
+      <sgds-button name="subject" type="submit" value="fav_HTML" ariaLabel="HTML">HTML</sgds-button>
+      <sgds-button name="subject" type="submit" value="fav_CSS" ariaLabel="CSS">CSS</sgds-button>
+      <sgds-button name="subject" type="submit" value="fav_JS" ariaLabel="JavaScript">JavaScript</sgds-button>
+    </form>
+    <p id="form-output"></p>
+  `;
+};
+
+export const FormSubmitValue = {
+  render: FormSubmitTemplate.bind({}),
+  name: "Form submit with name and value",
+  args: {},
+  parameters: {},
+  tags: ["!dev"]
+};
+
 export const Loading = {
   render: () => html`
     <div class="d-flex-column">

--- a/test/a11y/oobee/button.html
+++ b/test/a11y/oobee/button.html
@@ -17,8 +17,8 @@
 
     <form action="" method="get">
       Choose your favorite subject:
-      <sgds-button name="subject" type="submit" value="fav_HTML">HTML</sgds-button>
-      <sgds-button name="subject" type="submit" value="fav_CSS">CSS</sgds-button>
+      <sgds-button name="subject" type="submit" value="fav_HTML" ariaLabel="HTML">HTML</sgds-button>
+      <sgds-button name="subject" type="submit" value="fav_CSS" ariaLabel="CSS">CSS</sgds-button>
     </form>
   </body>
 </html>

--- a/test/a11y/oobee/button.html
+++ b/test/a11y/oobee/button.html
@@ -14,5 +14,11 @@
     <sgds-icon-button name="plus" ariaLabel="Add item"></sgds-icon-button>
 
     <sgds-close-button></sgds-close-button>
+
+    <form action="" method="get">
+      Choose your favorite subject:
+      <sgds-button name="subject" type="submit" value="fav_HTML">HTML</sgds-button>
+      <sgds-button name="subject" type="submit" value="fav_CSS">CSS</sgds-button>
+    </form>
   </body>
 </html>

--- a/test/button.element.test.ts
+++ b/test/button.element.test.ts
@@ -150,6 +150,90 @@ describe("when submitting a form", () => {
 
     expect(handleSubmit).to.have.been.calledOnce;
   });
+
+  it("should include the button's name/value in FormData when it is the submitter", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form action="" method="post">
+        <sgds-button type="submit" name="action" value="save">Save</sgds-button>
+      </form>
+    `);
+    const button = form.querySelector<SgdsButton>("sgds-button");
+    let formData: FormData;
+    const handleSubmit = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+      formData = new FormData(form);
+      // The submitter's name/value should be in FormData
+      // Note: FormData from the submit event submitter is handled by the browser
+      // We check the submitter element has the correct name/value
+      const submitter = event.submitter as HTMLButtonElement;
+      expect(submitter.name).to.equal("action");
+      expect(submitter.value).to.equal("save");
+    });
+
+    form.addEventListener("submit", handleSubmit);
+    button?.click();
+
+    expect(handleSubmit).to.have.been.calledOnce;
+  });
+
+  it("should not include name/value in FormData when the button has no name", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form action="" method="post">
+        <sgds-button type="submit" value="save">Save</sgds-button>
+      </form>
+    `);
+    const button = form.querySelector<SgdsButton>("sgds-button");
+    const handleSubmit = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+      const submitter = event.submitter as HTMLButtonElement;
+      expect(submitter.name).to.equal("");
+    });
+
+    form.addEventListener("submit", handleSubmit);
+    button?.click();
+
+    expect(handleSubmit).to.have.been.calledOnce;
+  });
+
+  it("should only include the clicked button's value when multiple submit buttons exist", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form action="" method="post">
+        <sgds-button type="submit" name="action" value="save">Save</sgds-button>
+        <sgds-button type="submit" name="action" value="delete">Delete</sgds-button>
+      </form>
+    `);
+    const deleteButton = form.querySelectorAll<SgdsButton>("sgds-button")[1];
+    const handleSubmit = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+      const submitter = event.submitter as HTMLButtonElement;
+      expect(submitter.name).to.equal("action");
+      expect(submitter.value).to.equal("delete");
+    });
+
+    form.addEventListener("submit", handleSubmit);
+    deleteButton?.click();
+
+    expect(handleSubmit).to.have.been.calledOnce;
+  });
+
+  it("should not include name/value for type='reset' buttons", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form action="" method="post">
+        <sgds-button type="submit" name="action" value="submit">Submit</sgds-button>
+        <sgds-button type="reset" name="action" value="reset">Reset</sgds-button>
+      </form>
+    `);
+    const resetButton = form.querySelectorAll<SgdsButton>("sgds-button")[1];
+    const handleSubmit = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+    });
+
+    form.addEventListener("submit", handleSubmit);
+    resetButton?.click();
+
+    // Reset should not trigger submit
+    expect(handleSubmit).to.not.have.been.called;
+  });
 });
 
 describe("when using methods", () => {


### PR DESCRIPTION
## :open_book: Description

Support button for the following use case https://www.w3schools.com/TAGs/att_button_name.asp


- new prop: `name` , `value`
- applies to type="submit" 
- not applicable when button is a link , i.e. href is present
- Affect IconButton, Button

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
