### PR TITLE
fix(Select, ComboBox): accessibility violations after menuIsOpen from oobee [skip-cd][run-chromatic]

### DIFF
--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -543,14 +543,22 @@ export class SgdsComboBox extends SelectElement {
         <!-- The input -->
         ${this._renderInput(showClearButton)} ${this._renderFeedback()}
 
-        <ul id=${this.dropdownMenuId} class="dropdown-menu" part="menu" tabindex="-1" ${ref(this.menuRef)}>
+        <div
+          id=${this.dropdownMenuId}
+          class="dropdown-menu"
+          part="menu"
+          tabindex="-1"
+          role="menu"
+          aria-label=${this.label || "Options"}
+          ${ref(this.menuRef)}
+        >
           <slot
             id="default"
             class=${classMap({ "d-none": this.loading || this.emptyMenuAsync || this.optionList.length === 0 })}
             @slotchange=${this._handleDefaultSlotChange}
           ></slot>
           ${this._renderFeedbackMenu()}
-        </ul>
+        </div>
       </div>
 
       <!-- Required an input element for constraint validation -->

--- a/src/components/Select/sgds-select.ts
+++ b/src/components/Select/sgds-select.ts
@@ -216,12 +216,12 @@ export class SgdsSelect extends SelectElement {
         ${this._renderLabel()}
         <!-- The input -->
         ${this._renderInput()} ${this._renderFeedback()}
-        <ul id=${this.dropdownMenuId} class="dropdown-menu" part="menu" tabindex="-1" ${ref(this.menuRef)}>
+        <div id=${this.dropdownMenuId} class="dropdown-menu" part="menu" tabindex="-1" role="menu" aria-label=${this.label || "Options"} ${ref(this.menuRef)}>
           <slot id="default" class=${classMap({ "is-loading": this.loading })} @slotchange=${this._handleSlotChange}
             >${this._renderMenu()}</slot
           >
           ${this.loading ? this._renderLoadingMenu() : nothing}
-        </ul>
+        </div>
       </div>
     `;
   }

--- a/src/components/Select/sgds-select.ts
+++ b/src/components/Select/sgds-select.ts
@@ -216,7 +216,15 @@ export class SgdsSelect extends SelectElement {
         ${this._renderLabel()}
         <!-- The input -->
         ${this._renderInput()} ${this._renderFeedback()}
-        <div id=${this.dropdownMenuId} class="dropdown-menu" part="menu" tabindex="-1" role="menu" aria-label=${this.label || "Options"} ${ref(this.menuRef)}>
+        <div
+          id=${this.dropdownMenuId}
+          class="dropdown-menu"
+          part="menu"
+          tabindex="-1"
+          role="menu"
+          aria-label=${this.label || "Options"}
+          ${ref(this.menuRef)}
+        >
           <slot id="default" class=${classMap({ "is-loading": this.loading })} @slotchange=${this._handleSlotChange}
             >${this._renderMenu()}</slot
           >

--- a/test/a11y/oobee/combo-box.html
+++ b/test/a11y/oobee/combo-box.html
@@ -6,7 +6,7 @@
   </head>
 
   <body>
-    <sgds-combo-box label="Select a fruit">
+    <sgds-combo-box label="Select a fruit" menuIsOpen>
       <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
       <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
       <sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>
@@ -37,6 +37,13 @@
     </sgds-combo-box>
 
     <sgds-combo-box label="Select fruits" multiSelect>
+      <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
+      <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
+      <sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>
+    </sgds-combo-box>
+
+    <!-- Multi-select menu open state -->
+    <sgds-combo-box label="Select fruits (open)" multiSelect menuIsOpen value="apple">
       <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
       <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
       <sgds-combo-box-option value="cherry">Cherry</sgds-combo-box-option>

--- a/test/a11y/oobee/progress-bar.html
+++ b/test/a11y/oobee/progress-bar.html
@@ -5,6 +5,30 @@
     <link href="/src/css/sgds.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
-    <sgds-progress-bar value="50" ariaLabel="Loading progress"></sgds-progress-bar>
+
+    <!-- Primary variant, no label -->
+    <sgds-progress-bar value="50" ariamin="0" ariamax="100" ariaLabel="Loading progress"></sgds-progress-bar>
+
+    <!-- Primary variant, with visible label -->
+    <sgds-progress-bar value="60" ariamin="0" ariamax="100" ariaLabel="File upload progress" label="60%"></sgds-progress-bar>
+
+    <!-- Neutral variant, no label -->
+    <sgds-progress-bar value="30" ariamin="0" ariamax="100" ariaLabel="Step progress" variant="neutral"></sgds-progress-bar>
+
+    <!-- Neutral variant, with visible label -->
+    <sgds-progress-bar value="75" ariamin="0" ariamax="100" ariaLabel="Download progress" variant="neutral" label="75%"></sgds-progress-bar>
+
+    <!-- Value at 0 (empty) -->
+    <sgds-progress-bar value="0" ariamin="0" ariamax="100" ariaLabel="Not started"></sgds-progress-bar>
+
+    <!-- Value at 100 (full) -->
+    <sgds-progress-bar value="100" ariamin="0" ariamax="100" ariaLabel="Complete" label="100%"></sgds-progress-bar>
+
+    <!-- Custom range (e.g. steps) -->
+    <sgds-progress-bar value="3" ariamin="0" ariamax="5" ariaLabel="Step 3 of 5" label="Step 3 of 5"></sgds-progress-bar>
+
+    <!-- Custom range, neutral variant -->
+    <sgds-progress-bar value="7" ariamin="1" ariamax="10" ariaLabel="Question 7 of 10" variant="neutral" label="7/10"></sgds-progress-bar>
+
   </body>
 </html>

--- a/test/a11y/oobee/select.html
+++ b/test/a11y/oobee/select.html
@@ -5,32 +5,32 @@
     <link href="/src/css/sgds.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
-    <sgds-select label="Choose a country">
+    <sgds-select label="Choose a country" menuIsOpen>
       <sgds-select-option value="sg">Singapore</sgds-select-option>
       <sgds-select-option value="my">Malaysia</sgds-select-option>
       <sgds-select-option value="id">Indonesia</sgds-select-option>
     </sgds-select>
 
-    <sgds-select label="Choose a country" required>
+    <sgds-select label="Choose a country" required menuIsOpen>
       <sgds-select-option value="sg">Singapore</sgds-select-option>
       <sgds-select-option value="my">Malaysia</sgds-select-option>
       <sgds-select-option value="id">Indonesia</sgds-select-option>
     </sgds-select>
 
-    <sgds-select label="Choose a country" readonly value="sg">
+    <sgds-select label="Choose a country" readonly value="sg" menuIsOpen>
       <sgds-select-option value="sg">Singapore</sgds-select-option>
       <sgds-select-option value="my">Malaysia</sgds-select-option>
       <sgds-select-option value="id">Indonesia</sgds-select-option>
     </sgds-select>
 
-    <sgds-select label="Choose a country" hintText="Select your country of residence">
+    <sgds-select label="Choose a country" hintText="Select your country of residence" menuIsOpen value="sg">
       <sgds-select-option value="sg">Singapore</sgds-select-option>
       <sgds-select-option value="my">Malaysia</sgds-select-option>
       <sgds-select-option value="id">Indonesia</sgds-select-option>
     </sgds-select>
 
-    <sgds-select label="Choose a country" invalid hasFeedback invalidFeedback="Please select a country">
-      <sgds-select-option value="sg">Singapore</sgds-select-option>
+    <sgds-select label="Choose a country" invalid hasFeedback invalidFeedback="Please select a country" menuIsOpen>
+      <sgds-select-option value="sg" active>Singapore</sgds-select-option>
       <sgds-select-option value="my">Malaysia</sgds-select-option>
       <sgds-select-option value="id">Indonesia</sgds-select-option>
     </sgds-select>

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -133,14 +133,16 @@ describe("sgds-combo-box ", () => {
           >
           </sgds-icon>
           </div>
-        <ul
+        <div
           class="dropdown-menu"
           id="id-7895-sgds-dropdown-menu-div"
           part="menu"
           tabindex="-1"
+          role="menu"
+          aria-label="Options"
           >
-              <slot></slot> 
-        </ul>
+              <slot></slot>
+        </div>
           `,
       { ignoreAttributes: ["id", "aria-controls", "aria-labelledby"] }
     );
@@ -498,19 +500,19 @@ describe("sgds-combo-box ", () => {
       ><sgds-combo-box-option value="one">One</sgds-combo-box-option>
     </sgds-combo-box>`);
     await waitUntil(() => !el.shadowRoot?.querySelector(".empty-menu"));
-    expect(el.shadowRoot?.querySelector("ul>.empty-menu")).to.not.exist;
+    expect(el.shadowRoot?.querySelector("div>.empty-menu")).to.not.exist;
     const input = el.shadowRoot?.querySelector<HTMLInputElement>("input.form-control");
     input?.focus();
 
     await el.updateComplete;
     await sendKeys({ type: "x" });
     await el.updateComplete;
-    expect(el.shadowRoot?.querySelector("ul>.empty-menu")).to.exist;
+    expect(el.shadowRoot?.querySelector("div>.empty-menu")).to.exist;
     input?.blur();
     await el.updateComplete;
     input?.click();
-    await waitUntil(() => !el.shadowRoot?.querySelector("ul>.empty-menu"));
-    expect(el.shadowRoot?.querySelector("ul>.empty-menu")).to.not.exist;
+    await waitUntil(() => !el.shadowRoot?.querySelector("div>.empty-menu"));
+    expect(el.shadowRoot?.querySelector("div>.empty-menu")).to.not.exist;
   });
   it("loading menu overrides no options menu ", async () => {
     const el = await fixture<SgdsComboBox>(html`<sgds-combo-box loading menuIsOpen> </sgds-combo-box>`);

--- a/test/select.test.ts
+++ b/test/select.test.ts
@@ -96,11 +96,13 @@ describe("<sgds-select>", () => {
             >
             </sgds-icon>
             </div>
-          <ul
+          <div
             class="dropdown-menu"
             id="id-7895-sgds-dropdown-menu-div"
             part="menu"
             tabindex="-1"
+            role="menu"
+            aria-label="Options"
             >
             <slot>
             <sgds-select-option
@@ -118,7 +120,7 @@ describe("<sgds-select>", () => {
               Option 2
             </sgds-select-option>
             </slot>
-          </ul>
+          </div>
         
             `,
       { ignoreAttributes: ["id", "aria-controls", "aria-labelledby"] }


### PR DESCRIPTION
## :open_book: Description

caught new accessibility violations after menuIsOpen

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
