### PR TITLE
fix(Table): resolve aria-required-children violation on role="table" [skip-cd][run-chromatic]

### DIFF
--- a/src/components/Table/sgds-table.ts
+++ b/src/components/Table/sgds-table.ts
@@ -101,6 +101,7 @@ export class SgdsTable extends SgdsElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.setAttribute("role", "table");
   }
 
   updated() {
@@ -168,6 +169,7 @@ export class SgdsTable extends SgdsElement {
   render() {
     return html`
       <div
+        role="rowgroup"
         class=${classMap({
           "table-responsive": this.responsive === "always",
           "table-responsive-sm": this.responsive === "sm",
@@ -177,15 +179,13 @@ export class SgdsTable extends SgdsElement {
         })}
         tabindex="0"
       >
-        <div role="table">
-          <slot id="table-slot" class=${classMap({ table: true, "no-border": !this.hasDefaultSlot })}></slot>
+        <slot id="table-slot" class=${classMap({ table: true, "no-border": !this.hasDefaultSlot })}></slot>
 
-          ${!this.hasDefaultSlot
-            ? html`<table class="table">
-                ${this._renderTable()}
-              </table>`
-            : ""}
-        </div>
+        ${!this.hasDefaultSlot
+          ? html`<table class="table">
+              ${this._renderTable()}
+            </table>`
+          : ""}
       </div>
     `;
   }


### PR DESCRIPTION
  Title: fix(Table): resolve aria-required-children violation [run-chromatic][skip-cd]                                               
                                                                                                                                     
  Summary                                                                                                                          
                                                                                                                                     
  - Fixes critical aria-required-children accessibility violation flagged by oobee browser app on the table component's              
  div[role="table"]                                                                                                                  
  - Moves role="table" from an inner shadow DOM div to the host element (<sgds-table>) so that slotted sgds-table-row[role="row"]    
  elements are valid ARIA children                                                                                                   
  - Adds role="rowgroup" to the shadow DOM wrapper div (ARIA equivalent of <thead>/<tbody>) and removes the redundant inner wrapper
  div                                                                                                                                
                                                                                                                                   
  Problem                                                                                                                            
                                                                                                                                   
  The div[role="table"] was inside the shadow DOM with only a <slot> as its DOM child. Axe-core cannot see through the slot boundary 
  to find the slotted sgds-table-row[role="row"] elements, so it reports that role="table" is missing required children.
                                                                                                                                     
  The local pnpm test:a11y did not catch this because it scopes scans to sgds-* element selectors via runA11yScan(["sgds-table",     
  ...]), which evaluates components differently from the full-page scan that the oobee browser app performs.
                                                                                                                                     
  Solution                                                                                                                           
     
  Before (invalid ARIA tree):                                                                                                        
  sgds-table                                                                                                                       
    #shadow-root
      div[role="table"]          ← axe checks this
        <slot>                   ← not a valid ARIA child
          → sgds-table-row[role="row"]  (invisible to axe)                                                                           
   
  After (valid ARIA tree):                                                                                                           
  sgds-table[role="table"]       ← host element                                                                                    
    #shadow-root                                                                                                                     
      div[role="rowgroup"]       ← valid child of table (≡ <tbody>)                                                                
        <slot>                                                                                                                       
          → sgds-table-row[role="row"]  ← valid child of rowgroup                                                                    
   
  Test plan                                                                                                                          
                                                                                                                                   
  - Run pnpm test:a11y table — should pass with 0 mustFix violations                                                                 
  - Run oobee browser app scan — should no longer flag aria-required-children on table                                             
  - Verify screen reader announces table structure correctly (VoiceOver/NVDA)                                                        
  - Visual regression: no layout changes (Chromatic) 