### PR TITLE
feat(Combobox, Input): added autocomplete prop [run-chromatic]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1" async crossorigin="anonymous" integrity="sha384-rUDf/ZJhJ3pWQW3ysktwBvtgwPDY0RYCZLdO5WlTMIpYuHWInBs4zBRynD5nMt3U"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1" async crossorigin="anonymous" integrity="sha384-8oAeZKrWToTHBOYttiplioCwNSuK4dyAl5eLvfJ+evjLWKP3l70cYN0PWNBj4ier"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
           for (const file of rootFiles) {
             const item = document.createElement("sgds-dropdown-item");
             const link = document.createElement("a");
-            link.href = file.url;
+            link.href = `./${file.url}`;
             link.textContent = file.title;
             item.appendChild(link);
             dropdown.appendChild(item);
@@ -302,7 +302,17 @@
           }, {});
 
           // Sort categories by appearance order
-          const categoryOrder = [null, "pattern", "blocks", "templates", "layouts", "patterns", "typography", "utility", "css"];
+          const categoryOrder = [
+            null,
+            "pattern",
+            "blocks",
+            "templates",
+            "layouts",
+            "patterns",
+            "typography",
+            "utility",
+            "css"
+          ];
 
           const sortedCategories = categoryOrder.filter(cat => groupedByFolder[cat]);
 

--- a/playground/Combobox.html
+++ b/playground/Combobox.html
@@ -30,7 +30,7 @@
   <div class="container">
     <div class="small-container"></div>
      <sgds-combo-box required hasFeedback multiselect clearable id="combobox-example" label="Items"
-          value="option1;option2" placeholder="ComboBox">
+          value="option1;option2" placeholder="ComboBox" name="status" autocomplete="off">
           <sgds-combo-box-option disabled value="option1">Apple</sgds-combo-box-option>
           <sgds-combo-box-option value="option2">Apricot</sgds-combo-box-option>
           <sgds-combo-box-option value="option3">Durian</sgds-combo-box-option>

--- a/playground/Combobox.html
+++ b/playground/Combobox.html
@@ -281,6 +281,41 @@
       <button onclick="document.querySelector('#novalidate-multi').setInvalid(false)">setInvalid(false)</button>
     </div>
   </div>
+
+  <div class="container">
+    <h2>Autocomplete examples</h2>
+
+    <div class="small-container" style="display: flex; flex-direction: column; gap: 2rem;">
+      <div>
+        <p><strong>autocomplete="on"</strong> (default) — browser may suggest previously entered values</p>
+        <sgds-combo-box
+          autocomplete="on"
+          label="ComboBox"
+          placeholder="Enter value"
+          hintText="Browser autocomplete enabled"
+          name="name"
+        >
+          <sgds-combo-box-option value="option1">Apple</sgds-combo-box-option>
+          <sgds-combo-box-option value="option2">Apricot</sgds-combo-box-option>
+          <sgds-combo-box-option value="option3">Durian</sgds-combo-box-option>
+        </sgds-combo-box>
+      </div>
+      <div>
+        <p><strong>autocomplete="off"</strong> — browser autocomplete suppressed</p>
+        <sgds-combo-box
+          autocomplete="off"
+          label="ComboBox"
+          placeholder="Enter value"
+          hintText="Browser autocomplete disabled"
+          name="name"
+        >
+          <sgds-combo-box-option value="option1">Apple</sgds-combo-box-option>
+          <sgds-combo-box-option value="option2">Apricot</sgds-combo-box-option>
+          <sgds-combo-box-option value="option3">Durian</sgds-combo-box-option>
+        </sgds-combo-box>
+      </div>
+    </div>
+  </div>
 </body>
 
 </html>

--- a/playground/Input.html
+++ b/playground/Input.html
@@ -4,10 +4,22 @@
 <link href="../src/css/sgds.css" rel="stylesheet" type="text/css" />
 
 <style>
-  body { padding: 24px; font-family: sans-serif; }
-  h2 { margin-top: 32px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
-  h3 { margin-top: 16px; color: #555; }
-  section { margin-bottom: 16px; }
+  body {
+    padding: 24px;
+    font-family: sans-serif;
+  }
+  h2 {
+    margin-top: 32px;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 4px;
+  }
+  h3 {
+    margin-top: 16px;
+    color: #555;
+  }
+  section {
+    margin-bottom: 16px;
+  }
 </style>
 
 <h2>States</h2>
@@ -22,7 +34,13 @@
 <sgds-input label="Readonly" value="Readonly input" readonly></sgds-input>
 
 <h3>Invalid</h3>
-<sgds-input label="Invalid" value="Bad value" invalid hasFeedback="both" invalidFeedback="This field has an error"></sgds-input>
+<sgds-input
+  label="Invalid"
+  value="Bad value"
+  invalid
+  hasFeedback="both"
+  invalidFeedback="This field has an error"
+></sgds-input>
 
 <h3>Valid</h3>
 <sgds-input label="Valid" value="Good value" valid></sgds-input>
@@ -39,13 +57,27 @@
 <sgds-input label="Price" prefix="$" suffix=".00" value="50"></sgds-input>
 
 <h3>Long prefix (URL) - THE BUG CASE</h3>
-<sgds-input label="Endpoint" prefix="http://localhost:3000/core-sec/product-management/sample-app/edit" value="test"></sgds-input>
+<sgds-input
+  label="Endpoint"
+  prefix="http://localhost:3000/core-sec/product-management/sample-app/edit"
+  value="test"
+></sgds-input>
 
 <h3>Long prefix (URL) + readonly</h3>
-<sgds-input label="Endpoint" prefix="http://localhost:3000/core-sec/product-management/sample-app/edit" value="Readonly value" readonly></sgds-input>
+<sgds-input
+  label="Endpoint"
+  prefix="http://localhost:3000/core-sec/product-management/sample-app/edit"
+  value="Readonly value"
+  readonly
+></sgds-input>
 
 <h3>Long prefix + disabled</h3>
-<sgds-input label="Endpoint" prefix="http://localhost:3000/core-sec/product-management/sample-app/edit" value="Disabled" disabled></sgds-input>
+<sgds-input
+  label="Endpoint"
+  prefix="http://localhost:3000/core-sec/product-management/sample-app/edit"
+  value="Disabled"
+  disabled
+></sgds-input>
 
 <h3>Long suffix</h3>
 <sgds-input label="Domain" suffix="@government.gov.sg" value="user.name"></sgds-input>
@@ -54,7 +86,15 @@
 <sgds-input label="Full URL" prefix="https://api.gov.sg/" suffix="/v2/endpoint" value="service-name"></sgds-input>
 
 <h3>Prefix + suffix + invalid</h3>
-<sgds-input label="Amount" prefix="$" suffix=".00" value="" invalid hasFeedback="both" invalidFeedback="Amount is required"></sgds-input>
+<sgds-input
+  label="Amount"
+  prefix="$"
+  suffix=".00"
+  value=""
+  invalid
+  hasFeedback="both"
+  invalidFeedback="Amount is required"
+></sgds-input>
 
 <h2>Loading State</h2>
 
@@ -139,20 +179,35 @@
 <h3>Empty with placeholder + prefix + suffix</h3>
 <sgds-input label="Range" prefix="Min:" suffix="Max: 100" placeholder="Enter value"></sgds-input>
 
+<h3>Autocomplete example</h3>
+<sgds-input
+  name="name"
+  label="Name(autocomplete OFF)"
+  placeholder="Enter your Name"
+  autocomplete="off"
+  hintText="Browser may suggest previously entered emails"
+></sgds-input>
+<sgds-input
+  name="name"
+  label="Name (autocomplete ON)"
+  placeholder="Enter your Name"
+  hintText="Browser may suggest previously entered emails"
+></sgds-input>
+
 <h2>Width Constraints</h2>
 
 <h3>Inside a narrow container (200px)</h3>
-<div style="width: 200px; border: 1px dashed #ccc; padding: 8px;">
+<div style="width: 200px; border: 1px dashed #ccc; padding: 8px">
   <sgds-input label="Narrow" prefix="$" suffix=".00" value="123"></sgds-input>
 </div>
 
 <h3>Inside a narrow container (200px) + long prefix</h3>
-<div style="width: 200px; border: 1px dashed #ccc; padding: 8px;">
+<div style="width: 200px; border: 1px dashed #ccc; padding: 8px">
   <sgds-input label="Narrow + long prefix" prefix="https://api.gov.sg" value="test"></sgds-input>
 </div>
 
 <h3>Inside a narrow container (150px) + action</h3>
-<div style="width: 150px; border: 1px dashed #ccc; padding: 8px;">
+<div style="width: 150px; border: 1px dashed #ccc; padding: 8px">
   <sgds-input label="Tiny" prefix="$" value="99">
     <sgds-icon-button slot="action" variant="ghost" name="check"></sgds-icon-button>
   </sgds-input>
@@ -164,18 +219,44 @@
 <sgds-input label="Style only" value="bad" invalid hasFeedback="style" invalidFeedback="Error"></sgds-input>
 
 <h3>hasFeedback="text" (message only)</h3>
-<sgds-input label="Text only" value="bad" invalid hasFeedback="text" invalidFeedback="Please fix this error"></sgds-input>
+<sgds-input
+  label="Text only"
+  value="bad"
+  invalid
+  hasFeedback="text"
+  invalidFeedback="Please fix this error"
+></sgds-input>
 
 <h3>hasFeedback="both" (border + message)</h3>
 <sgds-input label="Both" value="bad" invalid hasFeedback="both" invalidFeedback="This field is invalid"></sgds-input>
 
 <h3>Invalid + prefix + suffix</h3>
-<sgds-input label="Amount" prefix="$" suffix=".00" value="" invalid hasFeedback="both" invalidFeedback="Amount is required"></sgds-input>
+<sgds-input
+  label="Amount"
+  prefix="$"
+  suffix=".00"
+  value=""
+  invalid
+  hasFeedback="both"
+  invalidFeedback="Amount is required"
+></sgds-input>
 
 <h2>With Hint Text</h2>
 
 <h3>Hint text + prefix</h3>
-<sgds-input label="NRIC" prefix="S" hintText="Enter last 7 digits and checksum letter" placeholder="1234567A"></sgds-input>
+<sgds-input
+  label="NRIC"
+  prefix="S"
+  hintText="Enter last 7 digits and checksum letter"
+  placeholder="1234567A"
+></sgds-input>
 
 <h3>Hint text + invalid (hint replaced by error)</h3>
-<sgds-input label="Email" hintText="We'll never share your email" value="not-an-email" invalid hasFeedback="both" invalidFeedback="Please enter a valid email"></sgds-input>
+<sgds-input
+  label="Email"
+  hintText="We'll never share your email"
+  value="not-an-email"
+  invalid
+  hasFeedback="both"
+  invalidFeedback="Please enter a valid email"
+></sgds-input>

--- a/skills/sgds-components/reference/combo-box.md
+++ b/skills/sgds-components/reference/combo-box.md
@@ -39,6 +39,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 - **Custom filter**: set `filterFunction` as a JS property — not an HTML attribute — to implement prefix, fuzzy, or custom matching logic. Ignored when `async` is true.
 - **Async data**: set `async`, listen to `sgds-input` for `event.detail.displayValue`, fetch results, then replace `<sgds-combo-box-option>` children. Set `loading` to indicate fetch in progress.
+- **Browser autocomplete**: `autocomplete` is set to `"off"` by default to prevent browser autofill from interfering with the dropdown filtering and selection. Change to `"on"` only if you want browser autocomplete suggestions — not recommended for most use cases.
 - **Multi-select**: add `multiSelect`; `element.value` becomes a comma-separated string of selected values. Use `badgeFullWidth` to make badges span the full input width.
 - **Empty async menu**: use `emptyMenuAsync` to show an open (empty) menu immediately when in async mode before the user types.
 - **Programmatic control**: `menuIsOpen` lets you open or close the dropdown from JavaScript without user interaction.
@@ -152,6 +153,7 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `async` | boolean | `false` | Disables client-side filtering for server-side async filtering |
 | `emptyMenuAsync` | boolean | `false` | Shows an empty menu on open when in async mode |
 | `menuIsOpen` | boolean | `false` | Programmatically controls the dropdown menu open state |
+| `autocomplete` | string | `"off"` | Controls browser autocomplete behavior — typically set to `"off"` to prevent browser autofill interference with the dropdown list |
 | `filterFunction` | `(inputValue: string, item) => boolean` | contains filter | Custom filter function (ignored when `async` is true) |
 | `floatingOpts` | object | — | Options for Floating UI positioning (advanced) |
 

--- a/skills/sgds-components/reference/input.md
+++ b/skills/sgds-components/reference/input.md
@@ -42,6 +42,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - **Manual state override**: use `invalid` or `valid` to programmatically set the field's validation state — useful when validation logic lives outside the component (e.g. server-side errors).
 - **Custom validation flow**: set `noValidate` to disable browser-native constraint validation and take full control with your own logic; combine with `invalid` and `setInvalid()` for server-driven error states.
 - **Autofocus**: use `autofocus` to focus the input on page load — limit to one field per page to avoid disorienting keyboard and screen reader users.
+- **Autocomplete**: use `autocomplete="off"` to disable browser autocomplete for sensitive fields (e.g. password reset, NRIC, OTP codes). Defaults to `"on"` to allow browser autofill for common fields (email, name, address). Use specific autocomplete hints like `"email"`, `"tel"`, `"url"` for form auto-fill (see [MDN autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for full list).
 
 ## Edge Cases
 
@@ -66,6 +67,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 **Show validation feedback?** → Set `hasFeedback="both"` (border + message), `"style"` (border only), or `"text"` (message only), and `invalidFeedback`
 
 **Show inline loading spinner?** → `loading`
+
+**Disable browser autocomplete?** → `autocomplete="off"`
 
 **Icon action button after the field?** → Use the `action` slot with `<sgds-icon-button>`
 
@@ -124,6 +127,29 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 <!-- Loading state -->
 <sgds-input type="text" label="Lookup" loading></sgds-input>
+
+<!-- Password field with autocomplete disabled -->
+<sgds-input
+  type="password"
+  label="New Password"
+  name="password"
+  placeholder="Enter new password"
+  autocomplete="new-password"
+  required
+  hasFeedback="both"
+  invalidFeedback="Password must be at least 8 characters"
+></sgds-input>
+
+<!-- OTP input with autocomplete disabled -->
+<sgds-input
+  type="text"
+  label="One-Time Password"
+  name="otp"
+  placeholder="000000"
+  maxlength="6"
+  autocomplete="off"
+  required
+></sgds-input>
 ```
 
 ## API Summary
@@ -154,6 +180,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `disabled` | boolean | `false` | Disables the input |
 | `readonly` | boolean | `false` | Makes the input read-only |
 | `autofocus` | boolean | `false` | Focuses the input on load |
+| `autocomplete` | string | `"on"` | Controls browser autocomplete behavior — set to `"off"` to disable autocomplete for sensitive fields (e.g. password, NRIC, OTP) |
 | `loading` | boolean | `false` | Shows a loading spinner inside the input |
 | `noValidate` | boolean | `false` | Disables browser-native validation |
 

--- a/src/base/select-element.ts
+++ b/src/base/select-element.ts
@@ -79,6 +79,9 @@ export class SelectElement
   /** Marks the component as invalid. Replace the pseudo :invalid selector. */
   @property({ type: Boolean, reflect: true }) invalid = false;
 
+  /** Controlling of autocomplete behaviour */
+  @property({ type: String, reflect: true }) autocomplete = "on";
+
   /** Programatically sets the invalid state of the component. Pass in boolean value in the argument */
   public setInvalid(bool: boolean) {
     this.invalid = bool;

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -489,6 +489,7 @@ export class SgdsComboBox extends SelectElement {
             aria-labelledby="${this._labelId} ${this._controlId}Help ${this.invalid && this.hasFeedback
               ? `${this._controlId}-invalid`
               : ""}"
+            .autocomplete=${this.autocomplete}
           />
         </div>
 
@@ -570,6 +571,7 @@ export class SgdsComboBox extends SelectElement {
             ?required=${this.required}
             tabindex="-1"
             aria-hidden="true"
+            .autocomplete=${this.autocomplete}
           />`
         : nothing}
     `;

--- a/src/components/Input/sgds-input.ts
+++ b/src/components/Input/sgds-input.ts
@@ -77,6 +77,9 @@ export class SgdsInput extends SgdsFormValidatorMixin(FormControlElement) implem
   /** Makes the input readonly. */
   @property({ type: Boolean, reflect: true }) readonly = false;
 
+  /** Controlling of autocomplete behaviour */
+  @property({ type: String, reflect: true }) autocomplete = "on";
+
   /**
    * Specifies the granularity that the value must adhere to, or the special value `any` which means no stepping is
    * implied, allowing any numeric value. Only applies to number input types.
@@ -245,6 +248,7 @@ export class SgdsInput extends SgdsFormValidatorMixin(FormControlElement) implem
           @focus=${this._handleFocus}
           @blur=${this._handleBlur}
           aria-describedby=${ifDefined(ariaDescribedBy)}
+          .autocomplete=${this.autocomplete}
         />
         ${this.type === "password" ? this._renderPasswordToggle() : nothing}
         ${this.suffix ? html`<span class="form-control-suffix">${this.suffix}</span>` : nothing}

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -53,6 +53,13 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
       this._mixinValidate(this.input);
     }
 
+    updated(changedProperties: PropertyValueMap<this>) {
+      super.updated(changedProperties);
+      if (changedProperties.has("value")) {
+        this._mixinSetFormValue();
+      }
+    }
+
     /**
      * Native lifecycle of Form-Associated Custom Element Callbacks
      */

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -53,13 +53,6 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
       this._mixinValidate(this.input);
     }
 
-    updated(changedProperties: PropertyValueMap<this>) {
-      super.updated(changedProperties);
-      if (changedProperties.has("value")) {
-        this._mixinSetFormValue();
-      }
-    }
-
     /**
      * Native lifecycle of Form-Associated Custom Element Callbacks
      */

--- a/stories/component-templates/ComboBox/additional.mdx
+++ b/stories/component-templates/ComboBox/additional.mdx
@@ -149,6 +149,16 @@ Set `required` and `hasFeedback` to enable constraint validation with feedback s
   <Story of={ComboBoxStories.Validation} />
 </Canvas>
 
+## Autocomplete
+
+Use the `autocomplete` prop to control browser autocomplete behaviour on the combo box input. It accepts any valid HTML `autocomplete` attribute value.
+
+Set `autocomplete="on"` (default) to allow the browser to suggest previously entered values. Set `autocomplete="off"` to suppress browser suggestions.
+
+<Canvas of={ComboBoxStories.Autocomplete}>
+  <Story of={ComboBoxStories.Autocomplete} />
+</Canvas>
+
 ### Override default invalid feedback
 
 Use the `invalidFeedback` property to customise the error message.

--- a/stories/component-templates/ComboBox/additional.mdx
+++ b/stories/component-templates/ComboBox/additional.mdx
@@ -109,7 +109,7 @@ comboBox.filterFunction = (inputValue, menuItem) => {
 
 ## Access input's display value via custom event: sgds-input
 
-Hook onto the custom event: `sgds-input` to obtain the display value of the input 
+Hook onto the custom event: `sgds-input` to obtain the display value of the input
 
 <Canvas of={ComboBoxStories.AccessDisplayValue}>
   <Story of={ComboBoxStories.AccessDisplayValue} />
@@ -118,13 +118,11 @@ Hook onto the custom event: `sgds-input` to obtain the display value of the inpu
 ### Types
 
 ```ts
-
-import type { ISgdsComboBoxInputEventDetail } from '@govtechsg/sgds-web-component/components/ComboBox/sgds-combo-box';
+import type { ISgdsComboBoxInputEventDetail } from "@govtechsg/sgds-web-component/components/ComboBox/sgds-combo-box";
 
 const inputHandler = (e: CustomEvent<ISgdsComboBoxInputEventDetail>) => {
-  const displayValue = e.detail.displayValue
-}
-
+  const displayValue = e.detail.displayValue;
+};
 ```
 
 ## Asynchronous ComboBox
@@ -132,10 +130,9 @@ const inputHandler = (e: CustomEvent<ISgdsComboBoxInputEventDetail>) => {
 Asynchronous ComboBox search is for filtering remotely via an API request. The filtering is done through the response of API requests.
 Set the `async` attribute to true. You can then hook onto the `sgds-input` event to listen for input changes and make API requests accordingly.
 
-
-  - Use `loading` property to show loading spinner while waiting for API response.
-  - Use `emptyMenuAsync` property to show "No options" when there are no results from the API response.
-  - Populate the combo box options based on the API response.
+- Use `loading` property to show loading spinner while waiting for API response.
+- Use `emptyMenuAsync` property to show "No options" when there are no results from the API response.
+- Populate the combo box options based on the API response.
 
 <Canvas of={ComboBoxStories.AsyncCombobox}>
   <Story of={ComboBoxStories.AsyncCombobox} />
@@ -174,4 +171,3 @@ Set `noValidate` to disable built-in constraint validation. Use `setInvalid(bool
 <Canvas of={ComboBoxStories.NoValidate}>
   <Story of={ComboBoxStories.NoValidate} />
 </Canvas>
-

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -489,3 +489,45 @@ export const NoValidate = {
   parameters: {},
   tags: ["!dev"]
 };
+
+const AutocompleteTemplate = () =>
+  html`
+    <div style="display:flex;flex-direction:column;gap:2rem;">
+      <div>
+        <p><strong>autocomplete="on"</strong> (default) — browser may suggest previously entered values</p>
+        <sgds-combo-box
+          autocomplete="on"
+          label="Country"
+          placeholder="Select a country"
+          hintText="Browser autocomplete enabled"
+        >
+          <sgds-combo-box-option value="sg">Singapore</sgds-combo-box-option>
+          <sgds-combo-box-option value="my">Malaysia</sgds-combo-box-option>
+          <sgds-combo-box-option value="th">Thailand</sgds-combo-box-option>
+          <sgds-combo-box-option value="jp">Japan</sgds-combo-box-option>
+        </sgds-combo-box>
+      </div>
+      <div>
+        <p><strong>autocomplete="off"</strong> — browser autocomplete suppressed</p>
+        <sgds-combo-box
+          autocomplete="off"
+          label="Country"
+          placeholder="Select a country"
+          hintText="Browser autocomplete disabled"
+        >
+          <sgds-combo-box-option value="sg">Singapore</sgds-combo-box-option>
+          <sgds-combo-box-option value="my">Malaysia</sgds-combo-box-option>
+          <sgds-combo-box-option value="th">Thailand</sgds-combo-box-option>
+          <sgds-combo-box-option value="jp">Japan</sgds-combo-box-option>
+        </sgds-combo-box>
+      </div>
+    </div>
+  `;
+
+export const Autocomplete = {
+  render: AutocompleteTemplate.bind({}),
+  name: "Autocomplete prop",
+  args: {},
+  parameters: {},
+  tags: ["!dev"]
+};

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -496,29 +496,31 @@ const AutocompleteTemplate = () =>
       <div>
         <p><strong>autocomplete="on"</strong> (default) — browser may suggest previously entered values</p>
         <sgds-combo-box
+          name="name"
           autocomplete="on"
-          label="Country"
-          placeholder="Select a country"
+          label="Name"
+          placeholder="Select a user"
           hintText="Browser autocomplete enabled"
         >
-          <sgds-combo-box-option value="sg">Singapore</sgds-combo-box-option>
-          <sgds-combo-box-option value="my">Malaysia</sgds-combo-box-option>
-          <sgds-combo-box-option value="th">Thailand</sgds-combo-box-option>
-          <sgds-combo-box-option value="jp">Japan</sgds-combo-box-option>
+          <sgds-combo-box-option value="adamn">Adamn</sgds-combo-box-option>
+          <sgds-combo-box-option value="judy">Judy</sgds-combo-box-option>
+          <sgds-combo-box-option value="benedict">Benedict</sgds-combo-box-option>
+          <sgds-combo-box-option value="kelvin">Kelvin</sgds-combo-box-option>
         </sgds-combo-box>
       </div>
       <div>
         <p><strong>autocomplete="off"</strong> — browser autocomplete suppressed</p>
         <sgds-combo-box
+          name="name"
           autocomplete="off"
-          label="Country"
-          placeholder="Select a country"
+          label="Name"
+          placeholder="Select a user"
           hintText="Browser autocomplete disabled"
         >
-          <sgds-combo-box-option value="sg">Singapore</sgds-combo-box-option>
-          <sgds-combo-box-option value="my">Malaysia</sgds-combo-box-option>
-          <sgds-combo-box-option value="th">Thailand</sgds-combo-box-option>
-          <sgds-combo-box-option value="jp">Japan</sgds-combo-box-option>
+          <sgds-combo-box-option value="adamn">Adamn</sgds-combo-box-option>
+          <sgds-combo-box-option value="judy">Judy</sgds-combo-box-option>
+          <sgds-combo-box-option value="benedict">Benedict</sgds-combo-box-option>
+          <sgds-combo-box-option value="kelvin">Kelvin</sgds-combo-box-option>
         </sgds-combo-box>
       </div>
     </div>

--- a/stories/component-templates/Input/additional.mdx
+++ b/stories/component-templates/Input/additional.mdx
@@ -1,12 +1,12 @@
-## Password 
+## Password
 
-With the `type` prop set to `password`, a eye icon appears to allow unmasking of sensitive content in the input. 
+With the `type` prop set to `password`, a eye icon appears to allow unmasking of sensitive content in the input.
 
 <Canvas of={InputStories.PasswordInput}>
   <Story of={InputStories.PasswordInput} />
 </Canvas>
 
-## Disabled 
+## Disabled
 
 Add `disabled` prop to disabled the input
 
@@ -14,16 +14,16 @@ Add `disabled` prop to disabled the input
   <Story of={InputStories.DisabledInput} />
 </Canvas>
 
-## Invalid 
+## Invalid
 
-Add `hasFeedback` and `invalid` prop to visually enable invalid style of input. 
+Add `hasFeedback` and `invalid` prop to visually enable invalid style of input.
 Set invalid message with `invalidFeedback` prop
 
 <Canvas of={InputStories.InvalidInput}>
   <Story of={InputStories.InvalidInput} />
 </Canvas>
 
-## Valid 
+## Valid
 
 Add `hasFeedback` and `valid` prop to visually enable valid style of input
 
@@ -31,7 +31,7 @@ Add `hasFeedback` and `valid` prop to visually enable valid style of input
   <Story of={InputStories.ValidInput} />
 </Canvas>
 
-## Loading  
+## Loading
 
 Add `loading` prop to visually enable loading icon in input
 
@@ -39,7 +39,7 @@ Add `loading` prop to visually enable loading icon in input
   <Story of={InputStories.LoadingInput} />
 </Canvas>
 
-## Read only  
+## Read only
 
 Add `readonly` prop for a readonly input
 
@@ -47,7 +47,7 @@ Add `readonly` prop for a readonly input
   <Story of={InputStories.ReadonlyInput} />
 </Canvas>
 
-## Prefix and suffix 
+## Prefix and suffix
 
 Use the string type `prefix` or `suffix` prop to add more indication and meaning to the input value
 
@@ -59,9 +59,9 @@ Use the string type `prefix` or `suffix` prop to add more indication and meaning
   <Story of={InputStories.SuffixInput} />
 </Canvas>
 
-## Leading and trailing icons 
+## Leading and trailing icons
 
-Icon slots are meant to insert icons for visual and descriptive purposes. It is not intended for call to action. 
+Icon slots are meant to insert icons for visual and descriptive purposes. It is not intended for call to action.
 
 <Canvas of={InputStories.LeadingIcon}>
   <Story of={InputStories.LeadingIcon} />
@@ -81,25 +81,25 @@ Add call to action items in the `action` slot. It is recommended to use `<sgds-i
   <Story of={InputStories.Action} />
 </Canvas>
 
-## Validation 
+## Validation
 
-HTML form constraint validation is built-in. By default, there is no need to control the `invalid` prop to enable constraint validations. 
+HTML form constraint validation is built-in. By default, there is no need to control the `invalid` prop to enable constraint validations.
 
 - To enable invalid styles and feedback message set `hasFeedback="both"`
 - To enable invalid styles only, set `hasFeedback="style"`
 - To enable feedback message only, set `hasFeedback="text"`
 
-In this example, `hasFeedback` is set to `both`. Press submit to show constraint validation behaviour for `required` and `minlength=5`. 
+In this example, `hasFeedback` is set to `both`. Press submit to show constraint validation behaviour for `required` and `minlength=5`.
 Resetting the form, reset's the validity and the value of the input to its initial default value.
 
 <Canvas of={InputStories.InputValidation}>
   <Story of={InputStories.InputValidation} />
 </Canvas>
 
-### Overriding the invalid feedback message 
+### Overriding the invalid feedback message
 
-By default, the invalid feedback reflected is based on the browser's native error message based on the ValidityState.  To override the default message, 
-use `invalidFeedback` prop. 
+By default, the invalid feedback reflected is based on the browser's native error message based on the ValidityState. To override the default message,
+use `invalidFeedback` prop.
 
 <Canvas of={InputStories.OverrideInvalidFeedback}>
   <Story of={InputStories.OverrideInvalidFeedback} />

--- a/stories/component-templates/Input/additional.mdx
+++ b/stories/component-templates/Input/additional.mdx
@@ -104,3 +104,13 @@ use `invalidFeedback` prop.
 <Canvas of={InputStories.OverrideInvalidFeedback}>
   <Story of={InputStories.OverrideInvalidFeedback} />
 </Canvas>
+
+## Autocomplete
+
+Use the `autocomplete` prop to control browser autocomplete behaviour on the input. It accepts any valid HTML `autocomplete` attribute value.
+
+Set `autocomplete="on"` (default) to allow the browser to suggest previously entered values. Set `autocomplete="off"` to suppress browser suggestions.
+
+<Canvas of={InputStories.Autocomplete}>
+  <Story of={InputStories.Autocomplete} />
+</Canvas>

--- a/stories/component-templates/Input/additional.stories.js
+++ b/stories/component-templates/Input/additional.stories.js
@@ -159,18 +159,20 @@ const AutocompleteTemplate = () =>
       <div>
         <p><strong>autocomplete="on"</strong> (default) — browser may suggest previously entered values</p>
         <sgds-input
+          name="name"
           autocomplete="on"
-          label="Email"
-          placeholder="Enter your email"
+          label="Name"
+          placeholder="Enter your name"
           hintText="Browser autocomplete enabled"
         ></sgds-input>
       </div>
       <div>
         <p><strong>autocomplete="off"</strong> — browser autocomplete suppressed</p>
         <sgds-input
+          name="name"
           autocomplete="off"
-          label="Email"
-          placeholder="Enter your email"
+          label="Name"
+          placeholder="Enter your name"
           hintText="Browser autocomplete disabled"
         ></sgds-input>
       </div>

--- a/stories/component-templates/Input/additional.stories.js
+++ b/stories/component-templates/Input/additional.stories.js
@@ -152,3 +152,35 @@ export const OverrideInvalidFeedback = {
   parameters: {},
   tags: ["!dev"]
 };
+
+const AutocompleteTemplate = () =>
+  html`
+    <div style="display:flex;flex-direction:column;gap:2rem;">
+      <div>
+        <p><strong>autocomplete="on"</strong> (default) — browser may suggest previously entered values</p>
+        <sgds-input
+          autocomplete="on"
+          label="Email"
+          placeholder="Enter your email"
+          hintText="Browser autocomplete enabled"
+        ></sgds-input>
+      </div>
+      <div>
+        <p><strong>autocomplete="off"</strong> — browser autocomplete suppressed</p>
+        <sgds-input
+          autocomplete="off"
+          label="Email"
+          placeholder="Enter your email"
+          hintText="Browser autocomplete disabled"
+        ></sgds-input>
+      </div>
+    </div>
+  `;
+
+export const Autocomplete = {
+  render: AutocompleteTemplate.bind({}),
+  name: "Autocomplete prop",
+  args: {},
+  parameters: {},
+  tags: ["!dev"]
+};

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -123,6 +123,7 @@ describe("sgds-combo-box ", () => {
           <div class="combobox-input-container">
             <input
               aria-invalid="false"
+              autocomplete="on"
                 class="form-control"
               type="text"
             >

--- a/test/input.element.test.ts
+++ b/test/input.element.test.ts
@@ -15,7 +15,7 @@ describe("sgds-input", () => {
            <div class="form-control-row">
           <div class="form-control-group">
             <slot name="icon"></slot>
-            <input type="text" class="form-control" id="test-id" aria-invalid="false" placeholder="placeholder">
+            <input type="text" class="form-control" id="test-id" aria-invalid="false" autocomplete="on" placeholder="placeholder">
             <slot name="trailing-icon"></slot>
           </div>
           <slot name="action"></slot>
@@ -35,7 +35,7 @@ describe("sgds-input", () => {
         <div class="form-control-row">
           <div class="form-control-group">
             <slot name="icon"></slot>
-            <input type="text" class="form-control" id="test-id" aria-invalid="false" placeholder="placeholder">
+            <input type="text" class="form-control" id="test-id" aria-invalid="false" autocomplete="on" placeholder="placeholder">
             <span class="form-control-suffix">test</span>
             <slot name="trailing-icon"></slot>
           </div>
@@ -57,7 +57,7 @@ describe("sgds-input", () => {
             <span class="form-control-prefix">
               test
             </span>
-            <input type="text" class="form-control" id="test-id" aria-invalid="false" placeholder="placeholder">
+            <input type="text" class="form-control" id="test-id" aria-invalid="false" autocomplete="on" placeholder="placeholder">
             <slot name="trailing-icon"></slot>
           </div>
             <slot name="action"></slot>
@@ -75,7 +75,7 @@ describe("sgds-input", () => {
           <div class="form-control-row">
             <div class="form-control-group">
               <slot name="icon"></slot>
-              <input type="text" class="form-control" id="test-id" aria-invalid="false" placeholder="placeholder">
+              <input type="text" class="form-control" id="test-id" aria-invalid="false" autocomplete="on" placeholder="placeholder">
               <slot name="trailing-icon">
               <sgds-spinner
                 size="sm"


### PR DESCRIPTION
## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue):
1. When using input/combobox, browser autofill can cause the dropdown to be blocked:  
<img width="732" height="377" alt="image" src="https://github.com/user-attachments/assets/96479a1d-1041-47e6-93e1-c770cc09108a" />


**Solution:**
    - this can be removed by added the autocomplete prop to off as [documented](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
    - However, for `name='email'` it doesn't work 
         - (known issue, tried using autocomplete='new-password' but still cannot) 


## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
