### PR TITLE
fix(link): add pointer-events: none to a tag when sgds-link is disabled

### DIFF
--- a/src/components/Link/link.css
+++ b/src/components/Link/link.css
@@ -170,6 +170,7 @@
 :host([disabled]) .nav-link::slotted(a),
 .nav-link::slotted(a[disabled]) {
   text-decoration: none !important;
+  pointer-events: none;
 }
 @media (prefers-reduced-motion: reduce) {
   :host(:not([active])) .nav-link::slotted(a:not(:hover)),

--- a/test/link.test.ts
+++ b/test/link.test.ts
@@ -38,8 +38,11 @@ describe("<sgds-link>", () => {
   });
   it("when link is disabled, it adds disabled attribute to the slotted anchor elmement", async () => {
     const el = await fixture<SgdsLink>(html`<sgds-link disabled><a href="#"></a></sgds-link>`);
+    expect(el.querySelector("a")).to.exist;
     expect(el.querySelector("a")).to.have.attribute("disabled");
     expect(el.querySelector("a")).to.have.attribute("href", "javascript:void(0)");
     expect(el.querySelector("a")).to.have.attribute("tabindex", "-1");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(getComputedStyle(el.querySelector("a")!).pointerEvents).to.equal("none");
   });
 });


### PR DESCRIPTION
## :open_book: Description

Added `pointer-events: none` to `a` tag when `sgds-link` is disabled.

Fixes #693 

## :pencil2: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :test_tube: How Has This Been Tested?

- Added test to verify that `a` tag has `pointer-events: none` styling added when `sgds-link` is disabled.
- Human verification using storybook to verify that `onclick` does not trigger on disabled `sgds-link`.
- Attempted to add red green testing using click event listener but `pointer-events: none` does not affect programmatically triggered click event listeners so a red green unit test could not be written.

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
