### PR TITLE
docs(*): all component stories to appear on side bar [run-chromatic]

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -56,8 +56,9 @@ export const parameters = {
       "2-xl": { name: "2-xl desktop", styles: { width: "1440px", height: "1117px" } }
     }
   },
+  actions: { disable: true },
   controls: {
-    //  disable: true,
+    disable: true,
     expanded: true
   },
   options: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -61,6 +61,7 @@ export const parameters = {
     disable: true,
     expanded: true
   },
+  selectedPanel: "storybook/docs/panel",
   options: {
     storySort: {
       order: [

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.21.1
+npm install @govtechsg/sgds-web-component@3.22.0
 
 ```
 
@@ -53,14 +53,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1" async crossorigin="anonymous" integrity="sha384-8oAeZKrWToTHBOYttiplioCwNSuK4dyAl5eLvfJ+evjLWKP3l70cYN0PWNBj4ier"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0" async crossorigin="anonymous" integrity="sha384-9tsGmGQpbXpdrN3zrFc6/5Nb/psCD7arF+8sAmZpMzMJSI12mt7WGf6ndcgnciW8"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.21.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-5OKa7RaQpYeIsx/ZOXW2ttNUa7ftAEKXiWuSgFRmlXJUaJ1Bvf3etjlCw2qqjia8"></script>
 
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,10 +57,10 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0" async crossorigin="anonymous" integrity="sha384-9tsGmGQpbXpdrN3zrFc6/5Nb/psCD7arF+8sAmZpMzMJSI12mt7WGf6ndcgnciW8"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0" async crossorigin="anonymous" integrity="sha384-WbHc3VloPtEmncz7R/X4mNQFJjfGvRfOT3ZzHowp1XqQOWQcMoOBOHShxGvh+chP"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-5OKa7RaQpYeIsx/ZOXW2ttNUa7ftAEKXiWuSgFRmlXJUaJ1Bvf3etjlCw2qqjia8"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
 
 ```
 

--- a/scripts/generateStories.mjs
+++ b/scripts/generateStories.mjs
@@ -175,7 +175,7 @@ ${methodsMeta
       render: Template.bind({}),
       name: "Basic",
       args,
-      parameters,
+      parameters: { ...parameters, controls: { disable: false }, selectedPanel: "addon-controls" },
       ...(play ? { play } : {}),
     }
   `;

--- a/stories/component-templates/Accordion/additional.stories.js
+++ b/stories/component-templates/Accordion/additional.stories.js
@@ -4,40 +4,35 @@ export const BorderVariant = {
   render: Template.bind({}),
   name: "Border variant",
   args: { variant: "border" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const DensityVariant = {
   render: Template.bind({}),
   name: "Compact density",
   args: { density: "compact" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const SpaciousDensity = {
   render: Template.bind({}),
   name: "Spacious density",
   args: { density: "spacious" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const AllowMultiple = {
   render: Template.bind({}),
   name: "Allow multiple active accordion",
   args: { allowMultiple: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const LeadingIconTemplate = iconSize => html`
@@ -70,8 +65,7 @@ export const LeadingIconSlot = {
   render: LeadingIconTemplate.bind({}),
   name: "Icon slot",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const BadgeTemplate = args => html`
@@ -103,6 +97,5 @@ export const BadgeSlot = {
   render: BadgeTemplate.bind({}),
   name: "Badge slot",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Accordion/additional.stories.js
+++ b/stories/component-templates/Accordion/additional.stories.js
@@ -4,35 +4,35 @@ export const BorderVariant = {
   render: Template.bind({}),
   name: "Border variant",
   args: { variant: "border" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const DensityVariant = {
   render: Template.bind({}),
   name: "Compact density",
   args: { density: "compact" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const SpaciousDensity = {
   render: Template.bind({}),
   name: "Spacious density",
   args: { density: "spacious" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const AllowMultiple = {
   render: Template.bind({}),
   name: "Allow multiple active accordion",
   args: { allowMultiple: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const LeadingIconTemplate = iconSize => html`
@@ -65,7 +65,7 @@ export const LeadingIconSlot = {
   render: LeadingIconTemplate.bind({}),
   name: "Icon slot",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const BadgeTemplate = args => html`
@@ -97,5 +97,5 @@ export const BadgeSlot = {
   render: BadgeTemplate.bind({}),
   name: "Badge slot",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Accordion/additional.stories.js
+++ b/stories/component-templates/Accordion/additional.stories.js
@@ -4,35 +4,35 @@ export const BorderVariant = {
   render: Template.bind({}),
   name: "Border variant",
   args: { variant: "border" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const DensityVariant = {
   render: Template.bind({}),
   name: "Compact density",
   args: { density: "compact" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const SpaciousDensity = {
   render: Template.bind({}),
   name: "Spacious density",
   args: { density: "spacious" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const AllowMultiple = {
   render: Template.bind({}),
   name: "Allow multiple active accordion",
   args: { allowMultiple: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const LeadingIconTemplate = iconSize => html`
@@ -65,7 +65,7 @@ export const LeadingIconSlot = {
   render: LeadingIconTemplate.bind({}),
   name: "Icon slot",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const BadgeTemplate = args => html`
@@ -97,5 +97,5 @@ export const BadgeSlot = {
   render: BadgeTemplate.bind({}),
   name: "Badge slot",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Alert/additional.stories.js
+++ b/stories/component-templates/Alert/additional.stories.js
@@ -117,48 +117,42 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const WithTitle = {
   render: TitleTemplate.bind({}),
   name: "Title",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const WithLink = {
   render: LinkTemplate.bind({}),
   name: "Link",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const FilledActionTemplate = args => {
@@ -222,14 +216,12 @@ export const FilledWithAction = {
   render: FilledActionTemplate.bind({}),
   name: "Filled with action",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OutlinedWithAction = {
   render: OutlinedActionTemplate.bind({}),
   name: "Outlined with action",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Alert/additional.stories.js
+++ b/stories/component-templates/Alert/additional.stories.js
@@ -117,42 +117,42 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const WithTitle = {
   render: TitleTemplate.bind({}),
   name: "Title",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const WithLink = {
   render: LinkTemplate.bind({}),
   name: "Link",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const FilledActionTemplate = args => {
@@ -216,12 +216,12 @@ export const FilledWithAction = {
   render: FilledActionTemplate.bind({}),
   name: "Filled with action",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OutlinedWithAction = {
   render: OutlinedActionTemplate.bind({}),
   name: "Outlined with action",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Alert/additional.stories.js
+++ b/stories/component-templates/Alert/additional.stories.js
@@ -117,42 +117,42 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const WithTitle = {
   render: TitleTemplate.bind({}),
   name: "Title",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const WithLink = {
   render: LinkTemplate.bind({}),
   name: "Link",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const FilledActionTemplate = args => {
@@ -216,12 +216,12 @@ export const FilledWithAction = {
   render: FilledActionTemplate.bind({}),
   name: "Filled with action",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OutlinedWithAction = {
   render: OutlinedActionTemplate.bind({}),
   name: "Outlined with action",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Badge/additional.stories.js
+++ b/stories/component-templates/Badge/additional.stories.js
@@ -50,33 +50,33 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const WithTruncation = {
   render: TruncationTemplate.bind({}),
   name: "Truncation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Badge/additional.stories.js
+++ b/stories/component-templates/Badge/additional.stories.js
@@ -50,33 +50,33 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const WithTruncation = {
   render: TruncationTemplate.bind({}),
   name: "Truncation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Badge/additional.stories.js
+++ b/stories/component-templates/Badge/additional.stories.js
@@ -50,38 +50,33 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OutlinedVariants = {
   render: OutlinedVariantTemplate.bind({}),
   name: "Outlined variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const WithIcon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const WithTruncation = {
   render: TruncationTemplate.bind({}),
   name: "Truncation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Breadcrumb/additional.stories.js
+++ b/stories/component-templates/Breadcrumb/additional.stories.js
@@ -21,8 +21,9 @@ export const Overflow = {
   parameters: {
     docs: {
       story: {
-        height: "500px"
-      , controls: { disable: true } }
+        height: "500px",
+        controls: { disable: true }
+      }
     }
   }
 };

--- a/stories/component-templates/Breadcrumb/additional.stories.js
+++ b/stories/component-templates/Breadcrumb/additional.stories.js
@@ -22,8 +22,7 @@ export const Overflow = {
     docs: {
       story: {
         height: "500px"
-      }
+      , controls: { disable: true } }
     }
-  },
-  tags: ["!dev"]
+  }
 };

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -13,7 +13,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 const ToneTemplate = args => {
   return html`
@@ -50,7 +50,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const FullWidthTemplate = () => {
@@ -61,7 +61,7 @@ export const FullWidth = {
   render: FullWidthTemplate.bind({}),
   name: "Full width",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const SizeTemplate = () => {
@@ -75,7 +75,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ActiveTemplate = () => {
@@ -91,7 +91,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
@@ -103,7 +103,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ButtonWithIcon = {
@@ -118,7 +118,7 @@ export const ButtonWithIcon = {
   `,
   name: "Button with icon",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const FormSubmitTemplate = () => {
@@ -145,7 +145,7 @@ export const FormSubmitValue = {
   render: FormSubmitTemplate.bind({}),
   name: "Form submit with name and value",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Loading = {
@@ -175,5 +175,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -13,8 +13,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 const ToneTemplate = args => {
   return html`
@@ -51,8 +50,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const FullWidthTemplate = () => {
@@ -63,8 +61,7 @@ export const FullWidth = {
   render: FullWidthTemplate.bind({}),
   name: "Full width",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const SizeTemplate = () => {
@@ -78,8 +75,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ActiveTemplate = () => {
@@ -95,8 +91,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
@@ -108,8 +103,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ButtonWithIcon = {
@@ -124,8 +118,7 @@ export const ButtonWithIcon = {
   `,
   name: "Button with icon",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const FormSubmitTemplate = () => {
@@ -152,8 +145,7 @@ export const FormSubmitValue = {
   render: FormSubmitTemplate.bind({}),
   name: "Form submit with name and value",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Loading = {
@@ -183,6 +175,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Button/additional.stories.js
+++ b/stories/component-templates/Button/additional.stories.js
@@ -13,7 +13,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 const ToneTemplate = args => {
   return html`
@@ -50,7 +50,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const FullWidthTemplate = () => {
@@ -61,7 +61,7 @@ export const FullWidth = {
   render: FullWidthTemplate.bind({}),
   name: "Full width",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const SizeTemplate = () => {
@@ -75,7 +75,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ActiveTemplate = () => {
@@ -91,7 +91,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
@@ -103,7 +103,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ButtonWithIcon = {
@@ -118,7 +118,7 @@ export const ButtonWithIcon = {
   `,
   name: "Button with icon",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const FormSubmitTemplate = () => {
@@ -145,7 +145,7 @@ export const FormSubmitValue = {
   render: FormSubmitTemplate.bind({}),
   name: "Form submit with name and value",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Loading = {
@@ -175,5 +175,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Card/additional.stories.js
+++ b/stories/component-templates/Card/additional.stories.js
@@ -28,8 +28,7 @@ export const Stretched = {
   render: StretchedTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const DisabledTemplate = () => {
@@ -60,8 +59,7 @@ export const Disabled = {
   render: DisabledTemplate.bind({}),
   name: "Disabled state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const OrientationTemplate = () => {
@@ -109,8 +107,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ImagePositionTemplate = () => {
@@ -192,8 +189,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -258,8 +254,7 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const HideBorderTemplate = () => {
@@ -341,8 +336,7 @@ export const HideBorder = {
   render: HideBorderTemplate.bind({}),
   name: "Hide border",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const TintedTemplate = () => {
@@ -373,8 +367,7 @@ export const Tinted = {
   render: TintedTemplate.bind({}),
   name: "Tinted",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const OverflowMenuTemplate = () => {
@@ -412,6 +405,5 @@ export const OverflowMenu = {
   render: OverflowMenuTemplate.bind({}),
   name: "Overflow menu",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Card/additional.stories.js
+++ b/stories/component-templates/Card/additional.stories.js
@@ -28,7 +28,7 @@ export const Stretched = {
   render: StretchedTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const DisabledTemplate = () => {
@@ -59,7 +59,7 @@ export const Disabled = {
   render: DisabledTemplate.bind({}),
   name: "Disabled state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const OrientationTemplate = () => {
@@ -107,7 +107,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ImagePositionTemplate = () => {
@@ -189,7 +189,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -254,7 +254,7 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const HideBorderTemplate = () => {
@@ -336,7 +336,7 @@ export const HideBorder = {
   render: HideBorderTemplate.bind({}),
   name: "Hide border",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const TintedTemplate = () => {
@@ -367,7 +367,7 @@ export const Tinted = {
   render: TintedTemplate.bind({}),
   name: "Tinted",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const OverflowMenuTemplate = () => {
@@ -405,5 +405,5 @@ export const OverflowMenu = {
   render: OverflowMenuTemplate.bind({}),
   name: "Overflow menu",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Card/additional.stories.js
+++ b/stories/component-templates/Card/additional.stories.js
@@ -28,7 +28,7 @@ export const Stretched = {
   render: StretchedTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const DisabledTemplate = () => {
@@ -59,7 +59,7 @@ export const Disabled = {
   render: DisabledTemplate.bind({}),
   name: "Disabled state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const OrientationTemplate = () => {
@@ -107,7 +107,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ImagePositionTemplate = () => {
@@ -189,7 +189,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -254,7 +254,7 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const HideBorderTemplate = () => {
@@ -336,7 +336,7 @@ export const HideBorder = {
   render: HideBorderTemplate.bind({}),
   name: "Hide border",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const TintedTemplate = () => {
@@ -367,7 +367,7 @@ export const Tinted = {
   render: TintedTemplate.bind({}),
   name: "Tinted",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const OverflowMenuTemplate = () => {
@@ -405,5 +405,5 @@ export const OverflowMenu = {
   render: OverflowMenuTemplate.bind({}),
   name: "Overflow menu",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Checkbox/additional.stories.js
+++ b/stories/component-templates/Checkbox/additional.stories.js
@@ -66,44 +66,44 @@ export const Indeterminate = {
   render: Template.bind({}),
   name: "Indeterminate",
   args: { ...args, indeterminate: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Invalid = {
   render: InvalidTemplate.bind({}),
   name: "Invalid states",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const InvalidGroup = {
   render: InvalidGroupTemplate.bind({}),
   name: "Invalid CheckboxGroup",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Validation = {
   render: ValidationTemplateGroup.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ValidationSingle = {
   render: ValidationTemplateSingle.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplateGroup.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Checkbox/additional.stories.js
+++ b/stories/component-templates/Checkbox/additional.stories.js
@@ -66,44 +66,44 @@ export const Indeterminate = {
   render: Template.bind({}),
   name: "Indeterminate",
   args: { ...args, indeterminate: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Invalid = {
   render: InvalidTemplate.bind({}),
   name: "Invalid states",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const InvalidGroup = {
   render: InvalidGroupTemplate.bind({}),
   name: "Invalid CheckboxGroup",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Validation = {
   render: ValidationTemplateGroup.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ValidationSingle = {
   render: ValidationTemplateSingle.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplateGroup.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Checkbox/additional.stories.js
+++ b/stories/component-templates/Checkbox/additional.stories.js
@@ -66,51 +66,44 @@ export const Indeterminate = {
   render: Template.bind({}),
   name: "Indeterminate",
   args: { ...args, indeterminate: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Invalid = {
   render: InvalidTemplate.bind({}),
   name: "Invalid states",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const InvalidGroup = {
   render: InvalidGroupTemplate.bind({}),
   name: "Invalid CheckboxGroup",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Validation = {
   render: ValidationTemplateGroup.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ValidationSingle = {
   render: ValidationTemplateSingle.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplateGroup.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/CloseButton/additional.stories.js
+++ b/stories/component-templates/CloseButton/additional.stories.js
@@ -25,30 +25,26 @@ export const Sizes = {
   render: SizeTemplate,
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ToneDefault = {
   render: ToneDefaultTemplate,
   name: "Tone: default",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ToneFixedDark = {
   render: ToneFixedDarkTemplate,
   name: "Tone: fixed-dark",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ToneFixedLight = {
   render: ToneFixedLightTemplate,
   name: "Tone: fixed-light",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/CloseButton/additional.stories.js
+++ b/stories/component-templates/CloseButton/additional.stories.js
@@ -25,26 +25,26 @@ export const Sizes = {
   render: SizeTemplate,
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ToneDefault = {
   render: ToneDefaultTemplate,
   name: "Tone: default",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ToneFixedDark = {
   render: ToneFixedDarkTemplate,
   name: "Tone: fixed-dark",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ToneFixedLight = {
   render: ToneFixedLightTemplate,
   name: "Tone: fixed-light",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/CloseButton/additional.stories.js
+++ b/stories/component-templates/CloseButton/additional.stories.js
@@ -25,26 +25,26 @@ export const Sizes = {
   render: SizeTemplate,
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ToneDefault = {
   render: ToneDefaultTemplate,
   name: "Tone: default",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ToneFixedDark = {
   render: ToneFixedDarkTemplate,
   name: "Tone: fixed-dark",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ToneFixedLight = {
   render: ToneFixedLightTemplate,
   name: "Tone: fixed-light",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -7,7 +7,7 @@ export const ComboBoxMultiSelect = {
   render: Template.bind({}),
   name: "MultiSelect",
   args: { ...args, multiSelect: true, id: "multiselect-combobox-example" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const DefaultFilter = () => {
@@ -37,7 +37,7 @@ export const ComboBoxDefaultFilter = {
   render: DefaultFilter.bind({}),
   name: "ComboBox with default filter",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const CustomFilter = () => {
@@ -79,14 +79,14 @@ export const ComboBoxCustomFilter = {
   render: CustomFilter.bind({}),
   name: "ComboBox with custom filter",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ComboBoxDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ComboBoxMenuListProp = () => {
@@ -309,7 +309,7 @@ export const ComboBoxMenuList = {
   render: ComboBoxMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ComboBoxMenuListClearableProp = () => {
@@ -332,7 +332,7 @@ export const ComboBoxMenuListClearable = {
   render: ComboBoxMenuListClearableProp.bind({}),
   name: "Populating menu list with clearable property",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const AccessDisplayValueTemplate = () => {
@@ -361,14 +361,14 @@ export const AccessDisplayValue = {
   render: AccessDisplayValueTemplate.bind({}),
   name: "Accessing display value of ComboBox's input",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Loading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true, id: "loading-combobox-example" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const AsyncComboboxTemplate = () => {
@@ -384,7 +384,7 @@ export const AsyncCombobox = {
   render: AsyncComboboxTemplate.bind({}),
   name: "Asynchronous ComboBox",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ValidationTemplate = args =>
@@ -414,14 +414,14 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const NoValidateTemplate = () => {
@@ -475,7 +475,7 @@ export const NoValidate = {
   render: NoValidateTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const AutocompleteTemplate = () =>
@@ -518,5 +518,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -7,8 +7,7 @@ export const ComboBoxMultiSelect = {
   render: Template.bind({}),
   name: "MultiSelect",
   args: { ...args, multiSelect: true, id: "multiselect-combobox-example" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const DefaultFilter = () => {
@@ -38,8 +37,7 @@ export const ComboBoxDefaultFilter = {
   render: DefaultFilter.bind({}),
   name: "ComboBox with default filter",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const CustomFilter = () => {
@@ -81,16 +79,14 @@ export const ComboBoxCustomFilter = {
   render: CustomFilter.bind({}),
   name: "ComboBox with custom filter",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ComboBoxDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ComboBoxMenuListProp = () => {
@@ -313,8 +309,7 @@ export const ComboBoxMenuList = {
   render: ComboBoxMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ComboBoxMenuListClearableProp = () => {
@@ -337,8 +332,7 @@ export const ComboBoxMenuListClearable = {
   render: ComboBoxMenuListClearableProp.bind({}),
   name: "Populating menu list with clearable property",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const AccessDisplayValueTemplate = () => {
@@ -367,16 +361,14 @@ export const AccessDisplayValue = {
   render: AccessDisplayValueTemplate.bind({}),
   name: "Accessing display value of ComboBox's input",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Loading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true, id: "loading-combobox-example" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const AsyncComboboxTemplate = () => {
@@ -392,8 +384,7 @@ export const AsyncCombobox = {
   render: AsyncComboboxTemplate.bind({}),
   name: "Asynchronous ComboBox",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ValidationTemplate = args =>
@@ -423,16 +414,14 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const NoValidateTemplate = () => {
@@ -486,8 +475,7 @@ export const NoValidate = {
   render: NoValidateTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const AutocompleteTemplate = () =>
@@ -530,6 +518,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -7,7 +7,7 @@ export const ComboBoxMultiSelect = {
   render: Template.bind({}),
   name: "MultiSelect",
   args: { ...args, multiSelect: true, id: "multiselect-combobox-example" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const DefaultFilter = () => {
@@ -37,7 +37,7 @@ export const ComboBoxDefaultFilter = {
   render: DefaultFilter.bind({}),
   name: "ComboBox with default filter",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const CustomFilter = () => {
@@ -79,14 +79,14 @@ export const ComboBoxCustomFilter = {
   render: CustomFilter.bind({}),
   name: "ComboBox with custom filter",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ComboBoxDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ComboBoxMenuListProp = () => {
@@ -309,7 +309,7 @@ export const ComboBoxMenuList = {
   render: ComboBoxMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ComboBoxMenuListClearableProp = () => {
@@ -332,7 +332,7 @@ export const ComboBoxMenuListClearable = {
   render: ComboBoxMenuListClearableProp.bind({}),
   name: "Populating menu list with clearable property",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const AccessDisplayValueTemplate = () => {
@@ -361,14 +361,14 @@ export const AccessDisplayValue = {
   render: AccessDisplayValueTemplate.bind({}),
   name: "Accessing display value of ComboBox's input",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Loading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true, id: "loading-combobox-example" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const AsyncComboboxTemplate = () => {
@@ -384,7 +384,7 @@ export const AsyncCombobox = {
   render: AsyncComboboxTemplate.bind({}),
   name: "Asynchronous ComboBox",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ValidationTemplate = args =>
@@ -414,14 +414,14 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const NoValidateTemplate = () => {
@@ -475,7 +475,7 @@ export const NoValidate = {
   render: NoValidateTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const AutocompleteTemplate = () =>
@@ -518,5 +518,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Datepicker/additional.stories.js
+++ b/stories/component-templates/Datepicker/additional.stories.js
@@ -6,8 +6,7 @@ export const RangeSelection = {
   render: RangeTemplate.bind({}),
   name: "Range selection",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const FlipTemplate = args =>
@@ -21,8 +20,7 @@ export const Flip = {
   render: FlipTemplate.bind({}),
   name: "Flip",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ModeTemplate = args => {
@@ -39,15 +37,13 @@ export const SingleMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for single mode",
   args: { value: "23/05/2023", mode: "single" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const RangeMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for range mode",
   args: { value: "23/05/2023 - 15/12/2023", mode: "range" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const MinMaxTemplate = args => {
@@ -72,8 +68,7 @@ export const MinMax = {
   render: MinMaxTemplate.bind({}),
   name: "Min and max date",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const FormSubmissionTemplate = args => {
@@ -112,8 +107,7 @@ export const FormSubmission = {
   render: FormSubmissionTemplate.bind({}),
   name: "Form submission",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const CustomValidationTemplate = () => html`
@@ -148,8 +142,7 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const InvalidDateClearTemplate = () => {
@@ -201,6 +194,5 @@ export const InvalidDateClear = {
   render: InvalidDateClearTemplate.bind({}),
   name: "Invalid date auto-clear",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Datepicker/additional.stories.js
+++ b/stories/component-templates/Datepicker/additional.stories.js
@@ -6,7 +6,7 @@ export const RangeSelection = {
   render: RangeTemplate.bind({}),
   name: "Range selection",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const FlipTemplate = args =>
@@ -20,7 +20,7 @@ export const Flip = {
   render: FlipTemplate.bind({}),
   name: "Flip",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ModeTemplate = args => {
@@ -37,13 +37,13 @@ export const SingleMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for single mode",
   args: { value: "23/05/2023", mode: "single" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const RangeMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for range mode",
   args: { value: "23/05/2023 - 15/12/2023", mode: "range" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const MinMaxTemplate = args => {
@@ -68,7 +68,7 @@ export const MinMax = {
   render: MinMaxTemplate.bind({}),
   name: "Min and max date",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const FormSubmissionTemplate = args => {
@@ -107,7 +107,7 @@ export const FormSubmission = {
   render: FormSubmissionTemplate.bind({}),
   name: "Form submission",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const CustomValidationTemplate = () => html`
@@ -142,7 +142,7 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const InvalidDateClearTemplate = () => {
@@ -194,5 +194,5 @@ export const InvalidDateClear = {
   render: InvalidDateClearTemplate.bind({}),
   name: "Invalid date auto-clear",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Datepicker/additional.stories.js
+++ b/stories/component-templates/Datepicker/additional.stories.js
@@ -6,7 +6,7 @@ export const RangeSelection = {
   render: RangeTemplate.bind({}),
   name: "Range selection",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const FlipTemplate = args =>
@@ -20,7 +20,7 @@ export const Flip = {
   render: FlipTemplate.bind({}),
   name: "Flip",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ModeTemplate = args => {
@@ -37,13 +37,13 @@ export const SingleMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for single mode",
   args: { value: "23/05/2023", mode: "single" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const RangeMode = {
   render: ModeTemplate.bind({}),
   name: "Initial value for range mode",
   args: { value: "23/05/2023 - 15/12/2023", mode: "range" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const MinMaxTemplate = args => {
@@ -68,7 +68,7 @@ export const MinMax = {
   render: MinMaxTemplate.bind({}),
   name: "Min and max date",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const FormSubmissionTemplate = args => {
@@ -107,7 +107,7 @@ export const FormSubmission = {
   render: FormSubmissionTemplate.bind({}),
   name: "Form submission",
   args: { displayDate: new Date(2023, 5, 10) },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const CustomValidationTemplate = () => html`
@@ -142,7 +142,7 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const InvalidDateClearTemplate = () => {
@@ -194,5 +194,5 @@ export const InvalidDateClear = {
   render: InvalidDateClearTemplate.bind({}),
   name: "Invalid date auto-clear",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/DescriptionList/additional.stories.js
+++ b/stories/component-templates/DescriptionList/additional.stories.js
@@ -2,17 +2,17 @@ export const OptionalTitleDescription = {
   render: Template.bind({}),
   name: "Optional title and description",
   args: { title: true, description: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Stacked = {
   render: Template.bind({}),
   name: "Stacked layout",
   args: { stacked: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Bordered = {
   render: Template.bind({}),
   name: "Bordered",
   args: { bordered: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/DescriptionList/additional.stories.js
+++ b/stories/component-templates/DescriptionList/additional.stories.js
@@ -2,17 +2,17 @@ export const OptionalTitleDescription = {
   render: Template.bind({}),
   name: "Optional title and description",
   args: { title: true, description: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Stacked = {
   render: Template.bind({}),
   name: "Stacked layout",
   args: { stacked: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Bordered = {
   render: Template.bind({}),
   name: "Bordered",
   args: { bordered: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/DescriptionList/additional.stories.js
+++ b/stories/component-templates/DescriptionList/additional.stories.js
@@ -2,20 +2,17 @@ export const OptionalTitleDescription = {
   render: Template.bind({}),
   name: "Optional title and description",
   args: { title: true, description: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Stacked = {
   render: Template.bind({}),
   name: "Stacked layout",
   args: { stacked: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Bordered = {
   render: Template.bind({}),
   name: "Bordered",
   args: { bordered: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Divider/additional.stories.js
+++ b/stories/component-templates/Divider/additional.stories.js
@@ -28,13 +28,11 @@ export const Orientation = {
   render: OrientationTeamplate.bind({}),
   name: "Vertical",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Thickness = {
   render: ThicknessTemplate.bind({}),
   name: "Thickness",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Divider/additional.stories.js
+++ b/stories/component-templates/Divider/additional.stories.js
@@ -28,11 +28,11 @@ export const Orientation = {
   render: OrientationTeamplate.bind({}),
   name: "Vertical",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Thickness = {
   render: ThicknessTemplate.bind({}),
   name: "Thickness",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Divider/additional.stories.js
+++ b/stories/component-templates/Divider/additional.stories.js
@@ -28,11 +28,11 @@ export const Orientation = {
   render: OrientationTeamplate.bind({}),
   name: "Vertical",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Thickness = {
   render: ThicknessTemplate.bind({}),
   name: "Thickness",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Drawer/additional.stories.js
+++ b/stories/component-templates/Drawer/additional.stories.js
@@ -46,10 +46,9 @@ export const Placement = {
     docs: {
       story: {
         height: "500px"
-      }
+      , controls: { disable: true } }
     }
-  },
-  tags: ["!dev"]
+  }
 };
 
 const SizeTemplate = () => {
@@ -98,8 +97,7 @@ export const Sizes = {
     docs: {
       story: {
         height: "500px"
-      }
+      , controls: { disable: true } }
     }
-  },
-  tags: ["!dev"]
+  }
 };

--- a/stories/component-templates/Drawer/additional.stories.js
+++ b/stories/component-templates/Drawer/additional.stories.js
@@ -45,8 +45,9 @@ export const Placement = {
   parameters: {
     docs: {
       story: {
-        height: "500px"
-      , controls: { disable: true } }
+        height: "500px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -96,8 +97,9 @@ export const Sizes = {
   parameters: {
     docs: {
       story: {
-        height: "500px"
-      , controls: { disable: true } }
+        height: "500px",
+        controls: { disable: true }
+      }
     }
   }
 };

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -39,7 +39,7 @@ export const SgdsSelectClose = {
   name: "sgds-select close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true , controls: { disable: true } }
+    chromatic: { disableSnapshot: true, controls: { disable: true } }
   }
 };
 
@@ -72,7 +72,7 @@ export const SgdsSelectEvent = {
   name: "sgds-select event",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true , controls: { disable: true } }
+    chromatic: { disableSnapshot: true, controls: { disable: true } }
   }
 };
 
@@ -146,6 +146,6 @@ export const SgdsSelectDropdownItem = {
   name: "sgds-dropdown-item customisation",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true , controls: { disable: true } }
+    chromatic: { disableSnapshot: true, controls: { disable: true } }
   }
 };

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -39,7 +39,7 @@ export const SgdsSelectClose = {
   name: "sgds-select close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, controls: { disable: true } }
+    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
   }
 };
 
@@ -72,7 +72,7 @@ export const SgdsSelectEvent = {
   name: "sgds-select event",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, controls: { disable: true } }
+    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
   }
 };
 
@@ -146,6 +146,6 @@ export const SgdsSelectDropdownItem = {
   name: "sgds-dropdown-item customisation",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, controls: { disable: true } }
+    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
   }
 };

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -39,9 +39,8 @@ export const SgdsSelectClose = {
   name: "sgds-select close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true }
-  },
-  tags: ["!dev"]
+    chromatic: { disableSnapshot: true , controls: { disable: true } }
+  }
 };
 
 const SgdsSelectEventTemplate = args => {
@@ -73,9 +72,8 @@ export const SgdsSelectEvent = {
   name: "sgds-select event",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true }
-  },
-  tags: ["!dev"]
+    chromatic: { disableSnapshot: true , controls: { disable: true } }
+  }
 };
 
 const SgdsSelectDropdownItemTemplate = args => {
@@ -148,7 +146,6 @@ export const SgdsSelectDropdownItem = {
   name: "sgds-dropdown-item customisation",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true }
-  },
-  tags: ["!dev"]
+    chromatic: { disableSnapshot: true , controls: { disable: true } }
+  }
 };

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -39,7 +39,7 @@ export const SgdsSelectClose = {
   name: "sgds-select close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
+    chromatic: { disableSnapshot: true }
   }
 };
 
@@ -72,7 +72,7 @@ export const SgdsSelectEvent = {
   name: "sgds-select event",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
+    chromatic: { disableSnapshot: true }
   }
 };
 
@@ -146,6 +146,6 @@ export const SgdsSelectDropdownItem = {
   name: "sgds-dropdown-item customisation",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
+    chromatic: { disableSnapshot: true }
   }
 };

--- a/stories/component-templates/FileUpload/additional.stories.js
+++ b/stories/component-templates/FileUpload/additional.stories.js
@@ -8,7 +8,7 @@ export const DragAndDrop = {
   render: Template.bind({}),
   name: "Drag and Drop",
   args: { variant: "drag-and-drop", multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -24,7 +24,7 @@ export const ValidationDefaultInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -38,7 +38,7 @@ export const ValidationDragDropInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -72,7 +72,7 @@ export const UploadingStateDefault = {
   render: UploadingStateDefaultTemplate.bind({}),
   name: "Uploading State",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -106,7 +106,7 @@ export const UploadingStateDragDrop = {
   render: UploadingStateDragDropTemplate.bind({}),
   name: "Uploading State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -145,7 +145,7 @@ export const ErrorStateDefault = {
   render: ErrorStateDefaultTemplate.bind({}),
   name: "Error State",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -184,7 +184,7 @@ export const ErrorStateDragDrop = {
   render: ErrorStateDragDropTemplate.bind({}),
   name: "Error State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -222,7 +222,7 @@ export const SuccessStateDefault = {
   render: SuccessStateDefaultTemplate.bind({}),
   name: "Success State",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -260,7 +260,7 @@ export const SuccessStateDragDrop = {
   render: SuccessStateDragDropTemplate.bind({}),
   name: "Success State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -309,7 +309,7 @@ export const SgdsAddFiles = {
   render: SgdsAddFilesTemplate.bind({}),
   name: "Event: sgds-add-files",
   args: { multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -358,7 +358,7 @@ export const SgdsRemoveFile = {
   render: SgdsRemoveFileTemplate.bind({}),
   name: "Event: sgds-remove-file",
   args: { multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -409,7 +409,7 @@ export const SgdsChange = {
   render: SgdsChangeTemplate.bind({}),
   name: "Event: sgds-change",
   args: { multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -470,7 +470,7 @@ export const UploadToServer = {
   render: UploadToServerTemplate.bind({}),
   name: "Upload to Server",
   args: { multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };
 
@@ -546,6 +546,6 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: { required: true, hasFeedback: true, noValidate: true, multiple: true },
-  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "padded" },
   tags: []
 };

--- a/stories/component-templates/FileUpload/additional.stories.js
+++ b/stories/component-templates/FileUpload/additional.stories.js
@@ -8,7 +8,7 @@ export const DragAndDrop = {
   render: Template.bind({}),
   name: "Drag and Drop",
   args: { variant: "drag-and-drop", multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -24,7 +24,7 @@ export const ValidationDefaultInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -38,7 +38,7 @@ export const ValidationDragDropInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -72,7 +72,7 @@ export const UploadingStateDefault = {
   render: UploadingStateDefaultTemplate.bind({}),
   name: "Uploading State",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -106,7 +106,7 @@ export const UploadingStateDragDrop = {
   render: UploadingStateDragDropTemplate.bind({}),
   name: "Uploading State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -145,7 +145,7 @@ export const ErrorStateDefault = {
   render: ErrorStateDefaultTemplate.bind({}),
   name: "Error State",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -184,7 +184,7 @@ export const ErrorStateDragDrop = {
   render: ErrorStateDragDropTemplate.bind({}),
   name: "Error State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -222,7 +222,7 @@ export const SuccessStateDefault = {
   render: SuccessStateDefaultTemplate.bind({}),
   name: "Success State",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -260,7 +260,7 @@ export const SuccessStateDragDrop = {
   render: SuccessStateDragDropTemplate.bind({}),
   name: "Success State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -309,7 +309,7 @@ export const SgdsAddFiles = {
   render: SgdsAddFilesTemplate.bind({}),
   name: "Event: sgds-add-files",
   args: { multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -358,7 +358,7 @@ export const SgdsRemoveFile = {
   render: SgdsRemoveFileTemplate.bind({}),
   name: "Event: sgds-remove-file",
   args: { multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -409,7 +409,7 @@ export const SgdsChange = {
   render: SgdsChangeTemplate.bind({}),
   name: "Event: sgds-change",
   args: { multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -470,7 +470,7 @@ export const UploadToServer = {
   render: UploadToServerTemplate.bind({}),
   name: "Upload to Server",
   args: { multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };
 
@@ -546,6 +546,6 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: { required: true, hasFeedback: true, noValidate: true, multiple: true },
-  parameters: { layout: "padded" },
+  parameters: { layout: "padded" , controls: { disable: true } },
   tags: []
 };

--- a/stories/component-templates/FileUpload/additional.stories.js
+++ b/stories/component-templates/FileUpload/additional.stories.js
@@ -8,7 +8,7 @@ export const DragAndDrop = {
   render: Template.bind({}),
   name: "Drag and Drop",
   args: { variant: "drag-and-drop", multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -24,7 +24,7 @@ export const ValidationDefaultInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -38,7 +38,7 @@ export const ValidationDragDropInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -72,7 +72,7 @@ export const UploadingStateDefault = {
   render: UploadingStateDefaultTemplate.bind({}),
   name: "Uploading State",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -106,7 +106,7 @@ export const UploadingStateDragDrop = {
   render: UploadingStateDragDropTemplate.bind({}),
   name: "Uploading State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -145,7 +145,7 @@ export const ErrorStateDefault = {
   render: ErrorStateDefaultTemplate.bind({}),
   name: "Error State",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -184,7 +184,7 @@ export const ErrorStateDragDrop = {
   render: ErrorStateDragDropTemplate.bind({}),
   name: "Error State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -222,7 +222,7 @@ export const SuccessStateDefault = {
   render: SuccessStateDefaultTemplate.bind({}),
   name: "Success State",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -260,7 +260,7 @@ export const SuccessStateDragDrop = {
   render: SuccessStateDragDropTemplate.bind({}),
   name: "Success State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -309,7 +309,7 @@ export const SgdsAddFiles = {
   render: SgdsAddFilesTemplate.bind({}),
   name: "Event: sgds-add-files",
   args: { multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -358,7 +358,7 @@ export const SgdsRemoveFile = {
   render: SgdsRemoveFileTemplate.bind({}),
   name: "Event: sgds-remove-file",
   args: { multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -409,7 +409,7 @@ export const SgdsChange = {
   render: SgdsChangeTemplate.bind({}),
   name: "Event: sgds-change",
   args: { multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -470,7 +470,7 @@ export const UploadToServer = {
   render: UploadToServerTemplate.bind({}),
   name: "Upload to Server",
   args: { multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };
 
@@ -546,6 +546,6 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: { required: true, hasFeedback: true, noValidate: true, multiple: true },
-  parameters: { layout: "padded" , controls: { disable: true } },
+  parameters: { layout: "padded", controls: { disable: true } },
   tags: []
 };

--- a/stories/component-templates/FileUpload/additional.stories.js
+++ b/stories/component-templates/FileUpload/additional.stories.js
@@ -8,7 +8,7 @@ export const DragAndDrop = {
   render: Template.bind({}),
   name: "Drag and Drop",
   args: { variant: "drag-and-drop", multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -24,7 +24,7 @@ export const ValidationDefaultInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -38,7 +38,7 @@ export const ValidationDragDropInvalid = {
     invalid: true,
     invalidFeedback: "Please upload at least one file"
   },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -72,7 +72,7 @@ export const UploadingStateDefault = {
   render: UploadingStateDefaultTemplate.bind({}),
   name: "Uploading State",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -106,7 +106,7 @@ export const UploadingStateDragDrop = {
   render: UploadingStateDragDropTemplate.bind({}),
   name: "Uploading State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -145,7 +145,7 @@ export const ErrorStateDefault = {
   render: ErrorStateDefaultTemplate.bind({}),
   name: "Error State",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -184,7 +184,7 @@ export const ErrorStateDragDrop = {
   render: ErrorStateDragDropTemplate.bind({}),
   name: "Error State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -222,7 +222,7 @@ export const SuccessStateDefault = {
   render: SuccessStateDefaultTemplate.bind({}),
   name: "Success State",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -260,7 +260,7 @@ export const SuccessStateDragDrop = {
   render: SuccessStateDragDropTemplate.bind({}),
   name: "Success State - Drag and Drop",
   args: {},
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -309,7 +309,7 @@ export const SgdsAddFiles = {
   render: SgdsAddFilesTemplate.bind({}),
   name: "Event: sgds-add-files",
   args: { multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -358,7 +358,7 @@ export const SgdsRemoveFile = {
   render: SgdsRemoveFileTemplate.bind({}),
   name: "Event: sgds-remove-file",
   args: { multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -409,7 +409,7 @@ export const SgdsChange = {
   render: SgdsChangeTemplate.bind({}),
   name: "Event: sgds-change",
   args: { multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -470,7 +470,7 @@ export const UploadToServer = {
   render: UploadToServerTemplate.bind({}),
   name: "Upload to Server",
   args: { multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -546,6 +546,6 @@ export const CustomValidation = {
   render: CustomValidationTemplate.bind({}),
   name: "Custom Validation with noValidate",
   args: { required: true, hasFeedback: true, noValidate: true, multiple: true },
-  parameters: { layout: "padded", controls: { disable: true } },
+  parameters: { layout: "padded", selectedPanel: "storybook/docs/panel" },
   tags: []
 };

--- a/stories/component-templates/Footer/additional.stories.js
+++ b/stories/component-templates/Footer/additional.stories.js
@@ -72,7 +72,7 @@ export const Extended = {
   render: ExtendedTemplate.bind({}),
   name: "Extended",
   args: {},
-  parameters: { layout: "fullscreen" , controls: { disable: true } },
+  parameters: { layout: "fullscreen", controls: { disable: true } },
   tags: []
 };
 
@@ -88,6 +88,6 @@ export const NeutralToneExtended = {
   render: ExtendedTemplate.bind({}),
   name: "Neutral Tone Extended",
   args: { tone: "neutral" },
-  parameters: { layout: "fullscreen" , controls: { disable: true } },
+  parameters: { layout: "fullscreen", controls: { disable: true } },
   tags: []
 };

--- a/stories/component-templates/Footer/additional.stories.js
+++ b/stories/component-templates/Footer/additional.stories.js
@@ -72,7 +72,7 @@ export const Extended = {
   render: ExtendedTemplate.bind({}),
   name: "Extended",
   args: {},
-  parameters: { layout: "fullscreen", controls: { disable: true } },
+  parameters: { layout: "fullscreen", selectedPanel: "storybook/docs/panel" },
   tags: []
 };
 
@@ -88,6 +88,6 @@ export const NeutralToneExtended = {
   render: ExtendedTemplate.bind({}),
   name: "Neutral Tone Extended",
   args: { tone: "neutral" },
-  parameters: { layout: "fullscreen", controls: { disable: true } },
+  parameters: { layout: "fullscreen", selectedPanel: "storybook/docs/panel" },
   tags: []
 };

--- a/stories/component-templates/Footer/additional.stories.js
+++ b/stories/component-templates/Footer/additional.stories.js
@@ -72,7 +72,7 @@ export const Extended = {
   render: ExtendedTemplate.bind({}),
   name: "Extended",
   args: {},
-  parameters: { layout: "fullscreen" },
+  parameters: { layout: "fullscreen" , controls: { disable: true } },
   tags: []
 };
 
@@ -88,6 +88,6 @@ export const NeutralToneExtended = {
   render: ExtendedTemplate.bind({}),
   name: "Neutral Tone Extended",
   args: { tone: "neutral" },
-  parameters: { layout: "fullscreen" },
+  parameters: { layout: "fullscreen" , controls: { disable: true } },
   tags: []
 };

--- a/stories/component-templates/Footer/additional.stories.js
+++ b/stories/component-templates/Footer/additional.stories.js
@@ -72,7 +72,7 @@ export const Extended = {
   render: ExtendedTemplate.bind({}),
   name: "Extended",
   args: {},
-  parameters: { layout: "fullscreen", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "fullscreen" },
   tags: []
 };
 
@@ -88,6 +88,6 @@ export const NeutralToneExtended = {
   render: ExtendedTemplate.bind({}),
   name: "Neutral Tone Extended",
   args: { tone: "neutral" },
-  parameters: { layout: "fullscreen", selectedPanel: "storybook/docs/panel" },
+  parameters: { layout: "fullscreen" },
   tags: []
 };

--- a/stories/component-templates/Icon/additional.stories.js
+++ b/stories/component-templates/Icon/additional.stories.js
@@ -22,12 +22,12 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Color = {
   render: ColorTemplate.bind({}),
   name: "Color",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Icon/additional.stories.js
+++ b/stories/component-templates/Icon/additional.stories.js
@@ -22,14 +22,12 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Color = {
   render: ColorTemplate.bind({}),
   name: "Color",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Icon/additional.stories.js
+++ b/stories/component-templates/Icon/additional.stories.js
@@ -22,12 +22,12 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Color = {
   render: ColorTemplate.bind({}),
   name: "Color",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/IconButton/additional.stories.js
+++ b/stories/component-templates/IconButton/additional.stories.js
@@ -12,7 +12,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ToneTemplate = args => {
@@ -46,7 +46,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const SizeTemplate = () => {
@@ -60,7 +60,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ActiveTemplate = () => {
@@ -76,7 +76,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
@@ -87,7 +87,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Loading = {
@@ -117,5 +117,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/IconButton/additional.stories.js
+++ b/stories/component-templates/IconButton/additional.stories.js
@@ -12,8 +12,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ToneTemplate = args => {
@@ -47,8 +46,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const SizeTemplate = () => {
@@ -62,8 +60,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ActiveTemplate = () => {
@@ -79,8 +76,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
@@ -91,8 +87,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Loading = {
@@ -122,6 +117,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/IconButton/additional.stories.js
+++ b/stories/component-templates/IconButton/additional.stories.js
@@ -12,7 +12,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ToneTemplate = args => {
@@ -46,7 +46,7 @@ export const Tone = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const SizeTemplate = () => {
@@ -60,7 +60,7 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ActiveTemplate = () => {
@@ -76,7 +76,7 @@ export const Active = {
   render: ActiveTemplate.bind({}),
   name: "Hover / Active state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
@@ -87,7 +87,7 @@ export const Disabled = {
   `,
   name: "Disabled state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Loading = {
@@ -117,5 +117,5 @@ export const Loading = {
   `,
   name: "Loading state",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/IconCard/additional.stories.js
+++ b/stories/component-templates/IconCard/additional.stories.js
@@ -4,16 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const OrientationTemplate = () =>
@@ -72,24 +70,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const NoPaddingTemplate = () =>
@@ -148,6 +143,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/IconCard/additional.stories.js
+++ b/stories/component-templates/IconCard/additional.stories.js
@@ -4,14 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const OrientationTemplate = () =>
@@ -70,21 +70,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const NoPaddingTemplate = () =>
@@ -143,5 +143,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/IconCard/additional.stories.js
+++ b/stories/component-templates/IconCard/additional.stories.js
@@ -4,14 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const OrientationTemplate = () =>
@@ -70,21 +70,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const NoPaddingTemplate = () =>
@@ -143,5 +143,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/IconList/additional.stories.js
+++ b/stories/component-templates/IconList/additional.stories.js
@@ -26,5 +26,5 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/IconList/additional.stories.js
+++ b/stories/component-templates/IconList/additional.stories.js
@@ -26,6 +26,5 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/IconList/additional.stories.js
+++ b/stories/component-templates/IconList/additional.stories.js
@@ -26,5 +26,5 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/ImageCard/additional.stories.js
+++ b/stories/component-templates/ImageCard/additional.stories.js
@@ -37,14 +37,14 @@ export const Stretched = {
   render: StretchedLinkTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const OrientationTemplate = () =>
@@ -113,7 +113,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ImagePositionTemplate = () => {
@@ -239,7 +239,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -337,21 +337,21 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const NoPaddingTemplate = () =>
@@ -418,5 +418,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/ImageCard/additional.stories.js
+++ b/stories/component-templates/ImageCard/additional.stories.js
@@ -37,16 +37,14 @@ export const Stretched = {
   render: StretchedLinkTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const OrientationTemplate = () =>
@@ -115,8 +113,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ImagePositionTemplate = () => {
@@ -242,8 +239,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -341,24 +337,21 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const NoPaddingTemplate = () =>
@@ -425,6 +418,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/ImageCard/additional.stories.js
+++ b/stories/component-templates/ImageCard/additional.stories.js
@@ -37,14 +37,14 @@ export const Stretched = {
   render: StretchedLinkTemplate.bind({}),
   name: "Stretched link",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const OrientationTemplate = () =>
@@ -113,7 +113,7 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ImagePositionTemplate = () => {
@@ -239,7 +239,7 @@ export const ImagePosition = {
   render: ImagePositionTemplate.bind({}),
   name: "Image position",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ImageAdjustmentTemplate = () => {
@@ -337,21 +337,21 @@ export const ImageAdjustment = {
   render: ImageAdjustmentTemplate.bind({}),
   name: "Image adjustment",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const NoPaddingTemplate = () =>
@@ -418,5 +418,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Input/additional.stories.js
+++ b/stories/component-templates/Input/additional.stories.js
@@ -50,54 +50,54 @@ export const PasswordInput = {
   render: Template.bind({}),
   name: "Password",
   args: { ...args, type: "password" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const DisabledInput = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const InvalidInput = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: true, invalid: true, invalidFeedback: "Invalid input detected" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ValidInput = {
   render: Template.bind({}),
   name: "Valid",
   args: { ...args, hasFeedback: true, valid: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const LoadingInput = {
   render: Template.bind({}),
   name: "Loading",
   args: { ...args, hasFeedback: true, loading: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const ReadonlyInput = {
   render: Template.bind({}),
   name: "Read only",
   args: { ...args, readonly: true, value: "readonly input" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const PrefixInput = {
   render: Template.bind({}),
   name: "With prefix",
   args: { ...args, prefix: "prefix" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const SuffixInput = {
   render: Template.bind({}),
   name: "With suffix",
   args: { ...args, suffix: "suffix" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const LeadingIcon = {
@@ -106,7 +106,7 @@ export const LeadingIcon = {
   args: {
     ...args
   },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const TrailingIcon = {
   render: TrailingIconTemplate.bind({}),
@@ -114,7 +114,7 @@ export const TrailingIcon = {
   args: {
     ...args
   },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Action = {
@@ -123,21 +123,21 @@ export const Action = {
   args: {
     ...args
   },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const InputValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const AutocompleteTemplate = () =>
@@ -170,5 +170,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Input/additional.stories.js
+++ b/stories/component-templates/Input/additional.stories.js
@@ -50,54 +50,54 @@ export const PasswordInput = {
   render: Template.bind({}),
   name: "Password",
   args: { ...args, type: "password" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const DisabledInput = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const InvalidInput = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: true, invalid: true, invalidFeedback: "Invalid input detected" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ValidInput = {
   render: Template.bind({}),
   name: "Valid",
   args: { ...args, hasFeedback: true, valid: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const LoadingInput = {
   render: Template.bind({}),
   name: "Loading",
   args: { ...args, hasFeedback: true, loading: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const ReadonlyInput = {
   render: Template.bind({}),
   name: "Read only",
   args: { ...args, readonly: true, value: "readonly input" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const PrefixInput = {
   render: Template.bind({}),
   name: "With prefix",
   args: { ...args, prefix: "prefix" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const SuffixInput = {
   render: Template.bind({}),
   name: "With suffix",
   args: { ...args, suffix: "suffix" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const LeadingIcon = {
@@ -106,7 +106,7 @@ export const LeadingIcon = {
   args: {
     ...args
   },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const TrailingIcon = {
   render: TrailingIconTemplate.bind({}),
@@ -114,7 +114,7 @@ export const TrailingIcon = {
   args: {
     ...args
   },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Action = {
@@ -123,21 +123,21 @@ export const Action = {
   args: {
     ...args
   },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const InputValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const AutocompleteTemplate = () =>
@@ -170,5 +170,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Input/additional.stories.js
+++ b/stories/component-templates/Input/additional.stories.js
@@ -50,62 +50,54 @@ export const PasswordInput = {
   render: Template.bind({}),
   name: "Password",
   args: { ...args, type: "password" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const DisabledInput = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const InvalidInput = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: true, invalid: true, invalidFeedback: "Invalid input detected" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ValidInput = {
   render: Template.bind({}),
   name: "Valid",
   args: { ...args, hasFeedback: true, valid: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const LoadingInput = {
   render: Template.bind({}),
   name: "Loading",
   args: { ...args, hasFeedback: true, loading: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const ReadonlyInput = {
   render: Template.bind({}),
   name: "Read only",
   args: { ...args, readonly: true, value: "readonly input" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const PrefixInput = {
   render: Template.bind({}),
   name: "With prefix",
   args: { ...args, prefix: "prefix" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const SuffixInput = {
   render: Template.bind({}),
   name: "With suffix",
   args: { ...args, suffix: "suffix" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const LeadingIcon = {
@@ -114,8 +106,7 @@ export const LeadingIcon = {
   args: {
     ...args
   },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const TrailingIcon = {
   render: TrailingIconTemplate.bind({}),
@@ -123,8 +114,7 @@ export const TrailingIcon = {
   args: {
     ...args
   },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Action = {
@@ -133,24 +123,21 @@ export const Action = {
   args: {
     ...args
   },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const InputValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const AutocompleteTemplate = () =>
@@ -183,6 +170,5 @@ export const Autocomplete = {
   render: AutocompleteTemplate.bind({}),
   name: "Autocomplete prop",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Link/additional.stories.js
+++ b/stories/component-templates/Link/additional.stories.js
@@ -19,8 +19,7 @@ export const Tones = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: { ...args },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const VariantTemplate = () => {
@@ -41,8 +40,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variant",
   args: { ...args },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const SizeTemplate = () => {
@@ -68,8 +66,7 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const ExternalLinkTemplate = () => {
@@ -95,8 +92,7 @@ export const ExternalLink = {
   render: ExternalLinkTemplate.bind({}),
   name: "Target _blank",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const WithIconTemplate = () => {
@@ -116,21 +112,18 @@ export const Icon = {
   render: WithIconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Active = {
   render: Template.bind({}),
   name: "Active",
   args: { active: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Link/additional.stories.js
+++ b/stories/component-templates/Link/additional.stories.js
@@ -19,7 +19,7 @@ export const Tones = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: { ...args },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const VariantTemplate = () => {
@@ -40,7 +40,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variant",
   args: { ...args },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const SizeTemplate = () => {
@@ -66,7 +66,7 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const ExternalLinkTemplate = () => {
@@ -92,7 +92,7 @@ export const ExternalLink = {
   render: ExternalLinkTemplate.bind({}),
   name: "Target _blank",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const WithIconTemplate = () => {
@@ -112,18 +112,18 @@ export const Icon = {
   render: WithIconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Active = {
   render: Template.bind({}),
   name: "Active",
   args: { active: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Link/additional.stories.js
+++ b/stories/component-templates/Link/additional.stories.js
@@ -19,7 +19,7 @@ export const Tones = {
   render: ToneTemplate.bind({}),
   name: "Tone",
   args: { ...args },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const VariantTemplate = () => {
@@ -40,7 +40,7 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variant",
   args: { ...args },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const SizeTemplate = () => {
@@ -66,7 +66,7 @@ export const Size = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const ExternalLinkTemplate = () => {
@@ -92,7 +92,7 @@ export const ExternalLink = {
   render: ExternalLinkTemplate.bind({}),
   name: "Target _blank",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const WithIconTemplate = () => {
@@ -112,18 +112,18 @@ export const Icon = {
   render: WithIconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Active = {
   render: Template.bind({}),
   name: "Active",
   args: { active: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Modal/additional.stories.js
+++ b/stories/component-templates/Modal/additional.stories.js
@@ -208,7 +208,7 @@ export const PreventClose = {
   name: "Prevent close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" },
+    chromatic: { disableSnapshot: true },
     layout: "fullscreen",
     docs: {
       story: {

--- a/stories/component-templates/Modal/additional.stories.js
+++ b/stories/component-templates/Modal/additional.stories.js
@@ -111,7 +111,7 @@ export const SmallSize = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -124,7 +124,7 @@ export const MediumSize = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -137,7 +137,7 @@ export const LargeSize = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -150,7 +150,7 @@ export const ExtraLargeSize = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -163,7 +163,7 @@ export const FullscreenSize = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -177,7 +177,7 @@ export const LongContent = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -191,7 +191,7 @@ export const noAnimation = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -201,7 +201,7 @@ export const PreventClose = {
   name: "Prevent close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true },
+    chromatic: { disableSnapshot: true , controls: { disable: true } },
     layout: "fullscreen",
     docs: {
       story: {
@@ -234,7 +234,7 @@ export const NoCloseButton = {
     docs: {
       story: {
         height: "700px"
-      }
+      , controls: { disable: true } }
     }
   }
 };

--- a/stories/component-templates/Modal/additional.stories.js
+++ b/stories/component-templates/Modal/additional.stories.js
@@ -208,7 +208,7 @@ export const PreventClose = {
   name: "Prevent close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, controls: { disable: true } },
+    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" },
     layout: "fullscreen",
     docs: {
       story: {

--- a/stories/component-templates/Modal/additional.stories.js
+++ b/stories/component-templates/Modal/additional.stories.js
@@ -110,8 +110,9 @@ export const SmallSize = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -123,8 +124,9 @@ export const MediumSize = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -136,8 +138,9 @@ export const LargeSize = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -149,8 +152,9 @@ export const ExtraLargeSize = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -162,8 +166,9 @@ export const FullscreenSize = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -176,8 +181,9 @@ export const LongContent = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -190,8 +196,9 @@ export const noAnimation = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -201,7 +208,7 @@ export const PreventClose = {
   name: "Prevent close",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true , controls: { disable: true } },
+    chromatic: { disableSnapshot: true, controls: { disable: true } },
     layout: "fullscreen",
     docs: {
       story: {
@@ -233,8 +240,9 @@ export const NoCloseButton = {
     layout: "fullscreen",
     docs: {
       story: {
-        height: "700px"
-      , controls: { disable: true } }
+        height: "700px",
+        controls: { disable: true }
+      }
     }
   }
 };

--- a/stories/component-templates/OverflowMenu/additional.stories.js
+++ b/stories/component-templates/OverflowMenu/additional.stories.js
@@ -14,13 +14,11 @@ export const SmallSize = {
   render: SizeTemplate.bind({}),
   name: "Small size",
   args: { size: "sm" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const MediumSize = {
   render: SizeTemplate.bind({}),
   name: "Medium size",
   args: { size: "md" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/OverflowMenu/additional.stories.js
+++ b/stories/component-templates/OverflowMenu/additional.stories.js
@@ -14,11 +14,11 @@ export const SmallSize = {
   render: SizeTemplate.bind({}),
   name: "Small size",
   args: { size: "sm" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const MediumSize = {
   render: SizeTemplate.bind({}),
   name: "Medium size",
   args: { size: "md" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/OverflowMenu/additional.stories.js
+++ b/stories/component-templates/OverflowMenu/additional.stories.js
@@ -14,11 +14,11 @@ export const SmallSize = {
   render: SizeTemplate.bind({}),
   name: "Small size",
   args: { size: "sm" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const MediumSize = {
   render: SizeTemplate.bind({}),
   name: "Medium size",
   args: { size: "md" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Pagination/additional.stories.js
+++ b/stories/component-templates/Pagination/additional.stories.js
@@ -7,8 +7,7 @@ export const PaginationWithAPI = {
   render: MockPaginationTemplate.bind({}),
   name: "API example",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const PaginationSizes = {
@@ -18,8 +17,7 @@ export const PaginationSizes = {
   `,
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const PaginationVariants = {
@@ -31,8 +29,7 @@ export const PaginationVariants = {
   `,
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Navigation = {
@@ -42,6 +39,5 @@ export const Navigation = {
   `,
   name: "Navigation button type",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Pagination/additional.stories.js
+++ b/stories/component-templates/Pagination/additional.stories.js
@@ -7,7 +7,7 @@ export const PaginationWithAPI = {
   render: MockPaginationTemplate.bind({}),
   name: "API example",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const PaginationSizes = {
@@ -17,7 +17,7 @@ export const PaginationSizes = {
   `,
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const PaginationVariants = {
@@ -29,7 +29,7 @@ export const PaginationVariants = {
   `,
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Navigation = {
@@ -39,5 +39,5 @@ export const Navigation = {
   `,
   name: "Navigation button type",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Pagination/additional.stories.js
+++ b/stories/component-templates/Pagination/additional.stories.js
@@ -7,7 +7,7 @@ export const PaginationWithAPI = {
   render: MockPaginationTemplate.bind({}),
   name: "API example",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const PaginationSizes = {
@@ -17,7 +17,7 @@ export const PaginationSizes = {
   `,
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const PaginationVariants = {
@@ -29,7 +29,7 @@ export const PaginationVariants = {
   `,
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Navigation = {
@@ -39,5 +39,5 @@ export const Navigation = {
   `,
   name: "Navigation button type",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/ProgressBar/additional.stories.js
+++ b/stories/component-templates/ProgressBar/additional.stories.js
@@ -22,11 +22,11 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Label",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/ProgressBar/additional.stories.js
+++ b/stories/component-templates/ProgressBar/additional.stories.js
@@ -22,11 +22,11 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Label",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/ProgressBar/additional.stories.js
+++ b/stories/component-templates/ProgressBar/additional.stories.js
@@ -22,13 +22,11 @@ export const Variants = {
   render: VariantTemplate.bind({}),
   name: "Variants",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Label",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -23,26 +23,26 @@ export const DisabledQT = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const InvalidQT = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: "both", invalid: true, invalidFeedback: "Invalid QT detected" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const QTValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -23,30 +23,26 @@ export const DisabledQT = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const InvalidQT = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: "both", invalid: true, invalidFeedback: "Invalid QT detected" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const QTValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -23,26 +23,26 @@ export const DisabledQT = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const InvalidQT = {
   render: Template.bind({}),
   name: "Invalid",
   args: { ...args, hasFeedback: "both", invalid: true, invalidFeedback: "Invalid QT detected" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const QTValidation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Radio/additional.stories.js
+++ b/stories/component-templates/Radio/additional.stories.js
@@ -24,38 +24,33 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Invalid = {
   render: Template.bind({}),
   name: "Invalid styles",
   args: { ...args, hasFeedback: true, invalidFeedback: "Feedback", invalid: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Autofocus = {
   render: Template.bind({}),
   name: "Autofocus",
   args: { ...args, autofocus: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Radio/additional.stories.js
+++ b/stories/component-templates/Radio/additional.stories.js
@@ -24,33 +24,33 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Invalid = {
   render: Template.bind({}),
   name: "Invalid styles",
   args: { ...args, hasFeedback: true, invalidFeedback: "Feedback", invalid: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Autofocus = {
   render: Template.bind({}),
   name: "Autofocus",
   args: { ...args, autofocus: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Radio/additional.stories.js
+++ b/stories/component-templates/Radio/additional.stories.js
@@ -24,33 +24,33 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Invalid = {
   render: Template.bind({}),
   name: "Invalid styles",
   args: { ...args, hasFeedback: true, invalidFeedback: "Feedback", invalid: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Autofocus = {
   render: Template.bind({}),
   name: "Autofocus",
   args: { ...args, autofocus: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Select/additional.stories.js
+++ b/stories/component-templates/Select/additional.stories.js
@@ -4,8 +4,7 @@ export const SelectDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const SelectMenuListProp = () => {
@@ -228,14 +227,12 @@ export const SelectMenuList = {
   render: SelectMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const SelectLoading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Select/additional.stories.js
+++ b/stories/component-templates/Select/additional.stories.js
@@ -4,7 +4,7 @@ export const SelectDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const SelectMenuListProp = () => {
@@ -227,12 +227,12 @@ export const SelectMenuList = {
   render: SelectMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const SelectLoading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Select/additional.stories.js
+++ b/stories/component-templates/Select/additional.stories.js
@@ -4,7 +4,7 @@ export const SelectDefaultSlot = {
   render: Template.bind({}),
   name: "Populating menu list with default slot",
   args: { ...args, thirdOptionDisabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const SelectMenuListProp = () => {
@@ -227,12 +227,12 @@ export const SelectMenuList = {
   render: SelectMenuListProp.bind({}),
   name: "Populating menu list with property",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const SelectLoading = {
   render: Template.bind({}),
   name: "Loading state",
   args: { ...args, loading: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Sidebar/additional.stories.js
+++ b/stories/component-templates/Sidebar/additional.stories.js
@@ -257,7 +257,7 @@ export const Default = {
       story: {
         inline: false,
         height: 440
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -277,7 +277,7 @@ export const MultiLevel = {
       story: {
         inline: false,
         height: 440
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -297,7 +297,7 @@ export const Overlay = {
       story: {
         inline: false,
         height: 440
-      }
+      , controls: { disable: true } }
     },
     argTypes: {
       attributes: true
@@ -320,7 +320,7 @@ export const Dynamic = {
       story: {
         inline: false,
         height: 440
-      }
+      , controls: { disable: true } }
     }
   }
 };
@@ -340,8 +340,7 @@ export const LinkedItems = {
       story: {
         inline: false,
         height: 440
-      }
+      , controls: { disable: true } }
     }
-  },
-  tags: ["!dev"]
+  }
 };

--- a/stories/component-templates/Sidebar/additional.stories.js
+++ b/stories/component-templates/Sidebar/additional.stories.js
@@ -256,8 +256,9 @@ export const Default = {
     docs: {
       story: {
         inline: false,
-        height: 440
-      , controls: { disable: true } }
+        height: 440,
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -276,8 +277,9 @@ export const MultiLevel = {
     docs: {
       story: {
         inline: false,
-        height: 440
-      , controls: { disable: true } }
+        height: 440,
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -296,8 +298,9 @@ export const Overlay = {
     docs: {
       story: {
         inline: false,
-        height: 440
-      , controls: { disable: true } }
+        height: 440,
+        controls: { disable: true }
+      }
     },
     argTypes: {
       attributes: true
@@ -319,8 +322,9 @@ export const Dynamic = {
     docs: {
       story: {
         inline: false,
-        height: 440
-      , controls: { disable: true } }
+        height: 440,
+        controls: { disable: true }
+      }
     }
   }
 };
@@ -339,8 +343,9 @@ export const LinkedItems = {
     docs: {
       story: {
         inline: false,
-        height: 440
-      , controls: { disable: true } }
+        height: 440,
+        controls: { disable: true }
+      }
     }
   }
 };

--- a/stories/component-templates/Sidenav/additional.stories.js
+++ b/stories/component-templates/Sidenav/additional.stories.js
@@ -93,65 +93,56 @@ export const SidenavItemAsLink = {
   render: SidenavItemAsLinkTemplate.bind({}),
   name: "SidenavItem as first level link",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const SidenavItemAsMenu = {
   render: SidenavItemAsMenuTemplate.bind({}),
   name: "SidenavItem as menu",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const EmbeddedMenu = {
   render: EmbeddedMenuTemplate.bind({}),
   name: "SidenavItem as an embedded menu",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const IconsOnFirstLevel = {
   render: IconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const ActiveLinkState = {
   render: Template.bind({}),
   name: "Active sidenav link",
   args: { ...args, activeSNL: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const ActiveaSidenavItemAsLinkState = {
   render: Template.bind({}),
   name: "Active sidenav item as a link",
   args: { ...args, activeSNIAsLink: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const ActiveaSidenavItemAsMenu = {
   render: Template.bind({}),
   name: "Active sidenav item as a menu",
   args: { ...args, active: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const DisabledItem = {
   render: DisabledTemplate.bind({}),
   name: "Disabled sidenav item",
   args: { ...args, active: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const DisabledLink = {
   render: DisabledLinkTemplate.bind({}),
   name: "Disabled sidenav link",
   args: { ...args, active: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Sidenav/additional.stories.js
+++ b/stories/component-templates/Sidenav/additional.stories.js
@@ -93,56 +93,56 @@ export const SidenavItemAsLink = {
   render: SidenavItemAsLinkTemplate.bind({}),
   name: "SidenavItem as first level link",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const SidenavItemAsMenu = {
   render: SidenavItemAsMenuTemplate.bind({}),
   name: "SidenavItem as menu",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const EmbeddedMenu = {
   render: EmbeddedMenuTemplate.bind({}),
   name: "SidenavItem as an embedded menu",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const IconsOnFirstLevel = {
   render: IconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const ActiveLinkState = {
   render: Template.bind({}),
   name: "Active sidenav link",
   args: { ...args, activeSNL: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const ActiveaSidenavItemAsLinkState = {
   render: Template.bind({}),
   name: "Active sidenav item as a link",
   args: { ...args, activeSNIAsLink: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const ActiveaSidenavItemAsMenu = {
   render: Template.bind({}),
   name: "Active sidenav item as a menu",
   args: { ...args, active: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const DisabledItem = {
   render: DisabledTemplate.bind({}),
   name: "Disabled sidenav item",
   args: { ...args, active: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const DisabledLink = {
   render: DisabledLinkTemplate.bind({}),
   name: "Disabled sidenav link",
   args: { ...args, active: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Sidenav/additional.stories.js
+++ b/stories/component-templates/Sidenav/additional.stories.js
@@ -93,56 +93,56 @@ export const SidenavItemAsLink = {
   render: SidenavItemAsLinkTemplate.bind({}),
   name: "SidenavItem as first level link",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const SidenavItemAsMenu = {
   render: SidenavItemAsMenuTemplate.bind({}),
   name: "SidenavItem as menu",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const EmbeddedMenu = {
   render: EmbeddedMenuTemplate.bind({}),
   name: "SidenavItem as an embedded menu",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const IconsOnFirstLevel = {
   render: IconTemplate.bind({}),
   name: "Icons",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const ActiveLinkState = {
   render: Template.bind({}),
   name: "Active sidenav link",
   args: { ...args, activeSNL: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const ActiveaSidenavItemAsLinkState = {
   render: Template.bind({}),
   name: "Active sidenav item as a link",
   args: { ...args, activeSNIAsLink: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const ActiveaSidenavItemAsMenu = {
   render: Template.bind({}),
   name: "Active sidenav item as a menu",
   args: { ...args, active: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const DisabledItem = {
   render: DisabledTemplate.bind({}),
   name: "Disabled sidenav item",
   args: { ...args, active: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const DisabledLink = {
   render: DisabledLinkTemplate.bind({}),
   name: "Disabled sidenav link",
   args: { ...args, active: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Skeleton/additional.stories.js
+++ b/stories/component-templates/Skeleton/additional.stories.js
@@ -31,13 +31,11 @@ export const Sheen = {
   render: SheenTemplate.bind({}),
   name: "Sheen",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Rows = {
   render: RowsTemplate.bind({}),
   name: "Rows",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Skeleton/additional.stories.js
+++ b/stories/component-templates/Skeleton/additional.stories.js
@@ -31,11 +31,11 @@ export const Sheen = {
   render: SheenTemplate.bind({}),
   name: "Sheen",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Rows = {
   render: RowsTemplate.bind({}),
   name: "Rows",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Skeleton/additional.stories.js
+++ b/stories/component-templates/Skeleton/additional.stories.js
@@ -31,11 +31,11 @@ export const Sheen = {
   render: SheenTemplate.bind({}),
   name: "Sheen",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Rows = {
   render: RowsTemplate.bind({}),
   name: "Rows",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Spinner/additional.stories.js
+++ b/stories/component-templates/Spinner/additional.stories.js
@@ -27,7 +27,7 @@ export const Tone = {
   name: "Tone",
   args: {},
   parameters: {
-    backgrounds: { default: "custom-blue" , controls: { disable: true } }
+    backgrounds: { default: "custom-blue", controls: { disable: true } }
   }
 };
 export const ToneInverseFixedLight = {

--- a/stories/component-templates/Spinner/additional.stories.js
+++ b/stories/component-templates/Spinner/additional.stories.js
@@ -27,38 +27,33 @@ export const Tone = {
   name: "Tone",
   args: {},
   parameters: {
-    backgrounds: { default: "custom-blue" }
-  },
-  tags: ["!dev"]
+    backgrounds: { default: "custom-blue" , controls: { disable: true } }
+  }
 };
 export const ToneInverseFixedLight = {
   render: ToneInverseAndFixedLightTemplate.bind({}),
   name: "Tone - inverse and fixed light",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Label = {
   render: Template.bind({}),
   name: "Label",
   args: { label: "Label" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const LabelHorizontal = {
   render: Template.bind({}),
   name: "Label - Horizontal",
   args: { label: "Label", orientation: "horizontal" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Spinner/additional.stories.js
+++ b/stories/component-templates/Spinner/additional.stories.js
@@ -27,33 +27,33 @@ export const Tone = {
   name: "Tone",
   args: {},
   parameters: {
-    backgrounds: { default: "custom-blue", controls: { disable: true } }
+    backgrounds: { default: "custom-blue", selectedPanel: "storybook/docs/panel" }
   }
 };
 export const ToneInverseFixedLight = {
   render: ToneInverseAndFixedLightTemplate.bind({}),
   name: "Tone - inverse and fixed light",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Label = {
   render: Template.bind({}),
   name: "Label",
   args: { label: "Label" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const LabelHorizontal = {
   render: Template.bind({}),
   name: "Label - Horizontal",
   args: { label: "Label", orientation: "horizontal" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Spinner/additional.stories.js
+++ b/stories/component-templates/Spinner/additional.stories.js
@@ -27,33 +27,33 @@ export const Tone = {
   name: "Tone",
   args: {},
   parameters: {
-    backgrounds: { default: "custom-blue", selectedPanel: "storybook/docs/panel" }
+    backgrounds: { default: "custom-blue" }
   }
 };
 export const ToneInverseFixedLight = {
   render: ToneInverseAndFixedLightTemplate.bind({}),
   name: "Tone - inverse and fixed light",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Size = {
   render: SizeTemplate.bind({}),
   name: "Size",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Label = {
   render: Template.bind({}),
   name: "Label",
   args: { label: "Label" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const LabelHorizontal = {
   render: Template.bind({}),
   name: "Label - Horizontal",
   args: { label: "Label", orientation: "horizontal" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Stepper/additional.stories.js
+++ b/stories/component-templates/Stepper/additional.stories.js
@@ -69,28 +69,28 @@ export const Orientation = {
   render: Template.bind({}),
   name: "Orientation",
   args: { ...args, orientation: "vertical" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Clickable = {
   render: ClickableTemplate.bind({}),
   name: "Clickable",
   args,
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const StepComponent = {
   render: StepComponentTemplate.bind({}),
   name: "With sgds-step Children",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const StepComponentClickable = {
   render: StepComponentClickableTemplate.bind({}),
   name: "With sgds-step Children (Clickable)",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const StepStatesTemplate = () => html`
@@ -111,7 +111,7 @@ export const StepStates = {
   render: StepStatesTemplate.bind({}),
   name: "Step States",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const SlottedClickableTemplate = () => html`
@@ -138,7 +138,7 @@ export const SlottedClickable = {
   render: SlottedClickableTemplate.bind({}),
   name: "Slotted Clickable Items",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const CustomIconTemplate = () => html`
@@ -159,7 +159,7 @@ export const CustomIcon = {
   render: CustomIconTemplate.bind({}),
   name: "Custom Icon",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const MockStepperTemplate = () => html`<mock-stepper></mock-stepper>`;
@@ -168,5 +168,5 @@ export const StepperExample = {
   render: MockStepperTemplate.bind({}),
   name: "Stepper example",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Stepper/additional.stories.js
+++ b/stories/component-templates/Stepper/additional.stories.js
@@ -69,28 +69,28 @@ export const Orientation = {
   render: Template.bind({}),
   name: "Orientation",
   args: { ...args, orientation: "vertical" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Clickable = {
   render: ClickableTemplate.bind({}),
   name: "Clickable",
   args,
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const StepComponent = {
   render: StepComponentTemplate.bind({}),
   name: "With sgds-step Children",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const StepComponentClickable = {
   render: StepComponentClickableTemplate.bind({}),
   name: "With sgds-step Children (Clickable)",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const StepStatesTemplate = () => html`
@@ -111,7 +111,7 @@ export const StepStates = {
   render: StepStatesTemplate.bind({}),
   name: "Step States",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const SlottedClickableTemplate = () => html`
@@ -138,7 +138,7 @@ export const SlottedClickable = {
   render: SlottedClickableTemplate.bind({}),
   name: "Slotted Clickable Items",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const CustomIconTemplate = () => html`
@@ -159,7 +159,7 @@ export const CustomIcon = {
   render: CustomIconTemplate.bind({}),
   name: "Custom Icon",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const MockStepperTemplate = () => html`<mock-stepper></mock-stepper>`;
@@ -168,5 +168,5 @@ export const StepperExample = {
   render: MockStepperTemplate.bind({}),
   name: "Stepper example",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Stepper/additional.stories.js
+++ b/stories/component-templates/Stepper/additional.stories.js
@@ -69,32 +69,28 @@ export const Orientation = {
   render: Template.bind({}),
   name: "Orientation",
   args: { ...args, orientation: "vertical" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Clickable = {
   render: ClickableTemplate.bind({}),
   name: "Clickable",
   args,
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const StepComponent = {
   render: StepComponentTemplate.bind({}),
   name: "With sgds-step Children",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const StepComponentClickable = {
   render: StepComponentClickableTemplate.bind({}),
   name: "With sgds-step Children (Clickable)",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const StepStatesTemplate = () => html`
@@ -115,8 +111,7 @@ export const StepStates = {
   render: StepStatesTemplate.bind({}),
   name: "Step States",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const SlottedClickableTemplate = () => html`
@@ -143,8 +138,7 @@ export const SlottedClickable = {
   render: SlottedClickableTemplate.bind({}),
   name: "Slotted Clickable Items",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const CustomIconTemplate = () => html`
@@ -165,8 +159,7 @@ export const CustomIcon = {
   render: CustomIconTemplate.bind({}),
   name: "Custom Icon",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const MockStepperTemplate = () => html`<mock-stepper></mock-stepper>`;
@@ -175,6 +168,5 @@ export const StepperExample = {
   render: MockStepperTemplate.bind({}),
   name: "Stepper example",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Switch/additional.stories.js
+++ b/stories/component-templates/Switch/additional.stories.js
@@ -32,17 +32,17 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Labels",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const Icon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Switch/additional.stories.js
+++ b/stories/component-templates/Switch/additional.stories.js
@@ -32,20 +32,17 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Labels",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const Icon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Switch/additional.stories.js
+++ b/stories/component-templates/Switch/additional.stories.js
@@ -32,17 +32,17 @@ export const Sizes = {
   render: SizeTemplate.bind({}),
   name: "Sizes",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Label = {
   render: LabelTemplate.bind({}),
   name: "Labels",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const Icon = {
   render: IconTemplate.bind({}),
   name: "Icon",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/SystemBanner/additional.stories.js
+++ b/stories/component-templates/SystemBanner/additional.stories.js
@@ -37,16 +37,14 @@ export const Dismissible = {
     dismissible: true,
     show: true
   },
-  parameters,
-  tags: ["!dev"]
+  parameters
 };
 
 export const ShowMore = {
   render: ShowMoreHookTemplate.bind({}),
   name: "Show more",
   args: {},
-  parameters,
-  tags: ["!dev"]
+  parameters
 };
 
 export const NoClampAction = {
@@ -56,8 +54,7 @@ export const NoClampAction = {
     show: true,
     noClampAction: true
   },
-  parameters,
-  tags: ["!dev"]
+  parameters
 };
 export const Fluid = {
   render: Template.bind({}),
@@ -98,6 +95,5 @@ export const BadgeSlot = {
   render: BadgeSlotTemplate.bind({}),
   name: "Badge slot",
   args: {},
-  parameters,
-  tags: ["!dev"]
+  parameters
 };

--- a/stories/component-templates/Tab/additional.stories.js
+++ b/stories/component-templates/Tab/additional.stories.js
@@ -4,32 +4,32 @@ export const SolidVariant = {
   render: Template.bind({}),
   name: "Solid variant",
   args: { variant: "solid" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const UnderlinedDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for underlined tabs",
   args: { density: "compact" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const SolidDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for solid tabs",
   args: { density: "compact", variant: "solid" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const OrientationUnderlined = {
   render: Template.bind({}),
   name: "Vertical orientation for underlined tabs",
   args: { orientation: "vertical" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const OrientationSolid = {
   render: Template.bind({}),
   name: "Vertical orientation for solid tabs",
   args: { orientation: "vertical", variant: "solid" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const EventsTemplate = () => {
@@ -95,6 +95,6 @@ export const Events = {
   name: "Tab events",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
+    chromatic: { disableSnapshot: true }
   }
 };

--- a/stories/component-templates/Tab/additional.stories.js
+++ b/stories/component-templates/Tab/additional.stories.js
@@ -4,32 +4,32 @@ export const SolidVariant = {
   render: Template.bind({}),
   name: "Solid variant",
   args: { variant: "solid" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const UnderlinedDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for underlined tabs",
   args: { density: "compact" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const SolidDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for solid tabs",
   args: { density: "compact", variant: "solid" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const OrientationUnderlined = {
   render: Template.bind({}),
   name: "Vertical orientation for underlined tabs",
   args: { orientation: "vertical" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const OrientationSolid = {
   render: Template.bind({}),
   name: "Vertical orientation for solid tabs",
   args: { orientation: "vertical", variant: "solid" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const EventsTemplate = () => {
@@ -95,6 +95,6 @@ export const Events = {
   name: "Tab events",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true, controls: { disable: true } }
+    chromatic: { disableSnapshot: true, selectedPanel: "storybook/docs/panel" }
   }
 };

--- a/stories/component-templates/Tab/additional.stories.js
+++ b/stories/component-templates/Tab/additional.stories.js
@@ -4,37 +4,32 @@ export const SolidVariant = {
   render: Template.bind({}),
   name: "Solid variant",
   args: { variant: "solid" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const UnderlinedDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for underlined tabs",
   args: { density: "compact" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const SolidDensityCompact = {
   render: Template.bind({}),
   name: "Compact density for solid tabs",
   args: { density: "compact", variant: "solid" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const OrientationUnderlined = {
   render: Template.bind({}),
   name: "Vertical orientation for underlined tabs",
   args: { orientation: "vertical" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const OrientationSolid = {
   render: Template.bind({}),
   name: "Vertical orientation for solid tabs",
   args: { orientation: "vertical", variant: "solid" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const EventsTemplate = () => {
@@ -100,7 +95,6 @@ export const Events = {
   name: "Tab events",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true }
-  },
-  tags: ["!dev"]
+    chromatic: { disableSnapshot: true , controls: { disable: true } }
+  }
 };

--- a/stories/component-templates/Tab/additional.stories.js
+++ b/stories/component-templates/Tab/additional.stories.js
@@ -95,6 +95,6 @@ export const Events = {
   name: "Tab events",
   args: {},
   parameters: {
-    chromatic: { disableSnapshot: true , controls: { disable: true } }
+    chromatic: { disableSnapshot: true, controls: { disable: true } }
   }
 };

--- a/stories/component-templates/Table/additional.stories.js
+++ b/stories/component-templates/Table/additional.stories.js
@@ -144,33 +144,33 @@ export const AlwaysResponsive = {
   render: Template.bind({}),
   name: "Always responsive",
   args: { responsive: "always" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Responsive = {
   render: Template.bind({}),
   name: "Responsive",
   args: { responsive: "sm" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const StructuredElements = {
   render: StructuredElementsTemplate.bind({}),
   name: "Structured elements",
   args: { responsive: "sm" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const StructuredElementsVertical = {
   render: StructuredElementsTemplateVertical.bind({}),
   name: "Structured elements with vertical",
   args: { responsive: "sm" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const StructuredElementsBoth = {
   render: StructuredElementsTemplateBoth.bind({}),
   name: "Structured elements with both header",
   args: { responsive: "sm" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Table/additional.stories.js
+++ b/stories/component-templates/Table/additional.stories.js
@@ -144,38 +144,33 @@ export const AlwaysResponsive = {
   render: Template.bind({}),
   name: "Always responsive",
   args: { responsive: "always" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Responsive = {
   render: Template.bind({}),
   name: "Responsive",
   args: { responsive: "sm" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const StructuredElements = {
   render: StructuredElementsTemplate.bind({}),
   name: "Structured elements",
   args: { responsive: "sm" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const StructuredElementsVertical = {
   render: StructuredElementsTemplateVertical.bind({}),
   name: "Structured elements with vertical",
   args: { responsive: "sm" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const StructuredElementsBoth = {
   render: StructuredElementsTemplateBoth.bind({}),
   name: "Structured elements with both header",
   args: { responsive: "sm" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Table/additional.stories.js
+++ b/stories/component-templates/Table/additional.stories.js
@@ -144,33 +144,33 @@ export const AlwaysResponsive = {
   render: Template.bind({}),
   name: "Always responsive",
   args: { responsive: "always" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Responsive = {
   render: Template.bind({}),
   name: "Responsive",
   args: { responsive: "sm" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const StructuredElements = {
   render: StructuredElementsTemplate.bind({}),
   name: "Structured elements",
   args: { responsive: "sm" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const StructuredElementsVertical = {
   render: StructuredElementsTemplateVertical.bind({}),
   name: "Structured elements with vertical",
   args: { responsive: "sm" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const StructuredElementsBoth = {
   render: StructuredElementsTemplateBoth.bind({}),
   name: "Structured elements with both header",
   args: { responsive: "sm" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Textarea/additional.stories.js
+++ b/stories/component-templates/Textarea/additional.stories.js
@@ -36,25 +36,25 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const DefaultValue = {
   render: DefaultValueTemplate.bind({}),
   name: "Default Value",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Textarea/additional.stories.js
+++ b/stories/component-templates/Textarea/additional.stories.js
@@ -36,25 +36,25 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: { invalidFeedback: "Custom error message" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const DefaultValue = {
   render: DefaultValueTemplate.bind({}),
   name: "Default Value",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Textarea/additional.stories.js
+++ b/stories/component-templates/Textarea/additional.stories.js
@@ -36,29 +36,25 @@ export const Validation = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Validation",
   args: { invalidFeedback: "Custom error message" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const DefaultValue = {
   render: DefaultValueTemplate.bind({}),
   name: "Default Value",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/ThumbnailCard/additional.stories.js
+++ b/stories/component-templates/ThumbnailCard/additional.stories.js
@@ -4,16 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const OrientationTemplate = () =>
@@ -66,24 +64,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const NoPaddingTemplate = () =>
@@ -136,6 +131,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/ThumbnailCard/additional.stories.js
+++ b/stories/component-templates/ThumbnailCard/additional.stories.js
@@ -4,14 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const OrientationTemplate = () =>
@@ -64,21 +64,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const NoPaddingTemplate = () =>
@@ -131,5 +131,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/ThumbnailCard/additional.stories.js
+++ b/stories/component-templates/ThumbnailCard/additional.stories.js
@@ -4,14 +4,14 @@ export const Stretched = {
   render: Template.bind({}),
   name: "Stretched link",
   args: { ...args, stretchedLink: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Disabled = {
   render: Template.bind({}),
   name: "Disabled state",
   args: { ...args, disabled: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const OrientationTemplate = () =>
@@ -64,21 +64,21 @@ export const Orientation = {
   render: OrientationTemplate.bind({}),
   name: "Orientation",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const HideBorder = {
   render: Template.bind({}),
   name: "Hide border",
   args: { ...args, hideBorder: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Tinted = {
   render: Template.bind({}),
   name: "Tinted",
   args: { ...args, tinted: true },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const NoPaddingTemplate = () =>
@@ -131,5 +131,5 @@ export const NoPadding = {
   render: NoPaddingTemplate.bind({}),
   name: "No padding",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Toast/additional.stories.js
+++ b/stories/component-templates/Toast/additional.stories.js
@@ -24,36 +24,31 @@ export const InfoVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant info",
   args: { variant: "info" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const SuccessVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant success",
   args: { variant: "success" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const DangerVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant danger",
   args: { variant: "danger" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const WarningVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant warning",
   args: { variant: "warning" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const NeutralVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant neutral",
   args: { variant: "neutral" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const DismissibleTemplate = args =>
@@ -76,8 +71,7 @@ export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const PositionTemplate = args =>
@@ -108,36 +102,31 @@ export const TopCenter = {
   render: PositionTemplate.bind({}),
   name: "Top center",
   args: { ...args, position: "top-center" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const TopEnd = {
   render: PositionTemplate.bind({}),
   name: "Top end",
   args: { ...args, position: "top-end" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const BottomStart = {
   render: PositionTemplate.bind({}),
   name: "Bottom start",
   args: { ...args, position: "bottom-start" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const BottomCenter = {
   render: PositionTemplate.bind({}),
   name: "Bottom center",
   args: { ...args, position: "bottom-center" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 export const BottomEnd = {
   render: PositionTemplate.bind({}),
   name: "Bottom end",
   args: { ...args, position: "bottom-end" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 const StackingTemplate = () =>
@@ -162,6 +151,5 @@ export const Stacking = {
   render: StackingTemplate.bind({}),
   name: "Stacking the toasts",
   args: { position: "bottom-end" },
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Toast/additional.stories.js
+++ b/stories/component-templates/Toast/additional.stories.js
@@ -24,31 +24,31 @@ export const InfoVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant info",
   args: { variant: "info" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const SuccessVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant success",
   args: { variant: "success" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const DangerVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant danger",
   args: { variant: "danger" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const WarningVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant warning",
   args: { variant: "warning" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const NeutralVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant neutral",
   args: { variant: "neutral" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const DismissibleTemplate = args =>
@@ -71,7 +71,7 @@ export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const PositionTemplate = args =>
@@ -102,31 +102,31 @@ export const TopCenter = {
   render: PositionTemplate.bind({}),
   name: "Top center",
   args: { ...args, position: "top-center" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const TopEnd = {
   render: PositionTemplate.bind({}),
   name: "Top end",
   args: { ...args, position: "top-end" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const BottomStart = {
   render: PositionTemplate.bind({}),
   name: "Bottom start",
   args: { ...args, position: "bottom-start" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const BottomCenter = {
   render: PositionTemplate.bind({}),
   name: "Bottom center",
   args: { ...args, position: "bottom-center" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 export const BottomEnd = {
   render: PositionTemplate.bind({}),
   name: "Bottom end",
   args: { ...args, position: "bottom-end" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 const StackingTemplate = () =>
@@ -151,5 +151,5 @@ export const Stacking = {
   render: StackingTemplate.bind({}),
   name: "Stacking the toasts",
   args: { position: "bottom-end" },
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Toast/additional.stories.js
+++ b/stories/component-templates/Toast/additional.stories.js
@@ -24,31 +24,31 @@ export const InfoVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant info",
   args: { variant: "info" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const SuccessVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant success",
   args: { variant: "success" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const DangerVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant danger",
   args: { variant: "danger" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const WarningVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant warning",
   args: { variant: "warning" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const NeutralVariant = {
   render: VariantTemplate.bind({}),
   name: "Variant neutral",
   args: { variant: "neutral" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const DismissibleTemplate = args =>
@@ -71,7 +71,7 @@ export const Dismissible = {
   render: DismissibleTemplate.bind({}),
   name: "Dismissible",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const PositionTemplate = args =>
@@ -102,31 +102,31 @@ export const TopCenter = {
   render: PositionTemplate.bind({}),
   name: "Top center",
   args: { ...args, position: "top-center" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const TopEnd = {
   render: PositionTemplate.bind({}),
   name: "Top end",
   args: { ...args, position: "top-end" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const BottomStart = {
   render: PositionTemplate.bind({}),
   name: "Bottom start",
   args: { ...args, position: "bottom-start" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const BottomCenter = {
   render: PositionTemplate.bind({}),
   name: "Bottom center",
   args: { ...args, position: "bottom-center" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 export const BottomEnd = {
   render: PositionTemplate.bind({}),
   name: "Bottom end",
   args: { ...args, position: "bottom-end" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 const StackingTemplate = () =>
@@ -151,5 +151,5 @@ export const Stacking = {
   render: StackingTemplate.bind({}),
   name: "Stacking the toasts",
   args: { position: "bottom-end" },
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };

--- a/stories/component-templates/Tooltip/additional.stories.js
+++ b/stories/component-templates/Tooltip/additional.stories.js
@@ -39,12 +39,12 @@ export const Placement = {
   render: PlacementTemplate.bind({}),
   name: "Placement",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };
 
 export const Trigger = {
   render: TriggerTemplate.bind({}),
   name: "Trigger",
   args: {},
-  parameters: { controls: { disable: true } }
+  parameters: { selectedPanel: "storybook/docs/panel" }
 };

--- a/stories/component-templates/Tooltip/additional.stories.js
+++ b/stories/component-templates/Tooltip/additional.stories.js
@@ -39,14 +39,12 @@ export const Placement = {
   render: PlacementTemplate.bind({}),
   name: "Placement",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };
 
 export const Trigger = {
   render: TriggerTemplate.bind({}),
   name: "Trigger",
   args: {},
-  parameters: {},
-  tags: ["!dev"]
+  parameters: { controls: { disable: true } }
 };

--- a/stories/component-templates/Tooltip/additional.stories.js
+++ b/stories/component-templates/Tooltip/additional.stories.js
@@ -39,12 +39,12 @@ export const Placement = {
   render: PlacementTemplate.bind({}),
   name: "Placement",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };
 
 export const Trigger = {
   render: TriggerTemplate.bind({}),
   name: "Trigger",
   args: {},
-  parameters: { selectedPanel: "storybook/docs/panel" }
+  parameters: {}
 };


### PR DESCRIPTION
## :open_book: Description

Previously, I disabled the component stories from appearing in the side bar because I needed to figure out how to disable the Controls panel and before AI rummaging the storybook 8 docs was hard. 

So i hide the stories , other than Basic stories. 

Restoring them back now


Basic stories --> Controls add-on active by default
Non-basic stories --> Code add-on active by default 



Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
