### PR TITLE
feat(Combobox): added new scroll-end event when menu reaches the end [run-chromatic]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.22.0
+npm install @govtechsg/sgds-web-component@3.22.1
 
 ```
 
@@ -53,14 +53,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0" async crossorigin="anonymous" integrity="sha384-WbHc3VloPtEmncz7R/X4mNQFJjfGvRfOT3ZzHowp1XqQOWQcMoOBOHShxGvh+chP"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1" async crossorigin="anonymous" integrity="sha384-j5VrNZcqKNUHLnCE92BAUxjweChuIOcFud+EqjXjXtn9B2g9xiYyqfnrlDIJ/lXk"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
 
 ```
 

--- a/skills/sgds-components/reference/combo-box.md
+++ b/skills/sgds-components/reference/combo-box.md
@@ -44,6 +44,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - **Empty async menu**: use `emptyMenuAsync` to show an open (empty) menu immediately when in async mode before the user types.
 - **Programmatic control**: `menuIsOpen` lets you open or close the dropdown from JavaScript without user interaction.
 - **Positioning**: `floatingOpts` passes options directly to Floating UI for advanced dropdown placement — use only when default positioning is insufficient.
+- **Infinite scroll / lazy load**: set `scrollBottomOffset` (number, pixels) to fire `sgds-scroll-end` before the user reaches the very bottom of the menu. Listen to `sgds-scroll-end` to load and append more `<sgds-combo-box-option>` elements. A positive offset (e.g. `20`) gives time to fetch data before the user hits the end.
 
 ## Edge Cases
 
@@ -77,6 +78,8 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 **Show a clear button?** → Add `clearable`
 
 **Full-width selected badges?** → Add `badgeFullWidth`
+
+**Infinite scroll / lazy-load more options?** → Set `scrollBottomOffset` and listen to `sgds-scroll-end`
 
 ```html
 <!-- Basic single-select combo box -->
@@ -154,6 +157,7 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `emptyMenuAsync` | boolean | `false` | Shows an empty menu on open when in async mode |
 | `menuIsOpen` | boolean | `false` | Programmatically controls the dropdown menu open state |
 | `autocomplete` | string | `"off"` | Controls browser autocomplete behavior — typically set to `"off"` to prevent browser autofill interference with the dropdown list |
+| `scrollBottomOffset` | number | `0` | Pixels before the bottom of the menu at which `sgds-scroll-end` fires — must be non-negative; negative values are treated as `0` |
 | `filterFunction` | `(inputValue: string, item) => boolean` | contains filter | Custom filter function (ignored when `async` is true) |
 | `floatingOpts` | object | — | Options for Floating UI positioning (advanced) |
 
@@ -180,6 +184,7 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `sgds-input` | `{ displayValue: string }` | User types into the input field |
 | `sgds-focus` | — | Input gains focus |
 | `sgds-blur` | — | Input loses focus |
+| `sgds-scroll-end` | — | Menu scroll position reaches the bottom (within `scrollBottomOffset` pixels) — use to trigger lazy loading |
 
 ---
 
@@ -189,4 +194,5 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 3. Use `clearable` to let users reset the selection without form submission.
 4. `filterFunction` must be set as a JS property (`.filterFunction = (input, item) => ...`), not as an HTML attribute.
 5. `<sgds-combo-box>` does **not** have `hasFeedback` or `invalidFeedback` attributes — unlike all other SGDS form components. Validation relies entirely on the browser-native `required` constraint. Do not add these attributes.
-6. **Boolean attribute handling**: For single-select, omit the `multiSelect` attribute entirely. For multi-select, include `multiSelect` with no value (HTML5 boolean) or `multiSelect="true"`. Do **NOT** use `multiSelect="false"` for single-select — in HTML, any attribute presence (even with value "false") is truthy. Omit the attribute for false.
+6. **Infinite scroll**: set `scrollBottomOffset` (number of pixels) and listen to `sgds-scroll-end` to append more `<sgds-combo-box-option>` elements before the user reaches the end of the list. The event fires once per scroll-to-bottom gesture and resets when the user scrolls back up.
+7. **Boolean attribute handling**: For single-select, omit the `multiSelect` attribute entirely. For multi-select, include `multiSelect` with no value (HTML5 boolean) or `multiSelect="true"`. Do **NOT** use `multiSelect="false"` for single-select — in HTML, any attribute presence (even with value "false") is truthy. Omit the attribute for false.

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -68,6 +68,9 @@ export class SgdsComboBox extends SelectElement {
   /** When filtering remotely and there are no results, set this to true to enable no options feedback on the menu. Applicable for async combo box only. */
   @property({ type: Boolean, reflect: true }) emptyMenuAsync = false;
 
+  /** Number of pixels from the bottom of the menu at which the sgds-scroll-end event fires. */
+  @property({ type: Number, reflect: true }) scrollBottomOffset = 0;
+
   /** The function used to filter the menu list, given the user's input value. */
   @property()
   filterFunction: (inputValue: string, item: SgdsComboBoxOptionData) => boolean = (inputValue, item) => {
@@ -84,6 +87,9 @@ export class SgdsComboBox extends SelectElement {
 
   // Used to show and hide the clear button
   @state() protected isFocused = false;
+
+  // Used to determine if the scroll reached the end with offset
+  @state() protected isScrollEnd = false;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -421,6 +427,25 @@ export class SgdsComboBox extends SelectElement {
     }
   }
 
+  // For scrolling to bottom of the menu
+  private async _handleScroll(e: MouseEvent) {
+    // To handle scrolling
+    const ele = e.target as HTMLElement;
+    if (ele) {
+      const endOfScroll = ele.scrollHeight - ele.clientHeight;
+      const offset = Math.max(0, this.scrollBottomOffset);
+
+      if (ele.scrollTop >= endOfScroll - offset) {
+        if (!this.isScrollEnd) {
+          this.emit("sgds-scroll-end");
+        }
+        this.isScrollEnd = true;
+      } else {
+        this.isScrollEnd = false;
+      }
+    }
+  }
+
   /** Template for the suffix icon */
   protected suffixIconTemplate: TemplateResult = html`<sgds-icon
     name=${this.menuIsOpen ? "chevron-up" : "chevron-down"}
@@ -552,6 +577,7 @@ export class SgdsComboBox extends SelectElement {
           role="menu"
           aria-label=${this.label || "Options"}
           ${ref(this.menuRef)}
+          @scroll=${this._handleScroll}
         >
           <slot
             id="default"

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -38,6 +38,7 @@ export type { ISgdsComboBoxInputEventDetail };
  * @event sgds-blur -  Emitted when user input is blurred.
  * @event sgds-invalid - Emitted when the combo box's invalid state is set to true.
  * @event sgds-valid - Emitted when the combo box's invalid state is set to false.
+ * @event sgds-scroll-end - Emitted once when the menu is scrolled to within `scrollBottomOffset` pixels of the bottom. Resets when the user scrolls back up.
  */
 export class SgdsComboBox extends SelectElement {
   static styles = [...SelectElement.styles, formTextControlStyle, comboBoxStyle];
@@ -427,9 +428,13 @@ export class SgdsComboBox extends SelectElement {
     }
   }
 
-  // For scrolling to bottom of the menu
+  /**
+   * Handles scroll events on the menu. Emits `sgds-scroll-end` once when the
+   * scroll position reaches within `scrollBottomOffset` pixels of the bottom.
+   * The event is suppressed until the user scrolls back up, preventing repeated
+   * emissions while the menu stays at the bottom.
+   */
   private async _handleScroll(e: MouseEvent) {
-    // To handle scrolling
     const ele = e.target as HTMLElement;
     if (ele) {
       const endOfScroll = ele.scrollHeight - ele.clientHeight;

--- a/stories/component-templates/ComboBox/additional.mdx
+++ b/stories/component-templates/ComboBox/additional.mdx
@@ -171,3 +171,13 @@ Set `noValidate` to disable built-in constraint validation. Use `setInvalid(bool
 <Canvas of={ComboBoxStories.NoValidate}>
   <Story of={ComboBoxStories.NoValidate} />
 </Canvas>
+
+## Scroll to bottom detection
+
+Use `scrollBottomOffset` (number, default `0`) to configure how many pixels before the bottom of the menu the `sgds-scroll-end` event fires. This is useful for implementing infinite scroll or lazy-loading more options as the user scrolls toward the end of the list.
+
+Set `scrollBottomOffset` to a positive number (e.g. `50`) to fire the event slightly before the very bottom, giving time to fetch and append new options before the user reaches the end. Negative values are treated as `0`.
+
+<Canvas of={ComboBoxStories.ScrollEnd}>
+  <Story of={ComboBoxStories.ScrollEnd} />
+</Canvas>

--- a/stories/component-templates/ComboBox/additional.stories.js
+++ b/stories/component-templates/ComboBox/additional.stories.js
@@ -520,3 +520,58 @@ export const Autocomplete = {
   args: {},
   parameters: {}
 };
+
+const ScrollEndTemplate = () => {
+  return html`
+    <div style="display:flex;flex-direction:column;gap:2rem;margin-bottom:3rem">
+      <div>
+        <p><strong>Scroll to bottom (sgds-scroll-end)</strong>: <span id="scroll-end-output"></span></p>
+
+        <sgds-combo-box
+          id="scroll-end-combobox-example"
+          label="Countries"
+          placeholder="Scroll to the bottom"
+          scrollBottomOffset="50"
+        >
+          <sgds-combo-box-option value="afghanistan">Afghanistan</sgds-combo-box-option>
+          <sgds-combo-box-option value="albania">Albania</sgds-combo-box-option>
+          <sgds-combo-box-option value="algeria">Algeria</sgds-combo-box-option>
+          <sgds-combo-box-option value="andorra">Andorra</sgds-combo-box-option>
+          <sgds-combo-box-option value="angola">Angola</sgds-combo-box-option>
+          <sgds-combo-box-option value="argentina">Argentina</sgds-combo-box-option>
+          <sgds-combo-box-option value="armenia">Armenia</sgds-combo-box-option>
+          <sgds-combo-box-option value="australia">Australia</sgds-combo-box-option>
+          <sgds-combo-box-option value="austria">Austria</sgds-combo-box-option>
+          <sgds-combo-box-option value="azerbaijan">Azerbaijan</sgds-combo-box-option>
+          <sgds-combo-box-option value="bahamas">Bahamas</sgds-combo-box-option>
+          <sgds-combo-box-option value="bahrain">Bahrain</sgds-combo-box-option>
+          <sgds-combo-box-option value="bangladesh">Bangladesh</sgds-combo-box-option>
+          <sgds-combo-box-option value="belgium">Belgium</sgds-combo-box-option>
+          <sgds-combo-box-option value="brazil">Brazil</sgds-combo-box-option>
+          <sgds-combo-box-option value="canada">Canada</sgds-combo-box-option>
+          <sgds-combo-box-option value="chile">Chile</sgds-combo-box-option>
+          <sgds-combo-box-option value="china">China</sgds-combo-box-option>
+          <sgds-combo-box-option value="colombia">Colombia</sgds-combo-box-option>
+          <sgds-combo-box-option value="denmark">Denmark</sgds-combo-box-option>
+        </sgds-combo-box>
+
+        <script>
+          const scrollEndCombo = document.querySelector("#scroll-end-combobox-example");
+          const scrollEndOutput = document.querySelector("#scroll-end-output");
+          let scrollEndCount = 0;
+          scrollEndCombo.addEventListener("sgds-scroll-end", () => {
+            scrollEndCount++;
+            scrollEndOutput.textContent = "sgds-scroll-end fired — bottom of menu reached (x" + scrollEndCount + ")";
+          });
+        </script>
+      </div>
+    </div>
+  `;
+};
+
+export const ScrollEnd = {
+  render: ScrollEndTemplate.bind({}),
+  name: "Scroll to bottom (sgds-scroll-end)",
+  args: {},
+  parameters: {}
+};

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -1974,3 +1974,134 @@ describe("setInvalid emits sgds-invalid and sgds-valid events", () => {
     expect(validHandler).to.have.been.calledOnce;
   });
 });
+
+describe("sgds-scroll-end event", () => {
+  const manyOptionsFixture = () => html`
+    <sgds-combo-box menuIsOpen style="--sgds-combo-box-menu-max-height:100px">
+      <sgds-combo-box-option value="a">Afghanistan</sgds-combo-box-option>
+      <sgds-combo-box-option value="b">Albania</sgds-combo-box-option>
+      <sgds-combo-box-option value="c">Algeria</sgds-combo-box-option>
+      <sgds-combo-box-option value="d">Andorra</sgds-combo-box-option>
+      <sgds-combo-box-option value="e">Angola</sgds-combo-box-option>
+      <sgds-combo-box-option value="f">Argentina</sgds-combo-box-option>
+      <sgds-combo-box-option value="g">Armenia</sgds-combo-box-option>
+      <sgds-combo-box-option value="h">Australia</sgds-combo-box-option>
+      <sgds-combo-box-option value="i">Austria</sgds-combo-box-option>
+      <sgds-combo-box-option value="j">Azerbaijan</sgds-combo-box-option>
+    </sgds-combo-box>
+  `;
+
+  it("emits sgds-scroll-end when scrolled to the bottom", async () => {
+    const el = await fixture<SgdsComboBox>(manyOptionsFixture());
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']") as HTMLElement;
+    const handler = sinon.spy();
+    el.addEventListener("sgds-scroll-end", handler);
+
+    menu.scrollTop = menu.scrollHeight - menu.clientHeight;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("does not emit sgds-scroll-end again while still at the bottom", async () => {
+    const el = await fixture<SgdsComboBox>(manyOptionsFixture());
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']") as HTMLElement;
+    const handler = sinon.spy();
+    el.addEventListener("sgds-scroll-end", handler);
+
+    menu.scrollTop = menu.scrollHeight - menu.clientHeight;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("emits sgds-scroll-end again after scrolling back up then back to the bottom", async () => {
+    const el = await fixture<SgdsComboBox>(manyOptionsFixture());
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']") as HTMLElement;
+    const handler = sinon.spy();
+    el.addEventListener("sgds-scroll-end", handler);
+
+    menu.scrollTop = menu.scrollHeight - menu.clientHeight;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    menu.scrollTop = 0;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    menu.scrollTop = menu.scrollHeight - menu.clientHeight;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    expect(handler).to.have.been.calledTwice;
+  });
+
+  it("fires sgds-scroll-end early when scrollBottomOffset is set", async () => {
+    const el = await fixture<SgdsComboBox>(html`
+      <sgds-combo-box menuIsOpen scrollBottomOffset="50" style="--sgds-combo-box-menu-max-height:100px">
+        <sgds-combo-box-option value="a">Afghanistan</sgds-combo-box-option>
+        <sgds-combo-box-option value="b">Albania</sgds-combo-box-option>
+        <sgds-combo-box-option value="c">Algeria</sgds-combo-box-option>
+        <sgds-combo-box-option value="d">Andorra</sgds-combo-box-option>
+        <sgds-combo-box-option value="e">Angola</sgds-combo-box-option>
+        <sgds-combo-box-option value="f">Argentina</sgds-combo-box-option>
+        <sgds-combo-box-option value="g">Armenia</sgds-combo-box-option>
+        <sgds-combo-box-option value="h">Australia</sgds-combo-box-option>
+        <sgds-combo-box-option value="i">Austria</sgds-combo-box-option>
+        <sgds-combo-box-option value="j">Azerbaijan</sgds-combo-box-option>
+      </sgds-combo-box>
+    `);
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']") as HTMLElement;
+    const handler = sinon.spy();
+    el.addEventListener("sgds-scroll-end", handler);
+
+    const endOfScroll = menu.scrollHeight - menu.clientHeight;
+    menu.scrollTop = endOfScroll - 50;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("treats negative scrollBottomOffset as 0", async () => {
+    const el = await fixture<SgdsComboBox>(html`
+      <sgds-combo-box menuIsOpen scrollBottomOffset="-100">
+        <sgds-combo-box-option value="a">Afghanistan</sgds-combo-box-option>
+        <sgds-combo-box-option value="b">Albania</sgds-combo-box-option>
+        <sgds-combo-box-option value="c">Algeria</sgds-combo-box-option>
+        <sgds-combo-box-option value="d">Andorra</sgds-combo-box-option>
+        <sgds-combo-box-option value="e">Angola</sgds-combo-box-option>
+        <sgds-combo-box-option value="f">Argentina</sgds-combo-box-option>
+        <sgds-combo-box-option value="g">Armenia</sgds-combo-box-option>
+        <sgds-combo-box-option value="h">Australia</sgds-combo-box-option>
+        <sgds-combo-box-option value="i">Austria</sgds-combo-box-option>
+        <sgds-combo-box-option value="j">Azerbaijan</sgds-combo-box-option>
+      </sgds-combo-box>
+    `);
+    await el.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']") as HTMLElement;
+    const handler = sinon.spy();
+    el.addEventListener("sgds-scroll-end", handler);
+
+    // Scroll to the exact bottom — should fire because offset is clamped to 0
+    const endOfScroll = menu.scrollHeight - menu.clientHeight;
+    menu.scrollTop = endOfScroll;
+    menu.dispatchEvent(new Event("scroll"));
+    await el.updateComplete;
+
+    expect(handler).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

1. For some use cases, the list is too long to be loaded on one single api, so solutions such as lazy load will be required. 
    - added a new event to emit when the scroll reaches the end of the dropdown menu 
    - added a new prop to accept any offset if user want to call api before hitting the very end 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
