### PR TITLE
feat(MainnavDropdown): ariaLabel prop for accessibility

### DIFF
--- a/cypress/apps/angular-app/src/components/mainnav/mainnav.component.html
+++ b/cypress/apps/angular-app/src/components/mainnav/mainnav.component.html
@@ -1,7 +1,7 @@
 <sgds-mainnav>
     <img width="130" src="https://www.designsystem.tech.gov.sg/assets/img/logo-sgds.svg" slot="brand">
     <sgds-mainnav-item><a href="#">ArgsTable Controlled</a></sgds-mainnav-item>
-    <sgds-mainnav-dropdown close="default">
+    <sgds-mainnav-dropdown close="default" ariaLabel="Dropdown menu">
         <span slot="toggler">Dropdown</span>
         <sgds-dropdown-item href="https://google.com">Item 1</sgds-dropdown-item>
         <sgds-dropdown-item href="#">Item 2</sgds-dropdown-item>

--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
 
         if (rootFiles.length > 0) {
           const dropdown = document.createElement("sgds-mainnav-dropdown");
+          dropdown.setAttribute("ariaLabel", "Components menu");
           const toggler = document.createElement("span");
           toggler.setAttribute("slot", "toggler");
           toggler.textContent = "Components";
@@ -145,9 +146,11 @@
           if (!folderFiles || folderFiles.length === 0) continue;
 
           const dropdown = document.createElement("sgds-mainnav-dropdown");
+          const folderLabel = folder.charAt(0).toUpperCase() + folder.slice(1);
+          dropdown.setAttribute("ariaLabel", `${folderLabel} menu`);
           const toggler = document.createElement("span");
           toggler.setAttribute("slot", "toggler");
-          toggler.textContent = folder.charAt(0).toUpperCase() + folder.slice(1);
+          toggler.textContent = folderLabel;
           dropdown.appendChild(toggler);
 
           for (const file of folderFiles) {

--- a/playground/Mainnav.html
+++ b/playground/Mainnav.html
@@ -11,7 +11,7 @@
   <sgds-mainnav-item disabled><a href="#">About</a></sgds-mainnav-item>
   <sgds-mainnav-item slot="end" class="test test2"><a href="#">Info</a></sgds-mainnav-item>
   <sgds-mainnav-item slot="end" id="night-theme"><a href="#"><sgds-icon name="moon"></sgds-icon></a></sgds-mainnav-item>
-  <sgds-mainnav-dropdown>
+  <sgds-mainnav-dropdown ariaLabel="Dropdown menu">
     <span slot="toggler">Dropdown</span>
     <sgds-dropdown-item disabled><a href="https://www.google.com/">Item 1</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="https://www.google.com/">Item 2</a></sgds-dropdown-item>
@@ -29,7 +29,7 @@
     <sgds-dropdown-item><a href="#">Item 3</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="#">Item 3</a></sgds-dropdown-item>
   </sgds-mainnav-dropdown>
-  <sgds-mainnav-dropdown slot="end">
+  <sgds-mainnav-dropdown slot="end" ariaLabel="Dropdown menu">
     <span slot="toggler">Dropdown</span>
     <sgds-dropdown-item><a href="#">Item 3</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="#">Item 3</a></sgds-dropdown-item>

--- a/playground/header.html
+++ b/playground/header.html
@@ -25,7 +25,7 @@
   </sgds-mainnav-item>
   <sgds-mainnav-item><a href="#">About</a></sgds-mainnav-item>
   <sgds-mainnav-item><a href="#">Services</a></sgds-mainnav-item>
-  <sgds-mainnav-dropdown>
+  <sgds-mainnav-dropdown ariaLabel="More menu">
     <span slot="toggler">More</span>
     <sgds-dropdown-item><a href="#">Item 1</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="#">Item 2</a></sgds-dropdown-item>
@@ -62,7 +62,7 @@
   </sgds-mainnav-item>
   <sgds-mainnav-item><a href="#">About</a></sgds-mainnav-item>
   <sgds-mainnav-item><a href="#">Services</a></sgds-mainnav-item>
-  <sgds-mainnav-dropdown>
+  <sgds-mainnav-dropdown ariaLabel="More menu">
     <span slot="toggler">More</span>
     <sgds-dropdown-item><a href="#">Item 1</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="#">Item 2</a></sgds-dropdown-item>

--- a/playground/layouts/layout-aside-both.html
+++ b/playground/layouts/layout-aside-both.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-aside-left.html
+++ b/playground/layouts/layout-aside-left.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-aside-right.html
+++ b/playground/layouts/layout-aside-right.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-breadcrumb.html
+++ b/playground/layouts/layout-breadcrumb.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-default.html
+++ b/playground/layouts/layout-default.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-sidebar-aside-left.html
+++ b/playground/layouts/layout-sidebar-aside-left.html
@@ -34,14 +34,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-sidebar-aside-right.html
+++ b/playground/layouts/layout-sidebar-aside-right.html
@@ -34,14 +34,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-sidebar-split.html
+++ b/playground/layouts/layout-sidebar-split.html
@@ -34,14 +34,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-sidebar.html
+++ b/playground/layouts/layout-sidebar.html
@@ -34,14 +34,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/layouts/layout-split.html
+++ b/playground/layouts/layout-split.html
@@ -59,14 +59,14 @@
     <sgds-mainnav fluid>
       <strong slot="brand">My App</strong>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Projects</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
 
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/playground/z-index.html
+++ b/playground/z-index.html
@@ -15,7 +15,7 @@
       <img width="130" src="https://www.designsystem.tech.gov.sg/assets/img/logo-sgds.svg" slot="brand" />
       <sgds-mainnav-item active><a href="#">Home</a></sgds-mainnav-item>
       <sgds-mainnav-item><a href="#">About</a></sgds-mainnav-item>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Services menu">
         <span slot="toggler">Services</span>
         <sgds-dropdown-item><a href="#">Option 1</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Option 2</a></sgds-dropdown-item>

--- a/skills/sgds-components/reference/mainnav.md
+++ b/skills/sgds-components/reference/mainnav.md
@@ -93,7 +93,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
   </sgds-mainnav-item>
 
   <!-- Dropdown nav item -->
-  <sgds-mainnav-dropdown>
+  <sgds-mainnav-dropdown ariaLabel="Resources menu">
     <span slot="toggler">Resources</span>
     <sgds-dropdown-item><a href="/docs">Documentation</a></sgds-dropdown-item>
     <sgds-dropdown-item><a href="/faq">FAQ</a></sgds-dropdown-item>
@@ -126,9 +126,13 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 ### `<sgds-mainnav-dropdown>`
 
-Inherits `<sgds-dropdown>` properties — see **[components-dropdown](dropdown.md)** for full API.
+| Attribute | Type | Default | Purpose |
+|---|---|---|---|
+| `active` | boolean | `false` | Applies active styles on the dropdown button |
+| `disabled` | boolean | `false` | Disables the dropdown toggle |
+| `ariaLabel` | string | — | Accessible label forwarded to the toggle button's `aria-label` attribute. **Required** for accessibility — screen readers cannot read slotted toggler text. |
 
-Key properties: `active`, `menuIsOpen`, `close`, `drop`.
+Also inherits `<sgds-dropdown>` properties — see **[components-dropdown](dropdown.md)** for full API (`menuIsOpen`, `close`, `drop`).
 
 ## Slots
 
@@ -172,3 +176,4 @@ Key properties: `active`, `menuIsOpen`, `close`, `drop`.
 4. `non-collapsible` slot stays visible on all screen sizes — use for icons that should never collapse.
 5. The collapsed menu events fire only on mobile breakpoints when using the hamburger toggle.
 6. Use `<sgds-masthead>` above `<sgds-mainnav>` as required for Singapore Government sites.
+7. **Always set `ariaLabel` on `<sgds-mainnav-dropdown>`** — the slotted toggler text is not accessible to screen readers through the shadow DOM boundary. Use a descriptive label like `"Resources menu"`.

--- a/src/components/Mainnav/sgds-mainnav-dropdown.ts
+++ b/src/components/Mainnav/sgds-mainnav-dropdown.ts
@@ -3,6 +3,7 @@ import { consume } from "@lit/context";
 import { property, query, queryAssignedElements, state } from "lit/decorators.js";
 import { SgdsMainnav } from "./sgds-mainnav";
 import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { offset } from "@floating-ui/dom";
 import genId from "../../utils/generateId";
 import dropdownStyle from "../Dropdown/dropdown.css";
@@ -61,6 +62,12 @@ export class SgdsMainnavDropdown extends SgdsElement {
   /** When true,  applies active styles on the dropdown button */
   @property({ type: Boolean, reflect: true })
   disabled = false;
+
+  /**
+   * Accessible label for the dropdown's toggle button. Forwarded to the button's aria-label attribute.
+   */
+  @property({ type: String })
+  ariaLabel: string;
 
   /** @internal */
   @queryAssignedElements({ slot: "toggler" }) private togglerNodes!: HTMLElement[];
@@ -271,6 +278,7 @@ export class SgdsMainnavDropdown extends SgdsElement {
           disabled: this.disabled
         })}"
         aria-disabled=${this.disabled ? "true" : "false"}
+        aria-label=${ifDefined(this.ariaLabel)}
         tabindex=${this.disabled ? "-1" : "0"}
         role="button"
         @click=${this._openMenu}
@@ -301,6 +309,7 @@ export class SgdsMainnavDropdown extends SgdsElement {
           disabled: this.disabled
         })}"
         aria-disabled=${this.disabled ? "true" : "false"}
+        aria-label=${ifDefined(this.ariaLabel)}
         id=${this.togglerId}
         tabindex=${this.disabled ? "-1" : "0"}
         role="button"

--- a/stories/component-templates/Mainnav/basic.js
+++ b/stories/component-templates/Mainnav/basic.js
@@ -13,7 +13,12 @@ export const Template = ({ expand, brandHref, active, href, disabled, menuIsOpen
       <sgds-mainnav-item>
         <a href="#">About</a>
       </sgds-mainnav-item>
-      <sgds-mainnav-dropdown ?active=${active} ?menuIsOpen=${menuIsOpen} close=${ifDefined(close)} ariaLabel="Dropdown menu">
+      <sgds-mainnav-dropdown
+        ?active=${active}
+        ?menuIsOpen=${menuIsOpen}
+        close=${ifDefined(close)}
+        ariaLabel="Dropdown menu"
+      >
         <span slot="toggler">Dropdown</span>
         <sgds-dropdown-item><a href="https://google.com">Item 1</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Item 2</a></sgds-dropdown-item>

--- a/stories/component-templates/Mainnav/basic.js
+++ b/stories/component-templates/Mainnav/basic.js
@@ -13,7 +13,7 @@ export const Template = ({ expand, brandHref, active, href, disabled, menuIsOpen
       <sgds-mainnav-item>
         <a href="#">About</a>
       </sgds-mainnav-item>
-      <sgds-mainnav-dropdown ?active=${active} ?menuIsOpen=${menuIsOpen} close=${ifDefined(close)}>
+      <sgds-mainnav-dropdown ?active=${active} ?menuIsOpen=${menuIsOpen} close=${ifDefined(close)} ariaLabel="Dropdown menu">
         <span slot="toggler">Dropdown</span>
         <sgds-dropdown-item><a href="https://google.com">Item 1</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Item 2</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/AsideBoth.stories.js
+++ b/stories/layouts/FullWidth/AsideBoth.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/AsideLeft.stories.js
+++ b/stories/layouts/FullWidth/AsideLeft.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/AsideRight.stories.js
+++ b/stories/layouts/FullWidth/AsideRight.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/Breadcrumb.stories.js
+++ b/stories/layouts/FullWidth/Breadcrumb.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/Default.stories.js
+++ b/stories/layouts/FullWidth/Default.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/FullWidth/Split.stories.js
+++ b/stories/layouts/FullWidth/Split.stories.js
@@ -26,12 +26,12 @@ const Template = () => html`
     <sgds-masthead></sgds-masthead>
     <sgds-mainnav>
       <strong slot="brand">My App</strong>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Workspace menu">
         <span slot="toggler">Workspace</span>
         <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
       </sgds-mainnav-dropdown>
-      <sgds-mainnav-dropdown>
+      <sgds-mainnav-dropdown ariaLabel="Manage menu">
         <span slot="toggler">Manage</span>
         <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
         <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/WithSidebar/Sidebar.stories.js
+++ b/stories/layouts/WithSidebar/Sidebar.stories.js
@@ -61,12 +61,12 @@ const Template = () => html`
       <sgds-masthead fluid></sgds-masthead>
       <sgds-mainnav fluid>
         <strong slot="brand">My App</strong>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Workspace menu">
           <span slot="toggler">Workspace</span>
           <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         </sgds-mainnav-dropdown>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Manage menu">
           <span slot="toggler">Manage</span>
           <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/WithSidebar/SidebarAsideLeft.stories.js
+++ b/stories/layouts/WithSidebar/SidebarAsideLeft.stories.js
@@ -61,12 +61,12 @@ const Template = () => html`
       <sgds-masthead fluid></sgds-masthead>
       <sgds-mainnav fluid>
         <strong slot="brand">My App</strong>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Workspace menu">
           <span slot="toggler">Workspace</span>
           <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         </sgds-mainnav-dropdown>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Manage menu">
           <span slot="toggler">Manage</span>
           <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/WithSidebar/SidebarAsideRight.stories.js
+++ b/stories/layouts/WithSidebar/SidebarAsideRight.stories.js
@@ -61,12 +61,12 @@ const Template = () => html`
       <sgds-masthead fluid></sgds-masthead>
       <sgds-mainnav fluid>
         <strong slot="brand">My App</strong>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Workspace menu">
           <span slot="toggler">Workspace</span>
           <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         </sgds-mainnav-dropdown>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Manage menu">
           <span slot="toggler">Manage</span>
           <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/WithSidebar/SidebarOverlay.stories.js
+++ b/stories/layouts/WithSidebar/SidebarOverlay.stories.js
@@ -53,12 +53,12 @@ const Template = () => html`
       <sgds-masthead fluid></sgds-masthead>
       <sgds-mainnav fluid>
         <strong slot="brand">My App</strong>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Workspace menu">
           <span slot="toggler">Workspace</span>
           <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         </sgds-mainnav-dropdown>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Manage menu">
           <span slot="toggler">Manage</span>
           <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/stories/layouts/WithSidebar/SidebarSplit.stories.js
+++ b/stories/layouts/WithSidebar/SidebarSplit.stories.js
@@ -61,12 +61,12 @@ const Template = () => html`
       <sgds-masthead fluid></sgds-masthead>
       <sgds-mainnav fluid>
         <strong slot="brand">My App</strong>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Workspace menu">
           <span slot="toggler">Workspace</span>
           <sgds-dropdown-item><a href="#">Dashboard</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Analytics</a></sgds-dropdown-item>
         </sgds-mainnav-dropdown>
-        <sgds-mainnav-dropdown>
+        <sgds-mainnav-dropdown ariaLabel="Manage menu">
           <span slot="toggler">Manage</span>
           <sgds-dropdown-item><a href="#">Team</a></sgds-dropdown-item>
           <sgds-dropdown-item><a href="#">Reports</a></sgds-dropdown-item>

--- a/test/a11y/oobee/mainnav.html
+++ b/test/a11y/oobee/mainnav.html
@@ -9,6 +9,11 @@
       <img slot="brand" alt="Site logo" src="https://placehold.co/120x40" />
       <sgds-mainnav-item href="#">Home</sgds-mainnav-item>
       <sgds-mainnav-item href="#">About</sgds-mainnav-item>
+      <sgds-mainnav-dropdown ariaLabel="Services menu">
+        <span slot="toggler">Services</span>
+        <sgds-dropdown-item href="#">Service 1</sgds-dropdown-item>
+        <sgds-dropdown-item href="#">Service 2</sgds-dropdown-item>
+      </sgds-mainnav-dropdown>
     </sgds-mainnav>
   </body>
 </html>


### PR DESCRIPTION
  Summary                                                                                             
                                                                                                        
  - Add ariaLabel property to <sgds-mainnav-dropdown> that forwards to aria-label on the shadow DOM <a  
  role="button"> toggle element, fixing the oobee-accessible-label a11y violation
  - Update all stories, playground demos, cypress tests, and index.html to include ariaLabel on every   
  <sgds-mainnav-dropdown> instance                                                                      
  - Document the new prop in the skills/sgds-components/reference/mainnav.md skill reference with usage
  guidance for AI agents                                                                                
                                                                                                      
  Test plan                                                                                             
                                                                                                      
  - Run oobee a11y scan on test/a11y/oobee/mainnav.html — oobee-accessible-label mustFix errors should  
  be resolved
  - Verify Storybook renders correctly with pnpm storybook                                              
  - Run pnpm test — existing mainnav tests pass                                                         
  - Inspect dropdown toggle in browser devtools — confirm aria-label attribute is present on the <a     
  role="button"> element          