### PR TITLE
fix(Drawer): remove reflect attribute from ariaLabel 

### DIFF
--- a/skills/sgds-components/reference/drawer.md
+++ b/skills/sgds-components/reference/drawer.md
@@ -131,6 +131,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `open` | boolean | `false` | Controls whether the drawer is visible |
 | `size` | `sm \| md \| lg` | `sm` | Width/height of the drawer panel |
 | `placement` | `top \| end \| bottom \| start` | `end` | Which screen edge the drawer slides from |
+| `ariaLabel` | string | `"Drawer"` | Accessible name for the dialog panel (forwarded to `aria-label` on the shadow DOM `role="dialog"` element). Override with a descriptive label for the drawer's purpose. |
 | `contained` | boolean | `false` | Scopes the drawer within its positioned parent instead of the viewport |
 
 ## Slots
@@ -163,8 +164,9 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 ---
 
 **For AI agents**:
-1. Use `show()` / `hide()` methods to open/close the drawer programmatically; the `open` attribute reflects the current state.
-2. `sgds-request-close` is cancelable — call `event.preventDefault()` to prevent closing (e.g. to confirm unsaved changes). Check `event.detail.source` to distinguish user actions.
-3. `contained` requires the parent element to have `position: relative` and explicit height for proper scoping.
-4. `sgds-initial-focus` is cancelable — call `event.preventDefault()` to control which element receives focus when the drawer opens.
-5. Footer slot typically holds `<sgds-button>` elements for primary and secondary actions.
+1. Always provide `ariaLabel` with a descriptive name matching the drawer's purpose (e.g. `ariaLabel="Filter Options"`). The default `"Drawer"` satisfies a11y checks but a specific label is preferred.
+2. Use `show()` / `hide()` methods to open/close the drawer programmatically; the `open` attribute reflects the current state.
+3. `sgds-request-close` is cancelable — call `event.preventDefault()` to prevent closing (e.g. to confirm unsaved changes). Check `event.detail.source` to distinguish user actions.
+4. `contained` requires the parent element to have `position: relative` and explicit height for proper scoping.
+5. `sgds-initial-focus` is cancelable — call `event.preventDefault()` to control which element receives focus when the drawer opens.
+6. Footer slot typically holds `<sgds-button>` elements for primary and secondary actions.

--- a/src/components/Drawer/sgds-drawer.ts
+++ b/src/components/Drawer/sgds-drawer.ts
@@ -1,6 +1,7 @@
-import { html, nothing, PropertyValueMap } from "lit";
+import { html, PropertyValueMap } from "lit";
 import { property, query } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 import SgdsElement from "../../base/sgds-element";
 import { animateTo, stopAnimations } from "../../utils/animate.js";
 import { getAnimation, setDefaultAnimation } from "../../utils/animation-registry.js";
@@ -66,7 +67,7 @@ export class SgdsDrawer extends SgdsElement {
   /**
    * The accessible label for the drawer dialog. This is required for assistive technology.
    */
-  @property({ type: String, reflect: true }) ariaLabel = "";
+  @property({ type: String }) ariaLabel = "Drawer";
 
   /**
    * By default, the drawer slides out of its containing block (usually the viewport). To make the drawer slide out of
@@ -275,7 +276,7 @@ export class SgdsDrawer extends SgdsElement {
           class="drawer-panel"
           role="dialog"
           aria-modal="true"
-          aria-label=${this.ariaLabel || nothing}
+          aria-label=${ifDefined(this.ariaLabel)}
           aria-hidden=${this.open ? "false" : "true"}
           tabindex="0"
         >


### PR DESCRIPTION
## :open_book: Description

aria-label should not be reflected in <sgds-drawer>  but forwarded down to shadow dom 


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
