### PR TITLE
fix(Card): prevent slot and tabindex attributes from being forwarded to shadow anchor [skip-cd]

### DIFF
--- a/playground/ThumbnailCard.html
+++ b/playground/ThumbnailCard.html
@@ -26,7 +26,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
     <sgds-thumbnail-card class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4" tinted hideBorder>
@@ -50,7 +50,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
     <sgds-thumbnail-card class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4" noPadding>
@@ -74,7 +74,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
     <sgds-thumbnail-card class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4" orientation="horizontal" tinted>
@@ -98,7 +98,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
     <sgds-thumbnail-card class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4" orientation="horizontal" tinted hideBorder>
@@ -122,7 +122,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
     <sgds-thumbnail-card class="sgds-col-4 sgds-col-sm-4 sgds-col-md-4 sgds-col-lg-4" orientation="horizontal" noPadding>
@@ -146,7 +146,7 @@
         <sgds-badge variant="neutral" outlined>Research</sgds-badge>
       </div>
       <sgds-link slot="link">
-        <a href="#">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
+        <a href="#" aria-label="Register now">Register now <sgds-icon name="arrow-right"></sgds-icon></a>
       </sgds-link>
     </sgds-thumbnail-card>
   </div>

--- a/src/base/card-element.ts
+++ b/src/base/card-element.ts
@@ -42,7 +42,7 @@ export class CardElement extends SgdsElement {
   }
 
   protected _forwardAnchorAttributes(anchor: HTMLAnchorElement | null) {
-    const SKIP = new Set(["class", "style", "id"]);
+    const SKIP = new Set(["class", "style", "id", "slot", "tabindex"]);
     if (
       !anchor?.href ||
       anchor.href.startsWith("javascript:") ||


### PR DESCRIPTION
…to card root anchor

When stretchedLink is enabled, _forwardAnchorAttributes was copying slot and tabindex from the footer anchor onto the card root element. This caused a11y violations (oobee-accessible-label) and incorrect DOM attributes. Also adds missing aria-label to playground demos.

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
