### PR TITLE
feat(Checkbox): add noValidate and setInvalid support for custom valdation[skip-cd]

### DIFF
--- a/contributing/architecture-decision-record/custom-validation.md
+++ b/contributing/architecture-decision-record/custom-validation.md
@@ -2,36 +2,63 @@
 
 ## Status
 
-Accepted
+Accepted (revised 26/06/2026)
 
 ## Context
 
-We provide an opinionated native validation behaviour using ElementInternals but should also allow users to opt-out and hook in their own custom validation library 
+We provide an opinionated native validation behaviour using ElementInternals but should also allow users to opt-out and hook in their own custom validation library
 
 ## Decision
 
-Add noValidate prop in form components. When true, it should not trigger the attachInternals of ElementsInternal API. 
-Any components with constraint validation and sgds validation built into the class, should also be disabled when noValidate is true. 
+Add noValidate prop in form components. When true, constraint validation and SGDS validation behaviours are disabled. Users can then call `setInvalid(bool)` and set `invalidFeedback` programmatically.
 
-Additionally the validatorMixin will detect closest `<form novalidate>` and disables constraint and sgds validation. This helps to make it easier for users to set noValidate once. 
+Additionally the validatorMixin will detect closest `<form novalidate>` and disables constraint and sgds validation. This helps to make it easier for users to set noValidate once.
+
+### Revised approach to InputValidationController instantiation
+
+**Original decision (23/09/2025):** When `noValidate` is true, skip creating `InputValidationController` entirely in `connectedCallback`.
+
+**Revised decision (26/06/2026):** Always create `InputValidationController` regardless of `noValidate`. Instead, guard each validation call site individually with `_mixinShouldSkipSgdsValidation()`.
+
+**Reason for revision:** The original approach broke form reset. When a user sets `setInvalid(true)` programmatically and then resets the form, `_mixinResetValidity` needs the controller to call `resetValidity()` and `updateInvalidState()` to clear the invalid state. Without the controller, the form could not return to a pristine state after reset.
+
+### How validation is prevented with noValidate
+
+The `_mixinShouldSkipSgdsValidation()` check gates every validation entry point in the mixin:
+
+- `_mixinHandleChange()` — returns early
+- `_mixinHandleInputChange()` — returns early
+- `_mixinValidate()` — returns early
+- `_mixinCheckValidity()` — returns `true` immediately
+- `_mixinReportValidity()` — returns `true` immediately
+- `_mixinSetValidity()` — returns early
+- `firstUpdated()` — skips initial validation
+- Each component's `_handleIsTouched()` — returns early
+
+The only operations that always run (even with noValidate) are in `_mixinResetValidity`:
+1. `resetValidity()` — clears ValidityState
+2. `updateInvalidState()` — sets `invalid = false`
+3. `_isTouched = false` — resets touched state
+
+Then `validateInput()` is skipped when noValidate is active (no need to re-validate for the next check).
 
 ## Consequences
 
-It is easier to implement custom validation without the interference of sgds opinionated validation behaviour. 
+It is easier to implement custom validation without the interference of sgds opinionated validation behaviour. Form reset always returns the component to a pristine state regardless of validation mode.
 
-Components requiring the update: 
+Components requiring the update:
 1. Input (Done on 23/09/2025)
-2. ComboBox
-3. Select
-4. CheckboxGroup
-5. Checkbox
-6. RadioGroup
+2. ComboBox (Done on 25/06/2026)
+3. Select (Done on 25/06/2026)
+4. CheckboxGroup (Done on 26/06/2026)
+5. Checkbox (Done on 26/06/2026)
+6. RadioGroup (Done on 25/06/2026)
 7. QuantityToggle
-8. Datepicker
-9. FileUpload
-10. Textarea
+8. Datepicker (Done on 25/06/2026)
+9. FileUpload (Done on 25/06/2026)
+10. Textarea (Done on 23/09/2025)
 
 
-## Date of proposal 
+## Date of proposal
 
 23/09/2025

--- a/playground/Checkbox.html
+++ b/playground/Checkbox.html
@@ -61,6 +61,83 @@
           <sgds-checkbox value="c">Option C</sgds-checkbox>
         </sgds-checkbox-group>
       </div>
+      <div>
+        <h2>Custom Validation with noValidate (Checkbox Group)</h2>
+        <form id="custom-validation-checkbox-form">
+          <sgds-checkbox-group
+            noValidate
+            required
+            label="Interests"
+            hintText="Select at least one interest"
+            name="interests"
+            hasFeedback
+            id="custom-validation-checkbox-group"
+          >
+            <sgds-checkbox value="sports">Sports</sgds-checkbox>
+            <sgds-checkbox value="music">Music</sgds-checkbox>
+            <sgds-checkbox value="reading">Reading</sgds-checkbox>
+          </sgds-checkbox-group>
+          <sgds-button type="submit">Submit</sgds-button>
+          <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        </form>
+        <script>
+          const checkboxGroup = document.getElementById("custom-validation-checkbox-group");
+          const checkboxForm = document.getElementById("custom-validation-checkbox-form");
+
+          checkboxGroup.addEventListener("sgds-change", e => {
+            if (!e.target.value) {
+              e.target.setInvalid(true);
+              e.target.invalidFeedback = "Please select at least one interest";
+            } else {
+              e.target.setInvalid(false);
+            }
+          });
+
+          checkboxForm.addEventListener("submit", e => {
+            e.preventDefault();
+            if (!checkboxGroup.value) {
+              checkboxGroup.setInvalid(true);
+              checkboxGroup.invalidFeedback = "Please select at least one interest";
+              return;
+            }
+            if (checkboxGroup.invalid) return;
+            alert("Form submitted successfully despite required field — constraint validation was disabled by the noValidate property.");
+          });
+        </script>
+      </div>
+
+      <div>
+        <h2>Custom Validation with noValidate (Standalone Checkbox)</h2>
+        <form id="custom-validation-standalone-form">
+          <sgds-checkbox
+            noValidate
+            required
+            hasFeedback="both"
+            name="terms"
+            value="agreed"
+            id="custom-validation-standalone-checkbox"
+          >
+            I agree to the Terms and Conditions
+          </sgds-checkbox>
+          <sgds-button type="submit">Submit</sgds-button>
+          <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        </form>
+        <script>
+          const standaloneCheckbox = document.getElementById("custom-validation-standalone-checkbox");
+          const standaloneForm = document.getElementById("custom-validation-standalone-form");
+
+          standaloneForm.addEventListener("submit", e => {
+            e.preventDefault();
+            if (!standaloneCheckbox.checked) {
+              standaloneCheckbox.setInvalid(true);
+              standaloneCheckbox.invalidFeedback = "You must agree to the terms";
+              return;
+            }
+            standaloneCheckbox.setInvalid(false);
+            alert("Form submitted successfully despite required field — constraint validation was disabled by the noValidate property.");
+          });
+        </script>
+      </div>
     </div>
   </body>
 </html>

--- a/playground/noValidateForm.html
+++ b/playground/noValidateForm.html
@@ -55,6 +55,31 @@
         id="custom-bio-textarea"
       ></sgds-textarea>
 
+      <sgds-checkbox-group
+        noValidate
+        required
+        label="Interests"
+        hintText="Select at least one interest"
+        name="interests"
+        hasFeedback
+        id="custom-interests-checkbox-group"
+      >
+        <sgds-checkbox value="sports">Sports</sgds-checkbox>
+        <sgds-checkbox value="music">Music</sgds-checkbox>
+        <sgds-checkbox value="reading">Reading</sgds-checkbox>
+      </sgds-checkbox-group>
+
+      <sgds-checkbox
+        noValidate
+        required
+        hasFeedback="both"
+        name="terms"
+        value="agreed"
+        id="custom-terms-checkbox"
+      >
+        I agree to the Terms and Conditions
+      </sgds-checkbox>
+
       <sgds-button type="submit">Submit</sgds-button>
       <sgds-button type="reset" variant="ghost">Reset</sgds-button>
     </form>
@@ -90,7 +115,28 @@
         placeholder="Enter notes"
       ></sgds-textarea>
 
+      <sgds-checkbox-group
+        required
+        label="Preferences"
+        hintText="This required validation is disabled by form novalidate"
+        name="preferences"
+        hasFeedback
+      >
+        <sgds-checkbox value="newsletter">Newsletter</sgds-checkbox>
+        <sgds-checkbox value="updates">Product updates</sgds-checkbox>
+      </sgds-checkbox-group>
+
+      <sgds-checkbox
+        required
+        hasFeedback="both"
+        name="consent"
+        value="yes"
+      >
+        I consent to data collection (required but validation disabled)
+      </sgds-checkbox>
+
       <sgds-button type="submit">Submit (No Validation)</sgds-button>
+      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
     </form>
 
     <script>
@@ -121,57 +167,66 @@
         }
       });
 
-      bioTextarea.addEventListener("sgds-input", e => {
-        const value = e.target.value;
-        // Bio must be at least 10 characters
-        if (!value || value.length >= 10) {
-          e.target.setInvalid(false);
-        } else {
+        bioTextarea.addEventListener("sgds-input", e => {
+          const value = e.target.value;
+          // Bio must be at least 10 characters
+          if (!value || value.length >= 10) {
+            e.target.setInvalid(false);
+          } else {
+            e.target.setInvalid(true);
+            e.target.invalidFeedback = "Bio must be at least 10 characters long";
+          }
+        });
+
+      const interestsGroup = document.getElementById("custom-interests-checkbox-group");
+      interestsGroup.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
           e.target.setInvalid(true);
-          e.target.invalidFeedback = "Bio must be at least 10 characters long";
+          e.target.invalidFeedback = "Please select at least one interest";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      const termsCheckbox = document.getElementById("custom-terms-checkbox");
+      termsCheckbox.addEventListener("sgds-change", e => {
+        if (!e.target.checked) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "You must agree to the terms";
+        } else {
+          e.target.setInvalid(false);
         }
       });
 
       document.getElementById("custom-validation-form").addEventListener("submit", e => {
         e.preventDefault();
+
+        // Validate checkbox group on submit
+        if (!interestsGroup.value) {
+          interestsGroup.setInvalid(true);
+          interestsGroup.invalidFeedback = "Please select at least one interest";
+        }
+        // Validate standalone checkbox on submit
+        if (!termsCheckbox.checked) {
+          termsCheckbox.setInvalid(true);
+          termsCheckbox.invalidFeedback = "You must agree to the terms";
+        }
+
+        // Check if any field is invalid
+        const components = e.target.querySelectorAll("sgds-input, sgds-textarea, sgds-checkbox-group, sgds-checkbox");
+        const hasInvalid = Array.from(components).some(c => c.invalid);
+        if (hasInvalid) return;
+
         const formData = new FormData(e.target);
         const formDataObj = Object.fromEntries(formData);
         console.log("Custom validation form submitted");
         console.log("FormData entries:", formDataObj);
-        console.log("Username value:", usernameInput.value);
-        console.log("Age value:", ageInput.value);
-        console.log("Bio value:", bioTextarea.value);
-        alert(
-          `Form submitted!\nUsername: ${formDataObj.username || "empty"}\nAge: ${formDataObj.age || "empty"}\nBio: ${
-            formDataObj.bio || "empty"
-          }\nCheck console for details.`
-        );
+        alert("Form submitted successfully despite required fields — constraint validation was disabled by the noValidate property.");
       });
 
       document.getElementById("no-validation-form").addEventListener("submit", e => {
         e.preventDefault();
-        const formData = new FormData(e.target);
-        const formDataObj = Object.fromEntries(formData);
-        console.log("No validation form submitted");
-        console.log("FormData entries:", formDataObj);
-        alert(
-          `Form submitted without validation!\nEmail: ${formDataObj.email || "empty"}\nPhone: ${
-            formDataObj.phone || "empty"
-          }\nNotes: ${formDataObj.notes || "empty"}\nCheck console for details.`
-        );
-      });
-
-      // Debug: Log when inputs change
-      usernameInput.addEventListener("sgds-change", e => {
-        console.log("Username changed:", e.target.value);
-      });
-
-      ageInput.addEventListener("sgds-change", e => {
-        console.log("Age changed:", e.target.value);
-      });
-
-      bioTextarea.addEventListener("sgds-change", e => {
-        console.log("Bio changed:", e.target.value);
+        alert("Form submitted successfully despite required fields — constraint validation was disabled by the form novalidate attribute.");
       });
     </script>
   </body>

--- a/skills/sgds-components/reference/checkbox.md
+++ b/skills/sgds-components/reference/checkbox.md
@@ -111,6 +111,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `hintText` | string | `""` | Hint text below the label |
 | `value` | string | `""` | Comma-separated values of checked checkboxes |
 | `required` | boolean | `false` | Makes at least one checkbox required |
+| `noValidate` | boolean | `false` | Disables native and SGDS validation |
 | `hasFeedback` | boolean | `false` | Enables validation feedback UI |
 | `invalidFeedback` | string | `"Please tick at least one box if you want to proceed"` | Error message when nothing is checked |
 
@@ -124,6 +125,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `indeterminate` | boolean | `false` | Shows the indeterminate (partial) state |
 | `disabled` | boolean | `false` | Disables the checkbox |
 | `required` | boolean | `false` | Makes the checkbox required (standalone) |
+| `noValidate` | boolean | `false` | Disables native and SGDS validation (standalone) |
 | `hasFeedback` | `style \| text \| both` | — | Validation feedback display (standalone) |
 | `invalidFeedback` | string | `""` | Error message (standalone) |
 
@@ -134,23 +136,36 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `<sgds-checkbox-group>` | *(default)* | `<sgds-checkbox>` elements |
 | `<sgds-checkbox>` | *(default)* | Checkbox label text |
 
+## Methods
+
+| Component | Method | Description |
+|---|---|---|
+| `<sgds-checkbox-group>` | `setInvalid(bool)` | Programmatically sets the invalid state |
+| `<sgds-checkbox>` | `setInvalid(bool)` | Programmatically sets the invalid state |
+
 ## Events
 
 | Component | Event | Detail | When |
 |---|---|---|---|
 | `<sgds-checkbox-group>` | `sgds-change` | — | Any checkbox in the group is checked or unchecked; read `element.value` for current checked values |
+| `<sgds-checkbox-group>` | `sgds-invalid` | — | The group's invalid state is set to true |
+| `<sgds-checkbox-group>` | `sgds-valid` | — | The group's invalid state is set to false |
 | `<sgds-checkbox>` | `sgds-change` | `{ checked: boolean, value: string }` | Checked state changes |
 | `<sgds-checkbox>` | `sgds-check` | — | Checkbox is checked |
 | `<sgds-checkbox>` | `sgds-uncheck` | — | Checkbox is unchecked |
 | `<sgds-checkbox>` | `sgds-focus` | — | Gains focus |
 | `<sgds-checkbox>` | `sgds-blur` | — | Loses focus |
+| `<sgds-checkbox>` | `sgds-invalid` | — | The checkbox's invalid state is set to true |
+| `<sgds-checkbox>` | `sgds-valid` | — | The checkbox's invalid state is set to false |
 
 ---
 
 **For AI agents**:
 1. For multi-checkbox forms, use `<sgds-checkbox-group>` — `hasFeedback` and `invalidFeedback` belong on the group.
-2. `<sgds-checkbox-group>` `value` is a comma-separated string of the values of all currently checked checkboxes.
+2. `<sgds-checkbox-group>` `value` is a semicolon-separated string of the values of all currently checked checkboxes.
 3. On `sgds-change` from a group, read `element.value` to get the current selection — no event detail for group.
 4. `indeterminate` is useful for "select all" patterns; toggling it programmatically is valid.
 5. Standalone `<sgds-checkbox>` elements (outside a group) work like a plain HTML checkbox with `name` and `value`.
 6. `hasFeedback` type differs: `<sgds-checkbox-group hasFeedback>` takes a boolean; `<sgds-checkbox hasFeedback="both">` takes a string enum (`style | text | both`). Never add `hasFeedback="both"` to a group.
+7. For custom validation, add `noValidate` and `hasFeedback` to the component, then call `setInvalid(true/false)` and set `invalidFeedback` inside the `sgds-change` event listener.
+8. `setInvalid(true)` emits `sgds-invalid`; `setInvalid(false)` emits `sgds-valid`.

--- a/skills/sgds-forms/SKILL.md
+++ b/skills/sgds-forms/SKILL.md
@@ -155,7 +155,7 @@ For 3rd-party validation libraries (e.g. Zod) or fully custom logic, disable SGD
 
 ### Option 1 — Disable per component with `noValidate`
 
-Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`** and **`<sgds-datepicker>`. Other components are WIP.
+Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`**, **`<sgds-datepicker>`**, **`<sgds-file-upload>`**, **`<sgds-select>`**, **`<sgds-radio-group>`**, **`<sgds-checkbox>`**, and **`<sgds-checkbox-group>`**. Other components are WIP.
 
 ```html
 <sgds-input
@@ -228,12 +228,12 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 | `<sgds-input>`                              | ✅ Implemented |
 | `<sgds-textarea>`                           | ✅ Implemented |
 | `<sgds-datepicker>`                         | ✅ Implemented |
-| `<sgds-checkbox>` / `<sgds-checkbox-group>` | WIP            |
+| `<sgds-checkbox>` / `<sgds-checkbox-group>` | ✅ Implemented |
 | `<sgds-quantity-toggle>`                    | WIP            |
-| `<sgds-radio-group>`                        | WIP            |
-| `<sgds-file-upload>`                        | WIP            |
-| `<sgds-select>`                             | WIP            |
-| `<sgds-combo-box>`                          | WIP            |
+| `<sgds-radio-group>`                        | ✅ Implemented |
+| `<sgds-file-upload>`                        | ✅ Implemented |
+| `<sgds-select>`                             | ✅ Implemented |
+| `<sgds-combo-box>`                          | ✅ Implemented |
 
 ---
 
@@ -245,7 +245,7 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 4. Use `invalidFeedback` to override the browser's native constraint validation message with a custom string.
 5. Constraint validation and form submission blocking are built-in — do not add extra submit event listeners to replicate this behaviour.
 6. Use `new FormData(event.target)` in the submit handler to read values. For file uploads, read `selectedFiles` directly from the `<sgds-file-upload>` element.
-7. When using custom/3rd-party validation on `<sgds-input>`, `<sgds-textarea>`, or `<sgds-datepicker>`, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker).
-8. Only `<sgds-input>`, `<sgds-textarea>`, and `<sgds-datepicker>` fully support custom validation via `noValidate` + `setInvalid`. All other form components have this feature as WIP.
+7. When using custom/3rd-party validation, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker, `sgds-change` for select/combo-box/radio-group/checkbox-group, `sgds-add-files`/`sgds-remove-file` for file-upload).
+8. `<sgds-input>`, `<sgds-textarea>`, `<sgds-datepicker>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-radio-group>`, `<sgds-checkbox>`, `<sgds-checkbox-group>`, and `<sgds-file-upload>` fully support custom validation via `noValidate` + `setInvalid`. Only `<sgds-quantity-toggle>` has this feature as WIP.
 9. The reset button (`type="reset"`) automatically clears all validity states and values — no extra reset logic is needed.
 10. Disabled components are excluded from constraint validation and will never block form submission.

--- a/src/components/Checkbox/sgds-checkbox-group.ts
+++ b/src/components/Checkbox/sgds-checkbox-group.ts
@@ -8,6 +8,8 @@ import { defaultValue } from "../../utils/defaultvalue";
 import { SgdsFormValidatorMixin } from "../../utils/validatorMixin";
 import { watch } from "../../utils/watch";
 import checkboxGroupStyles from "./checkbox-group.css";
+import type { ISgdsCheckboxGroupChangeEventDetail } from "./types";
+export type { ISgdsCheckboxGroupChangeEventDetail };
 /**
  * @summary CheckboxGroup is a form component for multiselection of checkboxes.
  *
@@ -57,8 +59,6 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
   @state()
   private _blurredCheckboxes = new Set<SgdsCheckbox>();
 
-  @state()
-  private formEvent: FormEvent;
 
   connectedCallback() {
     super.connectedCallback();
@@ -103,11 +103,15 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
     const valueArray = this.value ? this.value.split(";") : [];
     valueArray.push(newValue);
     this.value = valueArray.join(";");
+    this._updateInputValue();
+    this.emit<ISgdsCheckboxGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
   }
   private _removeValue(oldValue: string) {
     const valueArray = this.value ? this.value.split(";") : [];
     const newValueArray = valueArray.filter(v => v !== oldValue);
     this.value = newValueArray.join(";");
+    this._updateInputValue();
+    this.emit<ISgdsCheckboxGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
   }
 
   private _sanitizeSlot() {
@@ -133,12 +137,6 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
 
   @watch("value", { waitUntilFirstUpdate: true })
   _handleValueChange() {
-    if (this.formEvent === "reset" && this.value === this.defaultValue) {
-      this.formEvent = null;
-      return;
-    }
-
-    this.emit("sgds-change");
     const checkboxes = this._checkboxes;
     checkboxes.forEach(checkbox => {
       checkbox.checked = this.value.includes(checkbox.value);
@@ -200,11 +198,9 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
    * when input value is set programatically, need to manually dispatch a change event
    * In order to prevent race conditions and ensure sequence of events, set input's value here instead of binding to value prop of input
    */
-  private async _updateInputValue(eventName: FormEvent = "change") {
+  private async _updateInputValue(eventName = "change") {
     this.input.value = this.value;
-
     this.input.dispatchEvent(new InputEvent(eventName));
-    this.formEvent = eventName;
   }
 
   render() {
@@ -246,5 +242,3 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
 }
 
 export default SgdsCheckboxGroup;
-
-type FormEvent = "reset" | "change" | null;

--- a/src/components/Checkbox/sgds-checkbox-group.ts
+++ b/src/components/Checkbox/sgds-checkbox-group.ts
@@ -59,7 +59,6 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
   @state()
   private _blurredCheckboxes = new Set<SgdsCheckbox>();
 
-
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener("sgds-check", (e: CustomEvent) => {

--- a/src/components/Checkbox/sgds-checkbox-group.ts
+++ b/src/components/Checkbox/sgds-checkbox-group.ts
@@ -12,6 +12,8 @@ import checkboxGroupStyles from "./checkbox-group.css";
  * @summary CheckboxGroup is a form component for multiselection of checkboxes.
  *
  * @event sgds-change - Emitted when the value of the CheckboxGroup changes. This happens when checkboxes are checked or unchecked.
+ * @event sgds-invalid - Emitted when the checkbox group's invalid state is set to true.
+ * @event sgds-valid - Emitted when the checkbox group's invalid state is set to false.
  *
  * @slot default - Pass in `sgds-checkbox` into the default slot
  * @slot invalidIcon - The slot for invalid icon
@@ -40,11 +42,15 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
   /** Makes the checkbox group a required field. Only available for when multiselect is true */
   @property({ type: Boolean, reflect: true }) required = false;
 
+  /** Disables native and sgds validation for the checkbox group. */
+  @property({ type: Boolean, reflect: true }) noValidate = false;
+
   /** Consolidates the values of its child checked checkboxes into a single string with semi-colon delimiter. Only available when required is true  */
   @property({ reflect: true }) value = "";
 
   @state() private _isTouched = false;
 
+  /** @internal */
   @defaultValue()
   defaultValue = "";
 
@@ -143,6 +149,7 @@ export class SgdsCheckboxGroup extends SgdsFormValidatorMixin(FormControlElement
 
   @watch("_isTouched", { waitUntilFirstUpdate: true })
   _handleIsTouched() {
+    if (this._mixinShouldSkipSgdsValidation()) return;
     if (this._isTouched) {
       this.invalid = !this.input.checkValidity();
       this._updateInvalid();

--- a/src/components/Checkbox/sgds-checkbox.ts
+++ b/src/components/Checkbox/sgds-checkbox.ts
@@ -22,6 +22,8 @@ import formCheckStyles from "../../styles/form-check.css";
  * @event sgds-focus - Emitted when input is in focus.
  * @event sgds-check - Emitted when checkbox is checked
  * @event sgds-uncheck - Emitted when checkbox is unchecked
+ * @event sgds-invalid - Emitted when the checkbox's invalid state is set to true.
+ * @event sgds-valid - Emitted when the checkbox's invalid state is set to false.
  */
 export class SgdsCheckbox extends SgdsFormValidatorMixin(FormControlElement) implements SgdsFormControl {
   static styles = [...FormControlElement.styles, formCheckStyles, checkboxStyle];
@@ -40,7 +42,7 @@ export class SgdsCheckbox extends SgdsFormValidatorMixin(FormControlElement) imp
   /** Allows invalidFeedback, invalid and valid styles to be visible with the input */
   @property({ type: String, reflect: true }) hasFeedback: "style" | "text" | "both";
 
-  /** Gets or sets the default value used to reset this element. The initial value corresponds to the one originally specified in the HTML that created this element. */
+  /** @internal Gets or sets the default value used to reset this element. The initial value corresponds to the one originally specified in the HTML that created this element. */
   @defaultValue("checked")
   defaultChecked = false;
 
@@ -49,6 +51,9 @@ export class SgdsCheckbox extends SgdsFormValidatorMixin(FormControlElement) imp
 
   /** Makes the checkbox a required field. */
   @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Disables native and sgds validation for the checkbox. */
+  @property({ type: Boolean, reflect: true }) noValidate = false;
 
   /**Feedback text for error state when validated */
   @property({ type: String, reflect: true }) invalidFeedback = "";
@@ -113,6 +118,7 @@ export class SgdsCheckbox extends SgdsFormValidatorMixin(FormControlElement) imp
 
   @watch("_isTouched", { waitUntilFirstUpdate: true })
   _handleIsTouched() {
+    if (this._mixinShouldSkipSgdsValidation()) return;
     if (this._isTouched) {
       this.invalid = !this.input.checkValidity();
     }

--- a/src/components/Checkbox/types.ts
+++ b/src/components/Checkbox/types.ts
@@ -1,0 +1,3 @@
+export interface ISgdsCheckboxGroupChangeEventDetail {
+  value: string;
+}

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -31,9 +31,7 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
     connectedCallback(): void {
       super.connectedCallback();
 
-      if (this._mixinShouldSkipSgdsValidation()) return;
-
-      /** Idempotency guarantee */
+      /** Idempotency guarantee — always create so reset can clear validity even with noValidate */
       this.inputValidationController ??= new InputValidationController(this);
     }
     async firstUpdated(changedProperties: PropertyValueMap<this>) {
@@ -92,18 +90,18 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
     }
     /**
      * During form resetting,
-     * 1. ValidityState is reset
-     * 2. invalid reactive prop is updated after the reset
-     * 3. Revalidates the ValidityState (but do not update invalid prop)
-     * to prepare for the next validity check
-     * 4. Reset touched state to false for a pristine form
+     * 1. ValidityState is reset (always, regardless of noValidate)
+     * 2. invalid reactive prop is updated after the reset (always)
+     * 3. Reset touched state to false for a pristine form (always)
+     * 4. Revalidates the ValidityState (but do not update invalid prop)
+     * to prepare for the next validity check (skipped when noValidate)
      */
     _mixinResetValidity(input: HTMLInputElement | SgdsInput | HTMLTextAreaElement) {
-      if (this._mixinShouldSkipSgdsValidation()) return;
       this.inputValidationController.resetValidity();
       this.inputValidationController.updateInvalidState();
-      this.inputValidationController.validateInput(input);
       this._isTouched ? (this._isTouched = false) : null;
+      if (this._mixinShouldSkipSgdsValidation()) return;
+      this.inputValidationController.validateInput(input);
     }
 
     _mixinValidate(input: HTMLInputElement | SgdsInput | HTMLTextAreaElement) {

--- a/stories/component-templates/Checkbox/additional.stories.js
+++ b/stories/component-templates/Checkbox/additional.stories.js
@@ -3,24 +3,28 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 const ValidationTemplateGroup = args =>
   html`
-    <form>
+    <form class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
       <sgds-checkbox-group required hasFeedback id="sameid">
         <sgds-checkbox value="he">he</sgds-checkbox>
         <sgds-checkbox value="him">him</sgds-checkbox>
       </sgds-checkbox-group>
 
-      <sgds-button type="submit">Submit</sgds-button>
-      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="submit">Submit</sgds-button>
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+      </div>
     </form>
   `;
 
 const ValidationTemplateSingle = args =>
   html`
-    <form>
+    <form class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
       <sgds-checkbox value="marketing" required hasFeedback="both">I acknowledge to receive marketing...</sgds-checkbox>
       <sgds-checkbox value="subcribe" hasFeedback="both">I agree to subscribe to...</sgds-checkbox>
-      <sgds-button type="submit">Submit</sgds-button>
-      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="submit">Submit</sgds-button>
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+      </div>
     </form>
   `;
 
@@ -89,14 +93,14 @@ export const InvalidGroup = {
 };
 export const Validation = {
   render: ValidationTemplateGroup.bind({}),
-  name: "Validation",
+  name: "Validation for CheckboxGroup",
   args: {},
   parameters: {}
 };
 
 export const ValidationSingle = {
   render: ValidationTemplateSingle.bind({}),
-  name: "Validation",
+  name: "Validation for standalone Checkbox",
   args: {},
   parameters: {}
 };

--- a/stories/component-templates/Checkbox/basic.js
+++ b/stories/component-templates/Checkbox/basic.js
@@ -3,29 +3,30 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 export const Template = args => {
   return html`
-    <sgds-checkbox-group
-      label=${ifDefined(args.label)}
-      invalidFeedback=${ifDefined(args.invalidFeedback)}
-      ?hasFeedback=${args.hasFeedback}
-      hintText=${ifDefined(args.hintText)}
-      ?required=${args.required}
-    >
-      <sgds-checkbox value="watermelon">Watermelon</sgds-checkbox>
-      <sgds-checkbox value="apple">Apple</sgds-checkbox>
-      <sgds-checkbox value="lychee">Lychee</sgds-checkbox>
-    </sgds-checkbox-group>
-    <br />
-    <sgds-checkbox
-      name=${ifDefined(args.name)}
-      ?disabled=${args.disabled}
-      value=${ifDefined(args.value)}
-      ?required=${args.required}
-      ?checked=${args.checked}
-      ?invalid=${args.invalid}
-      ?indeterminate=${args.indeterminate}
-      >Individual Checkbox. I agree to ...Lorem ipsum dolor sit amet. Et itaque natus sit laborum voluptatem aut rerum
-      ducimus eum tenetur molestias quo reiciendis ratione aut eaque voluptates est
-    </sgds-checkbox>
+    <div class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
+      <sgds-checkbox-group
+        label=${ifDefined(args.label)}
+        invalidFeedback=${ifDefined(args.invalidFeedback)}
+        ?hasFeedback=${args.hasFeedback}
+        hintText=${ifDefined(args.hintText)}
+        ?required=${args.required}
+      >
+        <sgds-checkbox value="watermelon">Watermelon</sgds-checkbox>
+        <sgds-checkbox value="apple">Apple</sgds-checkbox>
+        <sgds-checkbox value="lychee">Lychee</sgds-checkbox>
+      </sgds-checkbox-group>
+      <sgds-checkbox
+        name=${ifDefined(args.name)}
+        ?disabled=${args.disabled}
+        value=${ifDefined(args.value)}
+        ?required=${args.required}
+        ?checked=${args.checked}
+        ?invalid=${args.invalid}
+        ?indeterminate=${args.indeterminate}
+        >Individual Checkbox. I agree to ...Lorem ipsum dolor sit amet. Et itaque natus sit laborum voluptatem aut rerum
+        ducimus eum tenetur molestias quo reiciendis ratione aut eaque voluptates est
+      </sgds-checkbox>
+    </div>
   `;
 };
 export const args = {

--- a/stories/form-validation/customValidation.mdx
+++ b/stories/form-validation/customValidation.mdx
@@ -29,8 +29,8 @@ When `novalidate` is present on the closest parent `<form>`, all child form comp
 | Textarea       | Implemented |
 | ComboBox       | Implemented |
 | Datepicker     | Implemented |
-| Checkbox       | WIP         |
-| CheckboxGroup  | WIP         |
+| Checkbox       | Implemented |
+| CheckboxGroup  | Implemented |
 | QuantityToggle | WIP         |
 | RadioGroup     | WIP         |
 | FileUpload     | Implemented |

--- a/stories/form-validation/customValidation.stories.js
+++ b/stories/form-validation/customValidation.stories.js
@@ -7,7 +7,7 @@ const handleInput = e => {};
 
 const DisableValidationByInputTemplate = args => {
   return html`
-    <form id="custom-validation-form" class="d-flex-column">
+    <form id="custom-validation-form" class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
       <sgds-input
         noValidate
         label="Keys"
@@ -64,7 +64,23 @@ const DisableValidationByInputTemplate = args => {
         hasFeedback
         id="custom-validation__datepicker-novalidate"
       ></sgds-datepicker>
-      <sgds-button type="submit">Submit</sgds-button>
+      <sgds-checkbox-group
+        noValidate
+        required
+        label="Interests"
+        hintText="Select at least one interest"
+        name="checkbox-interests"
+        hasFeedback
+        id="custom-validation__checkbox-novalidate"
+      >
+        <sgds-checkbox value="sports">Sports</sgds-checkbox>
+        <sgds-checkbox value="music">Music</sgds-checkbox>
+        <sgds-checkbox value="reading">Reading</sgds-checkbox>
+      </sgds-checkbox-group>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        <sgds-button type="submit">Submit</sgds-button>
+      </div>
     </form>
     <script>
       const formOne = document.getElementById("custom-validation-form");
@@ -148,12 +164,22 @@ const DisableValidationByInputTemplate = args => {
           e.target.setInvalid(false);
         }
       });
+
+      const checkboxGroupOne = document.querySelector("sgds-checkbox-group#custom-validation__checkbox-novalidate");
+      checkboxGroupOne.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select at least one interest";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
     </script>
   `;
 };
 const DisableValidationByFormTemplate = args => {
   return html`
-    <form id="custom-validation-form_novalidate" class="d-flex-column" novalidate>
+    <form id="custom-validation-form_novalidate" class="sgds:flex sgds:flex-col sgds:gap-layout-xs" novalidate>
       <sgds-input
         label="Keys"
         hinttext="Keys cannot start with special characters like @, #, $"
@@ -204,7 +230,22 @@ const DisableValidationByFormTemplate = args => {
         hasFeedback
         id="custom-validation__datepicker-two-novalidate"
       ></sgds-datepicker>
-      <sgds-button type="submit">Submit</sgds-button>
+      <sgds-checkbox-group
+        required
+        label="Interests"
+        hintText="Select at least one interest"
+        name="checkbox-interests"
+        hasFeedback
+        id="custom-validation__checkbox-two-novalidate"
+      >
+        <sgds-checkbox value="sports">Sports</sgds-checkbox>
+        <sgds-checkbox value="music">Music</sgds-checkbox>
+        <sgds-checkbox value="reading">Reading</sgds-checkbox>
+      </sgds-checkbox-group>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        <sgds-button type="submit">Submit</sgds-button>
+      </div>
     </form>
     <script>
       const formTwo = document.getElementById("custom-validation-form_novalidate");
@@ -287,6 +328,16 @@ const DisableValidationByFormTemplate = args => {
         if (selected <= today) {
           e.target.setInvalid(true);
           e.target.invalidFeedback = "Please select a future date";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      const checkboxGroupTwo = document.getElementById("custom-validation__checkbox-two-novalidate");
+      checkboxGroupTwo.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select at least one interest";
         } else {
           e.target.setInvalid(false);
         }

--- a/test/checkbox.test.ts
+++ b/test/checkbox.test.ts
@@ -1025,3 +1025,66 @@ describe("reset clears invalid state when noValidate is true for checkbox-group"
     expect(group?.invalid).to.be.false;
   });
 });
+
+describe("FormData is correct when sgds-change fires for checkbox-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("FormData should reflect the updated value inside sgds-change listener", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-checkbox-group name="colors" value="">
+          <sgds-checkbox value="red">Red</sgds-checkbox>
+          <sgds-checkbox value="blue">Blue</sgds-checkbox>
+        </sgds-checkbox-group>
+      </form>
+    `);
+    const group = form.querySelector<SgdsCheckboxGroup>("sgds-checkbox-group")!;
+    await group.updateComplete;
+
+    let formDataValue: string | null = null;
+    group.addEventListener("sgds-change", () => {
+      const formData = new FormData(form);
+      formDataValue = formData.get("colors") as string;
+    });
+
+    // Simulate user clicking "red" checkbox
+    const redCheckbox = group.querySelector<SgdsCheckbox>('sgds-checkbox[value="red"]')!;
+    redCheckbox.click();
+    await group.updateComplete;
+
+    expect(formDataValue).to.equal("red");
+  });
+});
+
+describe("reset does not emit sgds-change for checkbox-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("should not emit sgds-change when form is reset", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-checkbox-group noValidate name="test" value="a">
+          <sgds-checkbox value="a">A</sgds-checkbox>
+          <sgds-checkbox value="b">B</sgds-checkbox>
+        </sgds-checkbox-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const group = form.querySelector<SgdsCheckboxGroup>("sgds-checkbox-group")!;
+    await group.updateComplete;
+
+    // Check "b" to change the value from default
+    const bCheckbox = group.querySelector<SgdsCheckbox>('sgds-checkbox[value="b"]')!;
+    bCheckbox.click();
+    await group.updateComplete;
+
+    const changeHandler = Sinon.spy();
+    group.addEventListener("sgds-change", changeHandler);
+
+    // Reset the form
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => group.value === "a");
+    await group.updateComplete;
+
+    expect(changeHandler).to.not.have.been.called;
+  });
+});

--- a/test/checkbox.test.ts
+++ b/test/checkbox.test.ts
@@ -1,7 +1,8 @@
-import { assert, elementUpdated, expect, fixture, html, waitUntil } from "@open-wc/testing";
+import { assert, elementUpdated, expect, fixture, fixtureCleanup, html, waitUntil } from "@open-wc/testing";
 import { sendKeys } from "@web/test-runner-commands";
 import Sinon from "sinon";
-import { SgdsButton, SgdsCheckbox, SgdsCheckboxGroup } from "../src/components";
+import type { SgdsButton } from "../src/components";
+import { SgdsCheckbox, SgdsCheckboxGroup } from "../src/components";
 import "./sgds-web-component";
 
 describe("<sgds-checkbox>", () => {
@@ -827,5 +828,200 @@ describe("sgds-checkbox-group", () => {
     await waitUntil(() => group?.invalid);
     // await elementUpdated(group!);
     expect(group?.invalid).to.be.true;
+  });
+});
+
+describe("noValidate disables native and sgds validation for standalone checkbox", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("should override required and allow form submission when noValidate is set", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-checkbox noValidate required value="terms">I agree</sgds-checkbox>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = Sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("with noValidate, invalid state does not appear on blur when required and unchecked", async () => {
+    const el = await fixture<SgdsCheckbox>(html`
+      <sgds-checkbox noValidate hasFeedback="both" required value="terms">I agree</sgds-checkbox>
+    `);
+    el.input.focus();
+    el.input.blur();
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+  });
+
+  it("with noValidate, setInvalid(true) still works for programmatic control", async () => {
+    const el = await fixture<SgdsCheckbox>(html`
+      <sgds-checkbox noValidate required hasFeedback="both" value="terms">I agree</sgds-checkbox>
+    `);
+    el.setInvalid(true);
+    el.invalidFeedback = "You must agree to the terms";
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+  });
+
+  it("setInvalid(true) emits sgds-invalid event", async () => {
+    const el = await fixture<SgdsCheckbox>(html` <sgds-checkbox noValidate value="terms">I agree</sgds-checkbox> `);
+    const handler = Sinon.spy();
+    el.addEventListener("sgds-invalid", handler);
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("setInvalid(false) emits sgds-valid event", async () => {
+    const el = await fixture<SgdsCheckbox>(html` <sgds-checkbox noValidate value="terms">I agree</sgds-checkbox> `);
+    const handler = Sinon.spy();
+    el.addEventListener("sgds-valid", handler);
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+});
+
+describe("noValidate disables native and sgds validation for checkbox-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("should override required and allow form submission when noValidate is set", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-checkbox-group noValidate required hasFeedback>
+          <sgds-checkbox value="a">A</sgds-checkbox>
+          <sgds-checkbox value="b">B</sgds-checkbox>
+        </sgds-checkbox-group>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = Sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("with noValidate, invalid state does not appear after all checkboxes blurred", async () => {
+    const el = await fixture<SgdsCheckboxGroup>(html`
+      <sgds-checkbox-group noValidate hasFeedback required>
+        <sgds-checkbox value="a">A</sgds-checkbox>
+        <sgds-checkbox value="b">B</sgds-checkbox>
+      </sgds-checkbox-group>
+    `);
+    const checkboxes = el.querySelectorAll("sgds-checkbox");
+    checkboxes.forEach(cb => cb.dispatchEvent(new Event("sgds-blur", { bubbles: true })));
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+  });
+
+  it("with noValidate, setInvalid(true) still works for programmatic control", async () => {
+    const el = await fixture<SgdsCheckboxGroup>(html`
+      <sgds-checkbox-group noValidate required hasFeedback>
+        <sgds-checkbox value="a">A</sgds-checkbox>
+        <sgds-checkbox value="b">B</sgds-checkbox>
+      </sgds-checkbox-group>
+    `);
+    el.setInvalid(true);
+    el.invalidFeedback = "Please select at least one option";
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+  });
+
+  it("setInvalid(true) emits sgds-invalid event", async () => {
+    const el = await fixture<SgdsCheckboxGroup>(html`
+      <sgds-checkbox-group noValidate>
+        <sgds-checkbox value="a">A</sgds-checkbox>
+      </sgds-checkbox-group>
+    `);
+    const handler = Sinon.spy();
+    el.addEventListener("sgds-invalid", handler);
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("setInvalid(false) emits sgds-valid event", async () => {
+    const el = await fixture<SgdsCheckboxGroup>(html`
+      <sgds-checkbox-group noValidate>
+        <sgds-checkbox value="a">A</sgds-checkbox>
+      </sgds-checkbox-group>
+    `);
+    const handler = Sinon.spy();
+    el.addEventListener("sgds-valid", handler);
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+});
+
+describe("form novalidate for checkbox-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("when form has novalidate, form submission proceeds even when checkbox-group is required", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-checkbox-group required>
+          <sgds-checkbox value="a">A</sgds-checkbox>
+          <sgds-checkbox value="b">B</sgds-checkbox>
+        </sgds-checkbox-group>
+        <sgds-button type="submit"></sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = Sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+});
+
+describe("reset clears invalid state when noValidate is true for checkbox-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("reset clears programmatic invalid state when component has noValidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-checkbox-group noValidate name="test">
+          <sgds-checkbox value="a">A</sgds-checkbox>
+        </sgds-checkbox-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const group = form.querySelector<SgdsCheckboxGroup>("sgds-checkbox-group");
+    group?.setInvalid(true);
+    await group?.updateComplete;
+    expect(group?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => group?.invalid === false);
+    expect(group?.invalid).to.be.false;
+  });
+
+  it("reset clears programmatic invalid state when form has novalidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-checkbox-group name="test">
+          <sgds-checkbox value="a">A</sgds-checkbox>
+        </sgds-checkbox-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const group = form.querySelector<SgdsCheckboxGroup>("sgds-checkbox-group");
+    group?.setInvalid(true);
+    await group?.updateComplete;
+    expect(group?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => group?.invalid === false);
+    expect(group?.invalid).to.be.false;
   });
 });


### PR DESCRIPTION
…dation

Enable custom validation on sgds-checkbox and sgds-checkbox-group via noValidate prop and setInvalid() method. Also fix validatorMixin reset behaviour to clear invalid state when noValidate is active. Update skills, stories, and tests accordingly.

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
