### PR TITLE
feat(RadioGroup): add noValidate and setInvalid support for custom validation [skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1" async crossorigin="anonymous" integrity="sha384-j5VrNZcqKNUHLnCE92BAUxjweChuIOcFud+EqjXjXtn9B2g9xiYyqfnrlDIJ/lXk"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1" async crossorigin="anonymous" integrity="sha384-lhd+cdp78mvnJrxiN0wX0RdSXxt5uy7jCaSFKslq0Jsj9sOMQRG8V3SsukS56i0B"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>

--- a/playground/Radio.html
+++ b/playground/Radio.html
@@ -46,13 +46,15 @@
 
       <div>
         <h2>Required Validation</h2>
-        <form>
+        <form class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
           <sgds-radio-group label="Agreement" name="agreement" required hasFeedback>
             <sgds-radio value="yes">I agree</sgds-radio>
             <sgds-radio value="no">I disagree</sgds-radio>
           </sgds-radio-group>
-          <br />
-          <sgds-button type="submit">Submit</sgds-button>
+          <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+            <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+            <sgds-button type="submit">Submit</sgds-button>
+          </div>
         </form>
       </div>
 
@@ -63,9 +65,53 @@
           <sgds-radio value="sms">SMS</sgds-radio>
           <sgds-radio value="push">Push Notification</sgds-radio>
         </sgds-radio-group>
-        <p style="margin-top: 12px; font-size: 0.875rem; color: #666;">
-          When checking a radio, it automatically receives focus for better keyboard navigation.
-        </p>
+      </div>
+
+      <div>
+        <h2>Custom Validation with noValidate</h2>
+        <form id="custom-validation-radio-form" class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
+          <sgds-radio-group
+            noValidate
+            required
+            label="Gender"
+            hintText="Please select a gender"
+            name="gender"
+            hasFeedback
+            id="custom-validation-radio-group"
+          >
+            <sgds-radio value="male">Male</sgds-radio>
+            <sgds-radio value="female">Female</sgds-radio>
+            <sgds-radio value="other">Other</sgds-radio>
+          </sgds-radio-group>
+          <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+            <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+            <sgds-button type="submit">Submit</sgds-button>
+          </div>
+        </form>
+        <script>
+          const radioGroup = document.getElementById("custom-validation-radio-group");
+          const radioForm = document.getElementById("custom-validation-radio-form");
+
+          radioGroup.addEventListener("sgds-change", e => {
+            if (!e.target.value) {
+              e.target.setInvalid(true);
+              e.target.invalidFeedback = "Please select a gender";
+            } else {
+              e.target.setInvalid(false);
+            }
+          });
+
+          radioForm.addEventListener("submit", e => {
+            e.preventDefault();
+            if (!radioGroup.value) {
+              radioGroup.setInvalid(true);
+              radioGroup.invalidFeedback = "Please select a gender";
+              return;
+            }
+            if (radioGroup.invalid) return;
+            alert("Form submitted successfully despite required field — constraint validation was disabled by the noValidate property.");
+          });
+        </script>
       </div>
     </div>
   </body>

--- a/playground/noValidateForm.html
+++ b/playground/noValidateForm.html
@@ -55,6 +55,20 @@
         id="custom-bio-textarea"
       ></sgds-textarea>
 
+      <sgds-radio-group
+        noValidate
+        required
+        label="Gender"
+        hintText="Please select a gender"
+        name="gender"
+        hasFeedback
+        id="custom-gender-radio"
+      >
+        <sgds-radio value="male">Male</sgds-radio>
+        <sgds-radio value="female">Female</sgds-radio>
+        <sgds-radio value="other">Other</sgds-radio>
+      </sgds-radio-group>
+
       <sgds-button type="submit">Submit</sgds-button>
       <sgds-button type="reset" variant="ghost">Reset</sgds-button>
     </form>
@@ -90,7 +104,20 @@
         placeholder="Enter notes"
       ></sgds-textarea>
 
+      <sgds-radio-group
+        required
+        label="Priority"
+        hintText="This required validation is disabled by form novalidate"
+        name="priority"
+        hasFeedback
+      >
+        <sgds-radio value="low">Low</sgds-radio>
+        <sgds-radio value="medium">Medium</sgds-radio>
+        <sgds-radio value="high">High</sgds-radio>
+      </sgds-radio-group>
+
       <sgds-button type="submit">Submit (No Validation)</sgds-button>
+      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
     </form>
 
     <script>
@@ -132,6 +159,16 @@
         }
       });
 
+      const genderRadio = document.getElementById("custom-gender-radio");
+      genderRadio.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select a gender";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
       document.getElementById("custom-validation-form").addEventListener("submit", e => {
         e.preventDefault();
         const formData = new FormData(e.target);
@@ -157,7 +194,7 @@
         alert(
           `Form submitted without validation!\nEmail: ${formDataObj.email || "empty"}\nPhone: ${
             formDataObj.phone || "empty"
-          }\nNotes: ${formDataObj.notes || "empty"}\nCheck console for details.`
+          }\nNotes: ${formDataObj.notes || "empty"}\nPriority: ${formDataObj.priority || "empty"}\nCheck console for details.`
         );
       });
 

--- a/skills/sgds-components/reference/radio.md
+++ b/skills/sgds-components/reference/radio.md
@@ -109,6 +109,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `hasFeedback` | boolean | `false` | Enables validation feedback UI |
 | `invalidFeedback` | string | `""` | Error message when no option is selected |
 | `invalid` | boolean | `false` | Manually sets the invalid state |
+| `noValidate` | boolean | `false` | Disables native and SGDS validation |
 | `autofocus` | boolean | `false` | When true, the checked radio automatically receives focus (improves keyboard navigation) |
 
 ### `<sgds-radio>`
@@ -127,11 +128,21 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `<sgds-radio-group>` | *(default)* | `<sgds-radio>` elements |
 | `<sgds-radio>` | *(default)* | Radio button label text |
 
+## Methods (`<sgds-radio-group>`)
+
+| Method | Description |
+|---|---|
+| `setInvalid(bool)` | Programmatically sets the invalid state. Pass `true` to mark invalid, `false` to clear. |
+| `reportValidity()` | Checks validity and returns boolean |
+| `checkValidity()` | Checks validity without native error popup |
+
 ## Events
 
 | Component | Event | Detail | When |
 |---|---|---|---|
 | `<sgds-radio-group>` | `sgds-change` | `{ value: string }` | A radio in the group is selected |
+| `<sgds-radio-group>` | `sgds-invalid` | — | The group's invalid state is set to true |
+| `<sgds-radio-group>` | `sgds-valid` | — | The group's invalid state is set to false |
 | `<sgds-radio>` | `sgds-focus` | — | Radio gains focus |
 | `<sgds-radio>` | `sgds-blur` | — | Radio loses focus |
 
@@ -143,3 +154,5 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 3. Listen to `sgds-change` on the group (not on individual radios) to get the selected value via `event.detail.value`.
 4. `hasFeedback` and `invalidFeedback` are set on the group, not on individual radios.
 5. To pre-select an option, prefer setting `value` on `<sgds-radio-group>`. The `checked` attribute on `<sgds-radio>` also pre-checks that radio on render, but avoid using both simultaneously — `value` on the group takes precedence and may conflict with `checked` on a child.
+6. For custom validation, add `noValidate` and `hasFeedback` to the group, then call `setInvalid(true/false)` and set `invalidFeedback` inside the `sgds-change` event listener.
+7. `setInvalid(true)` emits `sgds-invalid`; `setInvalid(false)` emits `sgds-valid`.

--- a/skills/sgds-forms/SKILL.md
+++ b/skills/sgds-forms/SKILL.md
@@ -155,7 +155,7 @@ For 3rd-party validation libraries (e.g. Zod) or fully custom logic, disable SGD
 
 ### Option 1 — Disable per component with `noValidate`
 
-Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`** and **`<sgds-datepicker>`. Other components are WIP.
+Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`**, **`<sgds-datepicker>`**, **`<sgds-file-upload>`**, **`<sgds-select>`**, and **`<sgds-radio-group>`**. Other components are WIP.
 
 ```html
 <sgds-input
@@ -230,10 +230,10 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 | `<sgds-datepicker>`                         | ✅ Implemented |
 | `<sgds-checkbox>` / `<sgds-checkbox-group>` | WIP            |
 | `<sgds-quantity-toggle>`                    | WIP            |
-| `<sgds-radio-group>`                        | WIP            |
-| `<sgds-file-upload>`                        | WIP            |
-| `<sgds-select>`                             | WIP            |
-| `<sgds-combo-box>`                          | WIP            |
+| `<sgds-radio-group>`                        | ✅ Implemented |
+| `<sgds-file-upload>`                        | ✅ Implemented |
+| `<sgds-select>`                             | ✅ Implemented |
+| `<sgds-combo-box>`                          | ✅ Implemented |
 
 ---
 
@@ -245,7 +245,7 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 4. Use `invalidFeedback` to override the browser's native constraint validation message with a custom string.
 5. Constraint validation and form submission blocking are built-in — do not add extra submit event listeners to replicate this behaviour.
 6. Use `new FormData(event.target)` in the submit handler to read values. For file uploads, read `selectedFiles` directly from the `<sgds-file-upload>` element.
-7. When using custom/3rd-party validation on `<sgds-input>`, `<sgds-textarea>`, or `<sgds-datepicker>`, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker).
-8. Only `<sgds-input>`, `<sgds-textarea>`, and `<sgds-datepicker>` fully support custom validation via `noValidate` + `setInvalid`. All other form components have this feature as WIP.
+7. When using custom/3rd-party validation, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker, `sgds-change` for select/combo-box/radio-group, `sgds-add-files`/`sgds-remove-file` for file-upload).
+8. `<sgds-input>`, `<sgds-textarea>`, `<sgds-datepicker>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-radio-group>`, and `<sgds-file-upload>` fully support custom validation via `noValidate` + `setInvalid`. Other form components have this feature as WIP.
 9. The reset button (`type="reset"`) automatically clears all validity states and values — no extra reset logic is needed.
 10. Disabled components are excluded from constraint validation and will never block form submission.

--- a/src/components/Radio/sgds-radio-group.ts
+++ b/src/components/Radio/sgds-radio-group.ts
@@ -51,12 +51,6 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
 
   @watch("value", { waitUntilFirstUpdate: true })
   _handleValueChange() {
-    if (this._isResetting) {
-      this._isResetting = false;
-      this._updateCheckedRadio();
-      return;
-    }
-    this.emit<ISgdsRadioGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
     this._updateCheckedRadio();
   }
   @watch("invalid", { waitUntilFirstUpdate: true })
@@ -65,14 +59,11 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
   }
 
   @state() private _isTouched = false;
-
-  private _isResetting = false;
   /**
    * radio requries a custom _mixinResetFormControl as the update of input value
    * requires to fire a reset event manually
    * */
   private _mixinResetFormControl() {
-    this._isResetting = true;
     this.value = this.input.value = this.defaultValue;
     this._updateInputValue("reset");
     this._mixinResetValidity(this.input);
@@ -122,6 +113,7 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
     }
 
     this.value = target.value;
+    this.emit<ISgdsRadioGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
 
     this._updateInputValue();
 
@@ -163,6 +155,7 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
     });
 
     this.value = radios[index].value;
+    this.emit<ISgdsRadioGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
     this._updateInputValue();
     radios[index].checked = true;
     radios[index].tabIndex = 0;

--- a/src/components/Radio/sgds-radio-group.ts
+++ b/src/components/Radio/sgds-radio-group.ts
@@ -51,6 +51,11 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
 
   @watch("value", { waitUntilFirstUpdate: true })
   _handleValueChange() {
+    if (this._isResetting) {
+      this._isResetting = false;
+      this._updateCheckedRadio();
+      return;
+    }
     this.emit<ISgdsRadioGroupChangeEventDetail>("sgds-change", { detail: { value: this.value } });
     this._updateCheckedRadio();
   }
@@ -60,11 +65,14 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
   }
 
   @state() private _isTouched = false;
+
+  private _isResetting = false;
   /**
    * radio requries a custom _mixinResetFormControl as the update of input value
    * requires to fire a reset event manually
    * */
   private _mixinResetFormControl() {
+    this._isResetting = true;
     this.value = this.input.value = this.defaultValue;
     this._updateInputValue("reset");
     this._mixinResetValidity(this.input);

--- a/src/components/Radio/sgds-radio-group.ts
+++ b/src/components/Radio/sgds-radio-group.ts
@@ -18,6 +18,8 @@ export type { ISgdsRadioGroupChangeEventDetail };
  *
  * @event sgds-change - Emitted when the radio group's selected value changes.
  * @eventDetail {ISgdsRadioGroupChangeEventDetail} sgds-change
+ * @event sgds-invalid - Emitted when the radio group's invalid state is set to true.
+ * @event sgds-valid - Emitted when the radio group's invalid state is set to false.
  *
  */
 export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
@@ -40,6 +42,9 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
 
   /** Makes the input as a required field. */
   @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Disables native and sgds validation for the radio group. */
+  @property({ type: Boolean, reflect: true }) noValidate = false;
 
   /** Automatically focuses the selected radio input in the group when it becomes checked. */
   @property({ type: Boolean, reflect: true }) autofocus = false;
@@ -210,6 +215,7 @@ export class SgdsRadioGroup extends SgdsFormValidatorMixin(FormControlElement) {
 
   @watch("_isTouched", { waitUntilFirstUpdate: true })
   _handleIsTouched() {
+    if (this._mixinShouldSkipSgdsValidation()) return;
     if (this._isTouched) {
       this.invalid = !this.input.checkValidity();
     }

--- a/src/utils/validatorMixin.ts
+++ b/src/utils/validatorMixin.ts
@@ -31,9 +31,7 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
     connectedCallback(): void {
       super.connectedCallback();
 
-      if (this._mixinShouldSkipSgdsValidation()) return;
-
-      /** Idempotency guarantee */
+      /** Idempotency guarantee — always create so reset can clear validity even with noValidate */
       this.inputValidationController ??= new InputValidationController(this);
     }
     async firstUpdated(changedProperties: PropertyValueMap<this>) {
@@ -92,18 +90,18 @@ export const SgdsFormValidatorMixin = <T extends Constructor<LitElement>>(superC
     }
     /**
      * During form resetting,
-     * 1. ValidityState is reset
-     * 2. invalid reactive prop is updated after the reset
-     * 3. Revalidates the ValidityState (but do not update invalid prop)
-     * to prepare for the next validity check
-     * 4. Reset touched state to false for a pristine form
+     * 1. ValidityState is reset (always, regardless of noValidate)
+     * 2. invalid reactive prop is updated after the reset (always)
+     * 3. Reset touched state to false for a pristine form (always)
+     * 4. Revalidates the ValidityState (but do not update invalid prop)
+     * to prepare for the next validity check (skipped when noValidate)
      */
     _mixinResetValidity(input: HTMLInputElement | SgdsInput | HTMLTextAreaElement) {
-      if (this._mixinShouldSkipSgdsValidation()) return;
       this.inputValidationController.resetValidity();
       this.inputValidationController.updateInvalidState();
-      this.inputValidationController.validateInput(input);
       this._isTouched ? (this._isTouched = false) : null;
+      if (this._mixinShouldSkipSgdsValidation()) return;
+      this.inputValidationController.validateInput(input);
     }
 
     _mixinValidate(input: HTMLInputElement | SgdsInput | HTMLTextAreaElement) {

--- a/stories/component-templates/Radio/additional.mdx
+++ b/stories/component-templates/Radio/additional.mdx
@@ -9,10 +9,10 @@ Add labels to individual `sgds-radio` through its default slot
   <Story of={RadioStories.Basic} />
 </Canvas>
 
-## Invalid 
+## Invalid
 
 Radio button's invalid styles are controlled by the radio group.
-To enable SGDS form validation styles set `hasFeedback` to true. 
+To enable SGDS form validation styles set `hasFeedback` to true.
 Add your custom invalid feedback message via `invalidFeedback` and control the stylings of the radio group with `invalid` boolean prop.
 
 `sgds-radio-group` controls and updates the `invalid` prop in its child `sgds-radio` buttons.
@@ -21,34 +21,12 @@ Add your custom invalid feedback message via `invalidFeedback` and control the s
   <Story of={RadioStories.Invalid} />
 </Canvas>
 
-## Disabled 
+## Disabled
 
 Disabled individual `sgds-radio` using the `disabled` prop.
 
 <Canvas of={RadioStories.Disabled}>
   <Story of={RadioStories.Disabled} />
-</Canvas>
-
-## Validation 
-
-HTML form constraint validation is built-in. By default, there is no need to control the `invalid` prop to enable constraint validations. 
-
-- To enable invalid styles and feedback message, set `hasFeedback` to true on `sgds-radio-group`.
-
-In this example, press submit to show constraint validation behaviour for `required` on the radio group. 
-Form reset reset's the validity and the value of the input to its initial default value.
-
-<Canvas of={RadioStories.Validation}>
-  <Story of={RadioStories.Validation} />
-</Canvas>
-
-### Overriding the invalid feedback message 
-
-By default, the invalid feedback reflected is based on the browser's native error message based on the ValidityState.  To override the default message, 
-use `invalidFeedback` prop. 
-
-<Canvas of={RadioStories.OverrideInvalidFeedback}>
-  <Story of={RadioStories.OverrideInvalidFeedback} />
 </Canvas>
 
 ## Autofocus
@@ -57,4 +35,34 @@ Set `autofocus` on the radio group to automatically focus the checked radio. Thi
 
 <Canvas of={RadioStories.Autofocus}>
   <Story of={RadioStories.Autofocus} />
+</Canvas>
+
+## Validation
+
+HTML form constraint validation is built-in. By default, there is no need to control the `invalid` prop to enable constraint validations.
+
+- To enable invalid styles and feedback message, set `hasFeedback` to true on `sgds-radio-group`.
+
+In this example, press submit to show constraint validation behaviour for `required` on the radio group.
+Form reset reset's the validity and the value of the input to its initial default value.
+
+<Canvas of={RadioStories.Validation}>
+  <Story of={RadioStories.Validation} />
+</Canvas>
+
+### Overriding the invalid feedback message
+
+By default, the invalid feedback reflected is based on the browser's native error message based on the ValidityState.  To override the default message,
+use `invalidFeedback` prop.
+
+<Canvas of={RadioStories.OverrideInvalidFeedback}>
+  <Story of={RadioStories.OverrideInvalidFeedback} />
+</Canvas>
+
+## Custom Validation with `noValidate`
+
+Set `noValidate` to disable built-in constraint validation. Use `setInvalid(bool)` and `invalidFeedback` to control the validation state programmatically via event listeners.
+
+<Canvas of={RadioStories.NoValidate}>
+  <Story of={RadioStories.NoValidate} />
 </Canvas>

--- a/stories/component-templates/Radio/additional.stories.js
+++ b/stories/component-templates/Radio/additional.stories.js
@@ -3,7 +3,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 const ValidationTemplate = args =>
   html`
-    <form>
+    <form class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
       <sgds-radio-group
         label="Select an option"
         required
@@ -15,24 +15,12 @@ const ValidationTemplate = args =>
         <sgds-radio value="2">Option 2</sgds-radio>
         <sgds-radio value="3">Option 3</sgds-radio>
       </sgds-radio-group>
-      <sgds-button type="submit">Submit</sgds-button>
-      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        <sgds-button type="submit">Submit</sgds-button>
+      </div>
     </form>
   `;
-
-export const Validation = {
-  render: ValidationTemplate.bind({}),
-  name: "Validation",
-  args: {},
-  parameters: {}
-};
-
-export const OverrideInvalidFeedback = {
-  render: ValidationTemplate.bind({}),
-  name: "Override default invalid feedback",
-  args: { invalidFeedback: "Custom error message" },
-  parameters: {}
-};
 
 export const Invalid = {
   render: Template.bind({}),
@@ -52,5 +40,75 @@ export const Autofocus = {
   render: Template.bind({}),
   name: "Autofocus",
   args: { ...args, autofocus: true },
+  parameters: {}
+};
+
+export const Validation = {
+  render: ValidationTemplate.bind({}),
+  name: "Validation",
+  args: {},
+  parameters: {}
+};
+
+export const OverrideInvalidFeedback = {
+  render: ValidationTemplate.bind({}),
+  name: "Override default invalid feedback",
+  args: { invalidFeedback: "Custom error message" },
+  parameters: {}
+};
+
+const NoValidateTemplate = () => {
+  return html`
+    <form id="novalidate-radio-story-form" class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
+      <sgds-radio-group
+        noValidate
+        required
+        label="Gender"
+        hintText="Custom validation: must select a gender"
+        hasFeedback
+        id="novalidate-radio-story"
+      >
+        <sgds-radio value="male">Male</sgds-radio>
+        <sgds-radio value="female">Female</sgds-radio>
+        <sgds-radio value="other">Other</sgds-radio>
+      </sgds-radio-group>
+      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
+        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        <sgds-button type="submit">Submit</sgds-button>
+      </div>
+    </form>
+    <script>
+      const noValidateRadio = document.querySelector("#novalidate-radio-story");
+      const noValidateRadioForm = document.querySelector("#novalidate-radio-story-form");
+
+      noValidateRadio.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select a gender";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      noValidateRadioForm.addEventListener("submit", e => {
+        e.preventDefault();
+        if (!noValidateRadio.value) {
+          noValidateRadio.setInvalid(true);
+          noValidateRadio.invalidFeedback = "Please select a gender";
+          return;
+        }
+        if (noValidateRadio.invalid) return;
+        alert(
+          "Form submitted successfully despite required field — constraint validation was disabled by the noValidate property."
+        );
+      });
+    </script>
+  `;
+};
+
+export const NoValidate = {
+  render: NoValidateTemplate.bind({}),
+  name: "Custom Validation with noValidate",
+  args: {},
   parameters: {}
 };

--- a/stories/form-validation/customValidation.mdx
+++ b/stories/form-validation/customValidation.mdx
@@ -32,6 +32,6 @@ When `novalidate` is present on the closest parent `<form>`, all child form comp
 | Checkbox       | WIP         |
 | CheckboxGroup  | WIP         |
 | QuantityToggle | WIP         |
-| RadioGroup     | WIP         |
+| RadioGroup     | Implemented |
 | FileUpload     | Implemented |
 | Select         | WIP         |

--- a/stories/form-validation/customValidation.stories.js
+++ b/stories/form-validation/customValidation.stories.js
@@ -64,6 +64,19 @@ const DisableValidationByInputTemplate = args => {
         hasFeedback
         id="custom-validation__datepicker-novalidate"
       ></sgds-datepicker>
+      <sgds-radio-group
+        noValidate
+        required
+        label="Gender"
+        hintText="Please select a gender"
+        name="radio-gender"
+        hasFeedback
+        id="custom-validation__radio-novalidate"
+      >
+        <sgds-radio value="male">Male</sgds-radio>
+        <sgds-radio value="female">Female</sgds-radio>
+        <sgds-radio value="other">Other</sgds-radio>
+      </sgds-radio-group>
       <sgds-button type="submit">Submit</sgds-button>
     </form>
     <script>
@@ -148,6 +161,16 @@ const DisableValidationByInputTemplate = args => {
           e.target.setInvalid(false);
         }
       });
+
+      const radioOne = document.querySelector("sgds-radio-group#custom-validation__radio-novalidate");
+      radioOne.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select a gender";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
     </script>
   `;
 };
@@ -204,6 +227,18 @@ const DisableValidationByFormTemplate = args => {
         hasFeedback
         id="custom-validation__datepicker-two-novalidate"
       ></sgds-datepicker>
+      <sgds-radio-group
+        required
+        label="Gender"
+        hintText="Please select a gender"
+        name="radio-gender"
+        hasFeedback
+        id="custom-validation__radio-two-novalidate"
+      >
+        <sgds-radio value="male">Male</sgds-radio>
+        <sgds-radio value="female">Female</sgds-radio>
+        <sgds-radio value="other">Other</sgds-radio>
+      </sgds-radio-group>
       <sgds-button type="submit">Submit</sgds-button>
     </form>
     <script>
@@ -287,6 +322,16 @@ const DisableValidationByFormTemplate = args => {
         if (selected <= today) {
           e.target.setInvalid(true);
           e.target.invalidFeedback = "Please select a future date";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      const radioTwo = document.getElementById("custom-validation__radio-two-novalidate");
+      radioTwo.addEventListener("sgds-change", e => {
+        if (!e.target.value) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Please select a gender";
         } else {
           e.target.setInvalid(false);
         }

--- a/test/radio.test.ts
+++ b/test/radio.test.ts
@@ -473,6 +473,38 @@ describe("reset clears invalid state when noValidate is true for radio-group", (
   });
 });
 
+describe("reset does not emit sgds-change for radio-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("should not emit sgds-change when form is reset", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-radio-group noValidate name="test" value="a">
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const radioGroup = form.querySelector<SgdsRadioGroup>("sgds-radio-group")!;
+    await radioGroup.updateComplete;
+
+    // Change value to "b" first
+    radioGroup.value = "b";
+    await radioGroup.updateComplete;
+
+    const changeHandler = sinon.spy();
+    radioGroup.addEventListener("sgds-change", changeHandler);
+
+    // Reset the form
+    changeHandler.resetHistory();
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => radioGroup.value === "a");
+
+    expect(changeHandler).to.not.have.been.called;
+  });
+});
+
 describe("setInvalid emits sgds-invalid and sgds-valid events for radio-group", () => {
   afterEach(() => fixtureCleanup());
 

--- a/test/radio.test.ts
+++ b/test/radio.test.ts
@@ -3,7 +3,8 @@ import { assert, elementUpdated, expect, fixture, fixtureCleanup, triggerFocusFo
 import { sendKeys } from "@web/test-runner-commands";
 import { html } from "lit";
 import sinon from "sinon";
-import { SgdsButton, SgdsRadio, SgdsRadioGroup } from "../src/components";
+import type { SgdsButton } from "../src/components";
+import { SgdsRadio, SgdsRadioGroup } from "../src/components";
 
 describe("<sgds-radio>", () => {
   afterEach(() => fixtureCleanup());
@@ -304,6 +305,203 @@ describe("<sgds-radio-group>", () => {
     await el.updateComplete;
     const radios = el.querySelectorAll("sgds-radio");
     radios.forEach(r => expect(r.disabled).to.be.true);
+  });
+});
+
+describe("noValidate disables native and sgds validation behaviours", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("should override required and allow form submission when noValidate is set", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-radio-group noValidate required hasFeedback>
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("with noValidate, invalid state does not appear on blur when required and empty", async () => {
+    const el = await fixture<SgdsRadioGroup>(html`
+      <sgds-radio-group noValidate hasFeedback required>
+        <sgds-radio value="a">A</sgds-radio>
+        <sgds-radio value="b">B</sgds-radio>
+      </sgds-radio-group>
+    `);
+    el.dispatchEvent(new Event("sgds-blur"));
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+  });
+
+  it("with noValidate, setInvalid(true) still works for programmatic control", async () => {
+    const el = await fixture<SgdsRadioGroup>(html`
+      <sgds-radio-group noValidate required hasFeedback>
+        <sgds-radio value="a">A</sgds-radio>
+        <sgds-radio value="b">B</sgds-radio>
+      </sgds-radio-group>
+    `);
+    el.setInvalid(true);
+    el.invalidFeedback = "Please select an option";
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+  });
+
+  it("with noValidate, programmatic setInvalid(true) persists after blur", async () => {
+    const el = await fixture<SgdsRadioGroup>(html`
+      <sgds-radio-group noValidate required hasFeedback>
+        <sgds-radio value="a">A</sgds-radio>
+        <sgds-radio value="b">B</sgds-radio>
+      </sgds-radio-group>
+    `);
+    el.setInvalid(true);
+    await el.updateComplete;
+    el.dispatchEvent(new Event("sgds-blur"));
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+  });
+
+  it("should still populate FormData when noValidate is enabled", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-radio-group noValidate name="radio-field" value="a">
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      expect(formData.get("radio-field")).to.equal("a");
+    });
+
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+});
+
+describe("form novalidate for sgds-radio-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("when form has novalidate, form submission proceeds even when radio-group is required", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-radio-group required>
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="submit"></sgds-button>
+      </form>
+    `);
+    const submitButton = form.querySelector<SgdsButton>("sgds-button");
+    const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+    submitButton?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("when form has novalidate, radio-group does not show invalid state on blur", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-radio-group required hasFeedback>
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+      </form>
+    `);
+    const radioGroup = form.querySelector<SgdsRadioGroup>("sgds-radio-group");
+    radioGroup?.dispatchEvent(new Event("sgds-blur"));
+    await radioGroup?.updateComplete;
+    expect(radioGroup?.invalid).to.be.false;
+  });
+});
+
+describe("reset clears invalid state when noValidate is true for radio-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("reset clears programmatic invalid state when component has noValidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-radio-group noValidate name="test">
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const radioGroup = form.querySelector<SgdsRadioGroup>("sgds-radio-group");
+    radioGroup?.setInvalid(true);
+    await radioGroup?.updateComplete;
+    expect(radioGroup?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => radioGroup?.invalid === false);
+    expect(radioGroup?.invalid).to.be.false;
+  });
+
+  it("reset clears programmatic invalid state when form has novalidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-radio-group name="test">
+          <sgds-radio value="a">A</sgds-radio>
+          <sgds-radio value="b">B</sgds-radio>
+        </sgds-radio-group>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const radioGroup = form.querySelector<SgdsRadioGroup>("sgds-radio-group");
+    radioGroup?.setInvalid(true);
+    await radioGroup?.updateComplete;
+    expect(radioGroup?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector<SgdsButton>("sgds-button")?.click());
+    await waitUntil(() => radioGroup?.invalid === false);
+    expect(radioGroup?.invalid).to.be.false;
+  });
+});
+
+describe("setInvalid emits sgds-invalid and sgds-valid events for radio-group", () => {
+  afterEach(() => fixtureCleanup());
+
+  it("setInvalid(true) emits sgds-invalid event", async () => {
+    const el = await fixture<SgdsRadioGroup>(html`
+      <sgds-radio-group noValidate>
+        <sgds-radio value="a">A</sgds-radio>
+        <sgds-radio value="b">B</sgds-radio>
+      </sgds-radio-group>
+    `);
+    const handler = sinon.spy();
+    el.addEventListener("sgds-invalid", handler);
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("setInvalid(false) emits sgds-valid event", async () => {
+    const el = await fixture<SgdsRadioGroup>(html`
+      <sgds-radio-group noValidate>
+        <sgds-radio value="a">A</sgds-radio>
+        <sgds-radio value="b">B</sgds-radio>
+      </sgds-radio-group>
+    `);
+    const handler = sinon.spy();
+    el.addEventListener("sgds-valid", handler);
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
   });
 });
 


### PR DESCRIPTION
…lidation

Enable custom validation on sgds-radio-group via noValidate prop and setInvalid() method. Also fix validatorMixin reset behaviour to clear invalid state when noValidate is active. Update skills, stories, and tests accordingly.

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
