### PR TITLE
chore(ComboBox): correct inaccurate info on skills [skip-cd]

### DIFF
--- a/skills/sgds-components/reference/combo-box.md
+++ b/skills/sgds-components/reference/combo-box.md
@@ -23,13 +23,14 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 ## Behaviour
 
 - Dropdown opens on input focus, typing, or clicking the trigger.
-- Options are filtered client-side in real time based on user input (substring match by default); set a custom `filterFunction` to change the matching strategy.
+- Options are filtered client-side in real time based on user input (startsWith match by default); set a custom `filterFunction` to change the matching strategy.
 - Set `async` to disable client-side filtering and handle results server-side via the `sgds-input` event.
 - Selecting an option populates the input and closes the dropdown.
-- In `multiSelect` mode, each selected option appears as a dismissible badge; `element.value` is a comma-separated string.
+- In `multiSelect` mode, each selected option appears as a dismissible badge; `element.value` is a semicolon-separated string (`;`).
+- In `multiSelect` mode, pressing `Backspace` when the input is empty removes the last selected badge.
 - `clearable` adds a clear button to reset the selection.
 - `loading` shows a spinner while async results are being fetched.
-- `required` makes the field required for form submission; an error state is shown on submit if no option is selected. Unlike `<sgds-select>`, there is no `hasFeedback` or `invalidFeedback` attribute — validation feedback relies on browser-native constraint validation.
+- `required` makes the field required for form submission; an error state is shown on submit if no option is selected. Set `hasFeedback` to display validation styling and `invalidFeedback` to show a custom error message below the input.
 - `disabled` makes the combo box non-interactive; `readonly` makes it visible but not selectable.
 - `hintText` and the error message occupy the same space below the input — when the field is invalid, `hintText` is replaced by the error message. Once the error is resolved, `hintText` reappears.
 - Keyboard: `Arrow` keys navigate options; `Enter` selects the highlighted option; `Esc` closes the dropdown.
@@ -39,8 +40,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 - **Custom filter**: set `filterFunction` as a JS property — not an HTML attribute — to implement prefix, fuzzy, or custom matching logic. Ignored when `async` is true.
 - **Async data**: set `async`, listen to `sgds-input` for `event.detail.displayValue`, fetch results, then replace `<sgds-combo-box-option>` children. Set `loading` to indicate fetch in progress.
-- **Browser autocomplete**: `autocomplete` is set to `"off"` by default to prevent browser autofill from interfering with the dropdown filtering and selection. Change to `"on"` only if you want browser autocomplete suggestions — not recommended for most use cases.
-- **Multi-select**: add `multiSelect`; `element.value` becomes a comma-separated string of selected values. Use `badgeFullWidth` to make badges span the full input width.
+- **Browser autocomplete**: `autocomplete` defaults to `"on"`. Set to `"off"` if browser autofill interferes with the dropdown filtering and selection.
+- **Multi-select**: add `multiSelect`; `element.value` becomes a semicolon-separated string (`;`) of selected values. Use `badgeFullWidth` to make badges span the full input width.
 - **Empty async menu**: use `emptyMenuAsync` to show an open (empty) menu immediately when in async mode before the user types.
 - **Programmatic control**: `menuIsOpen` lets you open or close the dropdown from JavaScript without user interaction.
 - **Positioning**: `floatingOpts` passes options directly to Floating UI for advanced dropdown placement — use only when default positioning is insufficient.
@@ -55,7 +56,6 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - **Pre-filled values**: set `value` to a string matching an existing option's `value` attribute; mismatches will show no selection.
 - **Clearing selection**: `clearable` resets `element.value` to empty — ensure downstream listeners on `sgds-change` handle an empty value gracefully.
 - **Mobile**: the dropdown renders inline; for very large datasets on small screens, consider limiting the option count via async filtering rather than rendering all options.
-- **IME input** (e.g. Chinese/Japanese): filtering fires via `sgds-input` which may fire during composition — use `async` mode with debouncing if IME input causes unintended filtering.
 - **⚠️ DO NOT use placeholder text as an option**: Never include options like `<sgds-combo-box-option value="">Select country</sgds-combo-box-option>`. Every option in the menu is a valid selectable value that will be submitted with the form. Use the `placeholder` attribute instead to display prompt text when no option is selected — it will not be included in the option list.
 
 ## Form Layout Context
@@ -144,11 +144,16 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `label` | string | `""` | Field label |
 | `hintText` | string | `""` | Hint text below the label |
 | `name` | string | — | Form field name |
-| `value` | string | — | Currently selected value(s) — comma-separated for multi-select |
+| `value` | string | `""` | Currently selected value(s) — semicolon-separated (`;`) for multi-select |
 | `placeholder` | string | — | Placeholder text |
 | `required` | boolean | `false` | Makes the field required |
+| `hasFeedback` | boolean | `false` | Enables validation styling and feedback message display |
+| `invalidFeedback` | string | `""` | Custom error message shown below input when invalid and `hasFeedback` is true |
+| `invalid` | boolean | `false` | Marks the component as invalid |
+| `noValidate` | boolean | `false` | Disables native and SGDS validation on this component |
 | `disabled` | boolean | `false` | Disables the combo box |
 | `readonly` | boolean | `false` | Makes the combo box read-only |
+| `autofocus` | boolean | `false` | Automatically focuses the input on mount |
 | `loading` | boolean | `false` | Shows a loading spinner in the input |
 | `multiSelect` | boolean | `false` | Enables multi-selection with badge display |
 | `clearable` | boolean | `false` | Shows a clear button to reset the selection |
@@ -156,9 +161,9 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `async` | boolean | `false` | Disables client-side filtering for server-side async filtering |
 | `emptyMenuAsync` | boolean | `false` | Shows an empty menu on open when in async mode |
 | `menuIsOpen` | boolean | `false` | Programmatically controls the dropdown menu open state |
-| `autocomplete` | string | `"off"` | Controls browser autocomplete behavior — typically set to `"off"` to prevent browser autofill interference with the dropdown list |
+| `autocomplete` | string | `"on"` | Controls browser autocomplete behavior — set to `"off"` to prevent browser autofill interference with the dropdown list |
 | `scrollBottomOffset` | number | `0` | Pixels before the bottom of the menu at which `sgds-scroll-end` fires — must be non-negative; negative values are treated as `0` |
-| `filterFunction` | `(inputValue: string, item) => boolean` | contains filter | Custom filter function (ignored when `async` is true) |
+| `filterFunction` | `(inputValue: string, item) => boolean` | startsWith filter | Custom filter function (ignored when `async` is true) |
 | `floatingOpts` | object | — | Options for Floating UI positioning (advanced) |
 
 ### `<sgds-combo-box-option>`
@@ -173,7 +178,18 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | Component | Slot | Purpose |
 |---|---|---|
 | `<sgds-combo-box>` | *(default)* | `<sgds-combo-box-option>` elements |
+| `<sgds-combo-box>` | `invalidIcon` | Custom icon shown when the field is invalid |
 | `<sgds-combo-box-option>` | *(default)* | Option label text |
+
+## Methods
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `setInvalid` | `(bool: boolean) => void` | Programmatically set or clear invalid state; emits `sgds-invalid` or `sgds-valid` |
+| `reportValidity` | `() => boolean` | Checks validity and shows browser validation UI |
+| `checkValidity` | `() => boolean` | Checks validity without showing UI |
+| `showMenu` | `() => void` | Programmatically opens the dropdown |
+| `hideMenu` | `() => void` | Programmatically closes the dropdown |
 
 ## Events (`<sgds-combo-box>`)
 
@@ -185,14 +201,20 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `sgds-focus` | — | Input gains focus |
 | `sgds-blur` | — | Input loses focus |
 | `sgds-scroll-end` | — | Menu scroll position reaches the bottom (within `scrollBottomOffset` pixels) — use to trigger lazy loading |
+| `sgds-invalid` | — | Emitted when `setInvalid(true)` is called |
+| `sgds-valid` | — | Emitted when `setInvalid(false)` is called |
+| `sgds-show` | — | Dropdown menu is about to show |
+| `sgds-after-show` | — | Dropdown menu has finished showing |
+| `sgds-hide` | — | Dropdown menu is about to hide |
+| `sgds-after-hide` | — | Dropdown menu has finished hiding |
 
 ---
 
 **For AI agents**:
-1. For single-select, `element.value` is the selected option's `value`. For multi-select, it is a comma-separated string.
+1. For single-select, `element.value` is the selected option's `value`. For multi-select, it is a semicolon-separated string (`;`).
 2. For async filtering, set `async` (boolean attribute), listen to `sgds-input` for `event.detail.displayValue`, fetch results, then populate `<sgds-combo-box-option>` children.
 3. Use `clearable` to let users reset the selection without form submission.
 4. `filterFunction` must be set as a JS property (`.filterFunction = (input, item) => ...`), not as an HTML attribute.
-5. `<sgds-combo-box>` does **not** have `hasFeedback` or `invalidFeedback` attributes — unlike all other SGDS form components. Validation relies entirely on the browser-native `required` constraint. Do not add these attributes.
+5. `<sgds-combo-box>` supports `hasFeedback` and `invalidFeedback` like other SGDS form components. Set `hasFeedback` to enable validation styling and `invalidFeedback` to display a custom error message.
 6. **Infinite scroll**: set `scrollBottomOffset` (number of pixels) and listen to `sgds-scroll-end` to append more `<sgds-combo-box-option>` elements before the user reaches the end of the list. The event fires once per scroll-to-bottom gesture and resets when the user scrolls back up.
 7. **Boolean attribute handling**: For single-select, omit the `multiSelect` attribute entirely. For multi-select, include `multiSelect` with no value (HTML5 boolean) or `multiSelect="true"`. Do **NOT** use `multiSelect="false"` for single-select — in HTML, any attribute presence (even with value "false") is truthy. Omit the attribute for false.


### PR DESCRIPTION
## :open_book: Description

While working on stackops, i realise that combobxo skills have some inaccuracies

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
