### PR TITLE
refactor(Combobox):  programatic value change should not trigger sgds-change

### DIFF
--- a/contributing/architecture-decision-record/change-event-user-interaction-only.md
+++ b/contributing/architecture-decision-record/change-event-user-interaction-only.md
@@ -1,0 +1,55 @@
+# Change Events Fire Only on User Interaction
+
+## Status
+
+Accepted
+
+## Context
+
+SGDS form components were emitting `sgds-change` from `@watch("value")` decorators, meaning any value change (user interaction, programmatic assignment, or form reset) would fire the event. This caused issues:
+
+1. **Form reset triggering validation** - Custom validation listeners attached to `sgds-change` would fire during reset, incorrectly showing validation errors when the form was being cleared.
+2. **Divergence from native behaviour** - Native `<input>`, `<select>`, and `<textarea>` elements only fire the `change` event in response to user-committed actions, never on programmatic `.value` assignment or form reset.
+3. **FormData timing** - When `sgds-change` was emitted from the watcher (during Lit's async update cycle), `FormData` had not yet been synced via `setFormValue`, so consumers reading `FormData` inside their `sgds-change` listener would get stale values.
+
+Reference: Shoelace (a peer Lit-based web component library) follows the same pattern - `sl-change` is only emitted from user interaction handlers, not from property watchers.
+
+## Decision
+
+`sgds-change` (and related events like `sgds-select`) must only be emitted from **user interaction handlers** (click, keyboard, clear button), never from `@watch("value")` watchers or during form reset.
+
+### Implementation pattern
+
+1. Remove `this.emit("sgds-change")` from `@watch("value")` watchers. The watcher should only handle internal state sync (updating child elements, syncing hidden inputs, running validation).
+2. Add `this.emit("sgds-change")` directly in user interaction methods (e.g. `_handleRadioClick`, `_handleItemSelected`, `_addValue`).
+3. Call `_mixinSetFormValue()` or `_updateInputValue()` **before** emitting `sgds-change`, so that `FormData` is correct when consumers read it in their event listener.
+4. Form reset (`_mixinResetFormControl`) sets the value without emitting change events since it is not a user-initiated action.
+
+### Components that required rectification
+
+| Component | Status |
+|-----------|--------|
+| RadioGroup | Done (03/07/2026) |
+| CheckboxGroup | Done (03/07/2026) |
+| ComboBox | Done (03/07/2026) |
+
+### Components already correct (no watcher-based emission)
+
+- Input
+- Textarea
+- Select
+- Datepicker
+- QuantityToggle
+- FileUpload
+- Checkbox
+
+## Consequences
+
+- Custom validation listeners on `sgds-change` no longer fire during form reset.
+- `FormData` is guaranteed to be up-to-date when `sgds-change` fires.
+- Programmatic `element.value = "x"` no longer emits `sgds-change`. Consumers who relied on this must use the component's public API or listen to property changes via MutationObserver if needed.
+- Consistent behaviour across all SGDS form components and aligned with the web platform.
+
+## Date of proposal
+
+03/07/2026

--- a/skills/sgds-components/reference/combo-box.md
+++ b/skills/sgds-components/reference/combo-box.md
@@ -23,13 +23,14 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 ## Behaviour
 
 - Dropdown opens on input focus, typing, or clicking the trigger.
-- Options are filtered client-side in real time based on user input (substring match by default); set a custom `filterFunction` to change the matching strategy.
+- Options are filtered client-side in real time based on user input (startsWith match by default); set a custom `filterFunction` to change the matching strategy.
 - Set `async` to disable client-side filtering and handle results server-side via the `sgds-input` event.
 - Selecting an option populates the input and closes the dropdown.
-- In `multiSelect` mode, each selected option appears as a dismissible badge; `element.value` is a comma-separated string.
+- In `multiSelect` mode, each selected option appears as a dismissible badge; `element.value` is a semicolon-separated string (`;`).
+- In `multiSelect` mode, pressing `Backspace` when the input is empty removes the last selected badge.
 - `clearable` adds a clear button to reset the selection.
 - `loading` shows a spinner while async results are being fetched.
-- `required` makes the field required for form submission; an error state is shown on submit if no option is selected. Unlike `<sgds-select>`, there is no `hasFeedback` or `invalidFeedback` attribute — validation feedback relies on browser-native constraint validation.
+- `required` makes the field required for form submission; an error state is shown on submit if no option is selected. Set `hasFeedback` to display validation styling and `invalidFeedback` to show a custom error message below the input.
 - `disabled` makes the combo box non-interactive; `readonly` makes it visible but not selectable.
 - `hintText` and the error message occupy the same space below the input — when the field is invalid, `hintText` is replaced by the error message. Once the error is resolved, `hintText` reappears.
 - Keyboard: `Arrow` keys navigate options; `Enter` selects the highlighted option; `Esc` closes the dropdown.
@@ -39,8 +40,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 - **Custom filter**: set `filterFunction` as a JS property — not an HTML attribute — to implement prefix, fuzzy, or custom matching logic. Ignored when `async` is true.
 - **Async data**: set `async`, listen to `sgds-input` for `event.detail.displayValue`, fetch results, then replace `<sgds-combo-box-option>` children. Set `loading` to indicate fetch in progress.
-- **Browser autocomplete**: `autocomplete` is set to `"off"` by default to prevent browser autofill from interfering with the dropdown filtering and selection. Change to `"on"` only if you want browser autocomplete suggestions — not recommended for most use cases.
-- **Multi-select**: add `multiSelect`; `element.value` becomes a comma-separated string of selected values. Use `badgeFullWidth` to make badges span the full input width.
+- **Browser autocomplete**: `autocomplete` defaults to `"on"`. Set to `"off"` if browser autofill interferes with the dropdown filtering and selection.
+- **Multi-select**: add `multiSelect`; `element.value` becomes a semicolon-separated string (`;`) of selected values. Use `badgeFullWidth` to make badges span the full input width.
 - **Empty async menu**: use `emptyMenuAsync` to show an open (empty) menu immediately when in async mode before the user types.
 - **Programmatic control**: `menuIsOpen` lets you open or close the dropdown from JavaScript without user interaction.
 - **Positioning**: `floatingOpts` passes options directly to Floating UI for advanced dropdown placement — use only when default positioning is insufficient.
@@ -55,7 +56,6 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - **Pre-filled values**: set `value` to a string matching an existing option's `value` attribute; mismatches will show no selection.
 - **Clearing selection**: `clearable` resets `element.value` to empty — ensure downstream listeners on `sgds-change` handle an empty value gracefully.
 - **Mobile**: the dropdown renders inline; for very large datasets on small screens, consider limiting the option count via async filtering rather than rendering all options.
-- **IME input** (e.g. Chinese/Japanese): filtering fires via `sgds-input` which may fire during composition — use `async` mode with debouncing if IME input causes unintended filtering.
 - **⚠️ DO NOT use placeholder text as an option**: Never include options like `<sgds-combo-box-option value="">Select country</sgds-combo-box-option>`. Every option in the menu is a valid selectable value that will be submitted with the form. Use the `placeholder` attribute instead to display prompt text when no option is selected — it will not be included in the option list.
 
 ## Form Layout Context
@@ -144,11 +144,16 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `label` | string | `""` | Field label |
 | `hintText` | string | `""` | Hint text below the label |
 | `name` | string | — | Form field name |
-| `value` | string | — | Currently selected value(s) — comma-separated for multi-select |
+| `value` | string | `""` | Currently selected value(s) — semicolon-separated (`;`) for multi-select |
 | `placeholder` | string | — | Placeholder text |
 | `required` | boolean | `false` | Makes the field required |
+| `hasFeedback` | boolean | `false` | Enables validation styling and feedback message display |
+| `invalidFeedback` | string | `""` | Custom error message shown below input when invalid and `hasFeedback` is true |
+| `invalid` | boolean | `false` | Marks the component as invalid |
+| `noValidate` | boolean | `false` | Disables native and SGDS validation on this component |
 | `disabled` | boolean | `false` | Disables the combo box |
 | `readonly` | boolean | `false` | Makes the combo box read-only |
+| `autofocus` | boolean | `false` | Automatically focuses the input on mount |
 | `loading` | boolean | `false` | Shows a loading spinner in the input |
 | `multiSelect` | boolean | `false` | Enables multi-selection with badge display |
 | `clearable` | boolean | `false` | Shows a clear button to reset the selection |
@@ -156,9 +161,9 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `async` | boolean | `false` | Disables client-side filtering for server-side async filtering |
 | `emptyMenuAsync` | boolean | `false` | Shows an empty menu on open when in async mode |
 | `menuIsOpen` | boolean | `false` | Programmatically controls the dropdown menu open state |
-| `autocomplete` | string | `"off"` | Controls browser autocomplete behavior — typically set to `"off"` to prevent browser autofill interference with the dropdown list |
+| `autocomplete` | string | `"on"` | Controls browser autocomplete behavior — set to `"off"` to prevent browser autofill interference with the dropdown list |
 | `scrollBottomOffset` | number | `0` | Pixels before the bottom of the menu at which `sgds-scroll-end` fires — must be non-negative; negative values are treated as `0` |
-| `filterFunction` | `(inputValue: string, item) => boolean` | contains filter | Custom filter function (ignored when `async` is true) |
+| `filterFunction` | `(inputValue: string, item) => boolean` | startsWith filter | Custom filter function (ignored when `async` is true) |
 | `floatingOpts` | object | — | Options for Floating UI positioning (advanced) |
 
 ### `<sgds-combo-box-option>`
@@ -173,7 +178,18 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | Component | Slot | Purpose |
 |---|---|---|
 | `<sgds-combo-box>` | *(default)* | `<sgds-combo-box-option>` elements |
+| `<sgds-combo-box>` | `invalidIcon` | Custom icon shown when the field is invalid |
 | `<sgds-combo-box-option>` | *(default)* | Option label text |
+
+## Methods
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `setInvalid` | `(bool: boolean) => void` | Programmatically set or clear invalid state; emits `sgds-invalid` or `sgds-valid` |
+| `reportValidity` | `() => boolean` | Checks validity and shows browser validation UI |
+| `checkValidity` | `() => boolean` | Checks validity without showing UI |
+| `showMenu` | `() => void` | Programmatically opens the dropdown |
+| `hideMenu` | `() => void` | Programmatically closes the dropdown |
 
 ## Events (`<sgds-combo-box>`)
 
@@ -185,14 +201,20 @@ For detailed form pattern guidance (when to pair fields, spacing, responsive beh
 | `sgds-focus` | — | Input gains focus |
 | `sgds-blur` | — | Input loses focus |
 | `sgds-scroll-end` | — | Menu scroll position reaches the bottom (within `scrollBottomOffset` pixels) — use to trigger lazy loading |
+| `sgds-invalid` | — | Emitted when `setInvalid(true)` is called |
+| `sgds-valid` | — | Emitted when `setInvalid(false)` is called |
+| `sgds-show` | — | Dropdown menu is about to show |
+| `sgds-after-show` | — | Dropdown menu has finished showing |
+| `sgds-hide` | — | Dropdown menu is about to hide |
+| `sgds-after-hide` | — | Dropdown menu has finished hiding |
 
 ---
 
 **For AI agents**:
-1. For single-select, `element.value` is the selected option's `value`. For multi-select, it is a comma-separated string.
+1. For single-select, `element.value` is the selected option's `value`. For multi-select, it is a semicolon-separated string (`;`).
 2. For async filtering, set `async` (boolean attribute), listen to `sgds-input` for `event.detail.displayValue`, fetch results, then populate `<sgds-combo-box-option>` children.
 3. Use `clearable` to let users reset the selection without form submission.
 4. `filterFunction` must be set as a JS property (`.filterFunction = (input, item) => ...`), not as an HTML attribute.
-5. `<sgds-combo-box>` does **not** have `hasFeedback` or `invalidFeedback` attributes — unlike all other SGDS form components. Validation relies entirely on the browser-native `required` constraint. Do not add these attributes.
+5. `<sgds-combo-box>` supports `hasFeedback` and `invalidFeedback` like other SGDS form components. Set `hasFeedback` to enable validation styling and `invalidFeedback` to display a custom error message.
 6. **Infinite scroll**: set `scrollBottomOffset` (number of pixels) and listen to `sgds-scroll-end` to append more `<sgds-combo-box-option>` elements before the user reaches the end of the list. The event fires once per scroll-to-bottom gesture and resets when the user scrolls back up.
 7. **Boolean attribute handling**: For single-select, omit the `multiSelect` attribute entirely. For multi-select, include `multiSelect` with no value (HTML5 boolean) or `multiSelect="true"`. Do **NOT** use `multiSelect="false"` for single-select — in HTML, any attribute presence (even with value "false") is truthy. Omit the attribute for false.

--- a/src/components/ComboBox/sgds-combo-box.ts
+++ b/src/components/ComboBox/sgds-combo-box.ts
@@ -195,13 +195,7 @@ export class SgdsComboBox extends SelectElement {
 
   @watch("value", { waitUntilFirstUpdate: true })
   async _handleValueChange() {
-    // when value change, always emit a change event
-    this.emit("sgds-change");
     this.options.forEach(o => o.removeAttribute("hidden"));
-
-    if (this.value) {
-      this.emit("sgds-select");
-    }
 
     const sgdsInput = await this._input;
     this._mixinSetFormValue();
@@ -221,6 +215,15 @@ export class SgdsComboBox extends SelectElement {
     if (!this._isTouched && this.value === "") return;
     if (this._mixinShouldSkipSgdsValidation()) return;
     this.invalid = !this._mixinReportValidity();
+  }
+
+  /** Emits sgds-change and sgds-select events. Call after setting this.value from user interaction. */
+  private _emitChangeEvents() {
+    this._mixinSetFormValue();
+    this.emit("sgds-change");
+    if (this.value) {
+      this.emit("sgds-select");
+    }
   }
 
   @watch("optionList", { waitUntilFirstUpdate: true })
@@ -271,6 +274,7 @@ export class SgdsComboBox extends SelectElement {
       this.selectedItems = [];
       this.value = this.selectedItems.join(";");
       this.options.forEach(o => (o.active = false));
+      this._emitChangeEvents();
     }
     // There is a race condition in certain situations where this.optionList is not fully updated during slotchange
     // Hence instead of using this.optionList, we have to perform a query on the <sgds-combo-box-option> elements
@@ -325,6 +329,7 @@ export class SgdsComboBox extends SelectElement {
         this.hideMenu();
       }
     }
+    this._emitChangeEvents();
   }
 
   private _handleItemUnselect(e: Event) {
@@ -341,6 +346,7 @@ export class SgdsComboBox extends SelectElement {
 
     this.selectedItems = this.selectedItems.filter(i => i.value !== foundItem.value);
     this.value = this.selectedItems.map(i => i.value).join(";");
+    this._emitChangeEvents();
   }
 
   private async _handleBadgeDismissed(e: CustomEvent, item: SgdsComboBoxOptionData) {
@@ -349,6 +355,7 @@ export class SgdsComboBox extends SelectElement {
     this.options?.forEach(o => (o.value === removedValue ? (o.active = false) : null));
     this.selectedItems = this.selectedItems.filter(i => i.value !== item.value);
     this.value = this.selectedItems.map(i => i.value).join(";");
+    this._emitChangeEvents();
   }
 
   private async _handleMultiSelectKeyDown(e: KeyboardEvent) {
@@ -363,6 +370,7 @@ export class SgdsComboBox extends SelectElement {
         this.options?.forEach(o => (o.value === removedValue ? (o.active = false) : null));
         this.selectedItems = this.selectedItems.slice(0, -1);
         this.value = this.selectedItems.map(i => i.value).join(";");
+        this._emitChangeEvents();
       }
     }
   }
@@ -395,6 +403,7 @@ export class SgdsComboBox extends SelectElement {
   protected async _handleClear() {
     this.value = this.displayValue = "";
     this.options?.forEach(o => (o.active = false));
+    this._emitChangeEvents();
 
     const sgdsInput = await this._input;
     sgdsInput.focus();

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -171,20 +171,19 @@ describe("sgds-combo-box ", () => {
     expect(el.menuIsOpen).to.be.false;
   });
 
-  it("should emit sgds-select event when combobox value is updated", async () => {
-    const el = await fixture<SgdsComboBox>(html` <sgds-combo-box
-      .menuList=${[
-        { label: "Option 1", value: "option1" },
-        { label: "Option 2", value: "option2" }
-      ]}
-    ></sgds-combo-box>`);
+  it("should emit sgds-select event when combobox option is selected by user", async () => {
+    const el = await fixture<SgdsComboBox>(html` <sgds-combo-box>
+      <sgds-combo-box-option value="option1">Option 1</sgds-combo-box-option>
+      <sgds-combo-box-option value="option2">Option 2</sgds-combo-box-option>
+    </sgds-combo-box>`);
     const selectHandler = sinon.spy();
     el?.addEventListener("sgds-select", selectHandler);
 
     expect(el.value).to.equal("");
-    el.value = "option1";
+    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="option1"]')!;
+    option1.click();
+    await el.updateComplete;
 
-    await waitUntil(() => selectHandler.calledOnce);
     expect(selectHandler).to.have.been.calledOnce;
   });
 
@@ -199,20 +198,19 @@ describe("sgds-combo-box ", () => {
     expect(event.detail).to.deep.equal({ displayValue: "A" });
   });
 
-  it("should emit sgds-change event when combobox value changes", async () => {
-    const el = await fixture<SgdsComboBox>(html` <sgds-combo-box
-      .menuList=${[
-        { label: "Option 1", value: "option1" },
-        { label: "Option 2", value: "option2" }
-      ]}
-    ></sgds-combo-box>`);
+  it("should emit sgds-change event when combobox option is selected by user", async () => {
+    const el = await fixture<SgdsComboBox>(html` <sgds-combo-box>
+      <sgds-combo-box-option value="option1">Option 1</sgds-combo-box-option>
+      <sgds-combo-box-option value="option2">Option 2</sgds-combo-box-option>
+    </sgds-combo-box>`);
     const changeHandler = sinon.spy();
     el?.addEventListener("sgds-change", changeHandler);
 
     expect(el.value).to.equal("");
-    el.value = "option1";
+    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="option1"]')!;
+    option1.click();
+    await el.updateComplete;
 
-    await waitUntil(() => changeHandler.calledOnce);
     expect(changeHandler).to.have.been.calledOnce;
   });
 
@@ -2103,5 +2101,111 @@ describe("sgds-scroll-end event", () => {
     await el.updateComplete;
 
     expect(handler).to.have.been.calledOnce;
+  });
+});
+
+describe("reset does not emit sgds-change for combo-box", () => {
+  it("should not emit sgds-change when form is reset (single select)", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-combo-box value="1">
+          <sgds-combo-box-option value="1">One</sgds-combo-box-option>
+          <sgds-combo-box-option value="2">Two</sgds-combo-box-option>
+        </sgds-combo-box>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const combobox = form.querySelector<SgdsComboBox>("sgds-combo-box")!;
+    await combobox.updateComplete;
+
+    // Select a different option to change value
+    const option2 = combobox.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="2"]')!;
+    option2.click();
+    await combobox.updateComplete;
+    expect(combobox.value).to.equal("2");
+
+    const changeHandler = sinon.spy();
+    combobox.addEventListener("sgds-change", changeHandler);
+
+    // Reset the form
+    const resetButton = form.querySelector<SgdsButton>("sgds-button[type='reset']")!;
+    resetButton.click();
+    await combobox.updateComplete;
+    await waitUntil(() => combobox.value === "1");
+
+    expect(changeHandler).to.not.have.been.called;
+  });
+
+  it("should not emit sgds-change when form is reset (multi select)", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-combo-box value="1" multiSelect>
+          <sgds-combo-box-option value="1">One</sgds-combo-box-option>
+          <sgds-combo-box-option value="2">Two</sgds-combo-box-option>
+          <sgds-combo-box-option value="3">Three</sgds-combo-box-option>
+        </sgds-combo-box>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const combobox = form.querySelector<SgdsComboBox>("sgds-combo-box")!;
+    await combobox.updateComplete;
+
+    // Select an additional option to change value
+    const option2 = combobox.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="2"]')!;
+    option2.click();
+    await combobox.updateComplete;
+    expect(combobox.value).to.equal("1;2");
+
+    const changeHandler = sinon.spy();
+    combobox.addEventListener("sgds-change", changeHandler);
+
+    // Reset the form
+    const resetButton = form.querySelector<SgdsButton>("sgds-button[type='reset']")!;
+    resetButton.click();
+    await combobox.updateComplete;
+    await waitUntil(() => combobox.value === "1");
+
+    expect(changeHandler).to.not.have.been.called;
+  });
+
+  it("should emit sgds-change when user selects option in multi select", async () => {
+    const el = await fixture<SgdsComboBox>(html`
+      <sgds-combo-box multiSelect>
+        <sgds-combo-box-option value="1">One</sgds-combo-box-option>
+        <sgds-combo-box-option value="2">Two</sgds-combo-box-option>
+      </sgds-combo-box>
+    `);
+    await el.updateComplete;
+
+    const changeHandler = sinon.spy();
+    el.addEventListener("sgds-change", changeHandler);
+
+    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="1"]')!;
+    option1.click();
+    await el.updateComplete;
+
+    expect(changeHandler).to.have.been.calledOnce;
+    expect(el.value).to.equal("1");
+  });
+
+  it("should emit sgds-change when user unselects option in multi select", async () => {
+    const el = await fixture<SgdsComboBox>(html`
+      <sgds-combo-box value="1;2" multiSelect>
+        <sgds-combo-box-option value="1">One</sgds-combo-box-option>
+        <sgds-combo-box-option value="2">Two</sgds-combo-box-option>
+      </sgds-combo-box>
+    `);
+    await el.updateComplete;
+
+    const changeHandler = sinon.spy();
+    el.addEventListener("sgds-change", changeHandler);
+
+    // Unselect option 1
+    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="1"]')!;
+    option1.click();
+    await el.updateComplete;
+
+    expect(changeHandler).to.have.been.calledOnce;
+    expect(el.value).to.equal("2");
   });
 });

--- a/test/combo-box.test.ts
+++ b/test/combo-box.test.ts
@@ -2197,11 +2197,14 @@ describe("reset does not emit sgds-change for combo-box", () => {
     `);
     await el.updateComplete;
 
+    // Wait for async initialization to set active on options
+    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="1"]')!;
+    await waitUntil(() => option1.active, "option1 should be active after initialization");
+
     const changeHandler = sinon.spy();
     el.addEventListener("sgds-change", changeHandler);
 
     // Unselect option 1
-    const option1 = el.querySelector<SgdsComboBoxOption>('sgds-combo-box-option[value="1"]')!;
     option1.click();
     await el.updateComplete;
 


### PR DESCRIPTION
  **Summary**
  
**Form reset should not trigger sgds-change** 
                                                                                                                                                                                             
  - Align sgds-change event behavior with native browser change events — emit only on user interaction, not on programmatic value changes or form reset                                    
  - Fix ComboBox which were emitting sgds-change from @watch("value") watchers                                                                                
  - Ensure FormData is synced before sgds-change fires so consumers get correct values in their listeners                                                                                    
  - Add ADR documenting this architectural decision                                                                                                                                          
                                                                                                                                                                                             
  Changes                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                         
  ComboBox: Moved sgds-change and sgds-select from @watch("value") to user interaction handlers via _emitChangeEvents() helper. Updated existing tests that incorrectly tested programmatic  
  value changes.                                                                                                                                                                           
                                                                                                                                                                                             
  ADR: contributing/architecture-decision-record/change-event-user-interaction-only.md                                                                                                       
  
  **Motivation**                                                                                                                                                                                 
                                                                                                                                                                                           
  Custom validation listeners on sgds-change were incorrectly firing during form reset, showing validation errors when the form was being cleared. Root cause: the @watch("value") pattern   
  treats all value changes (user, programmatic, reset) the same. Native inputs and peer libraries (Shoelace) only fire change on user-committed actions.                                   
                                                                                                                                                                                             
  **Test plan**                                                                                                                                                                                  
                                                                                 
  - ComboBox: reset does not emit sgds-change (single + multi select); user interaction emits correctly                                                                                      
  - Existing tests pass (updated two ComboBox tests that relied on programmatic emission)                                                                                                    
                                                                                             
                                                                                             
                                                                                             