### PR TITLE
fix(MainnavItem): prevent reboot.css anchor styles from overriding slotted link colours [skip-cd][run-chromatic]

### DIFF
--- a/src/components/Mainnav/mainnav-item.css
+++ b/src/components/Mainnav/mainnav-item.css
@@ -96,13 +96,13 @@
 
 ::slotted(*) {
   --sgds-link-color-default: var(--sgds-color-default);
+  --sgds-link-color-emphasis: var(--sgds-color-default);
   display: flex;
   cursor: pointer;
   height: auto !important;
   text-decoration: none !important;
   align-items: center;
-  text-decoration: none;
-  color: var(--sgds-link-color-default, var(--sgds-color-default));
+  color: var(--sgds-color-default) !important;
   padding: var(--sgds-padding-sm) var(--sgds-mainnav-mobile-padding-x);
   box-sizing: border-box;
 }
@@ -115,22 +115,36 @@
 
 :host(:not([disabled])[active]) ::slotted(*) {
   --sgds-link-color-default: var(--sgds-primary-color-default);
-  color: var(--sgds-link-color-default, var(--sgds-primary-color-default));
+  --sgds-link-color-emphasis: var(--sgds-primary-color-default);
+  color: var(--sgds-primary-color-default) !important;
+}
+
+:host(:not([disabled]):not([active])) ::slotted(a:hover) {
+  --sgds-link-color-emphasis: var(--sgds-color-default);
+  color: var(--sgds-color-default) !important;
+}
+
+:host(:not([disabled])[active]) ::slotted(a:hover) {
+  --sgds-link-color-emphasis: var(--sgds-primary-color-default);
+  color: var(--sgds-primary-color-default) !important;
 }
 
 :host([disabled]) ::slotted(a:hover) {
   --sgds-link-color-emphasis: var(--sgds-color-default);
-  color: var(--sgds-link-color-emphasis, var(--sgds-color-default));
+  color: var(--sgds-color-default) !important;
 }
 
-:host(:not([disabled])) ::slotted(a:hover) {
-  --sgds-link-color-emphasis: var(--sgds-primary-color-default);
-  color: var(--sgds-link-color-emphasis, var(--sgds-primary-color-default));
+:host(:not([disabled]):not([active])) ::slotted(a:active) {
+  color: var(--sgds-color-default) !important;
+}
+
+:host(:not([disabled])[active]) ::slotted(a:active) {
+  color: var(--sgds-primary-color-default) !important;
 }
 
 ::slotted(a:focus-visible) {
   --sgds-link-color-emphasis: var(--sgds-primary-color-default);
-  color: var(--sgds-link-color-emphasis, var(--sgds-primary-color-default));
+  color: var(--sgds-primary-color-default) !important;
   outline: var(--sgds-outline-focus);
   outline-offset: var(--sgds-outline-offset-focus);
 }


### PR DESCRIPTION
::slotted() has lower cascade priority than document-level styles, so global reboot.css rules (a { color: var(--sgds-link-color-default) } and a:hover { color: var(--sgds-link-color-emphasis) }) bleed through. Use \!important on color declarations and reset both link token custom properties to ensure component intent is preserved.


Link colour appears after clicking a mainnav item
<img width="4064" height="2184" alt="image" src="https://github.com/user-attachments/assets/1089324e-f01c-4d39-946d-86814f9ef162" />




## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
