### PR TITLE
fix(Layout): container sidebar layout to always have gutter 16 to 24px [run-chromatic][skip-cd]

### DIFF
--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -49,25 +49,27 @@ The **SGDS Grid System** is a mobile-first, fully responsive layout system based
 
 ### Standard (`.sgds-container`)
 
+The gutter uses `var(--sgds-gap-layout-md)` across all breakpoints.
+
+| Breakpoint        | Screen Size      | Class Prefix       | Columns | Container Width | Gutters                    | Outer Margins |
+| ----------------- | ---------------- | ------------------ | ------- | --------------- | -------------------------- | ------------- |
+| Extra Small       | 511px and below  | `.sgds-col-*`      | 4       | auto            | `var(--sgds-gap-layout-md)` | 20            |
+| Small             | 512px - 767px    | `.sgds-col-sm-*`   | 8       | auto            | `var(--sgds-gap-layout-md)` | 24            |
+| Medium            | 768px - 1023px   | `.sgds-col-md-*`   | 8       | auto            | `var(--sgds-gap-layout-md)` | 28            |
+| Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | 888px           | `var(--sgds-gap-layout-md)` | auto          |
+| Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | 1168px          | `var(--sgds-gap-layout-md)` | auto          |
+| Extra Extra Large | 1440px and above | `.sgds-col-2-xl-*` | 12      | 1312px          | `var(--sgds-gap-layout-md)` | auto          |
+
+### With Sticky Sidebar (`.sgds-container-sidebar`)
+
+Use for layouts where a sidebar exists alongside the main content area. The gutter is 16px (`--sgds-gap-md`) at smaller breakpoints and 24px (`--sgds-gap-xl`) from medium (768px) onwards.
+
 | Breakpoint        | Screen Size      | Class Prefix       | Columns | Container Width | Gutters | Outer Margins |
 | ----------------- | ---------------- | ------------------ | ------- | --------------- | ------- | ------------- |
 | Extra Small       | 511px and below  | `.sgds-col-*`      | 4       | auto            | 16      | 20            |
 | Small             | 512px - 767px    | `.sgds-col-sm-*`   | 8       | auto            | 16      | 24            |
-| Medium            | 768px - 1023px   | `.sgds-col-md-*`   | 8       | auto            | 24      | 28            |
-| Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | 888px           | 24      | auto          |
-| Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | 1168px          | 32      | auto          |
-| Extra Extra Large | 1440px and above | `.sgds-col-2-xl-*` | 12      | 1312px          | 32      | auto          |
-
-### With Sticky Sidebar (`.sgds-container-sidebar`)
-
-Use for layouts where a sidebar exists alongside the main content area. The gutter is always 24px (`--sgds-gap-xl`) regardless of breakpoint.
-
-| Breakpoint        | Screen Size      | Class Prefix       | Columns | Container Width        | Gutters | Outer Margins |
-| ----------------- | ---------------- | ------------------ | ------- | ---------------------- | ------- | ------------- |
-| Extra Small       | 511px and below  | `.sgds-col-*`      | 4       | auto                   | 24      | 20            |
-| Small             | 512px - 767px    | `.sgds-col-sm-*`   | 8       | auto                   | 24      | 24            |
-| Medium            | 768px - 1023px   | `.sgds-col-md-*`   | 8       | calc(100% - 96px)      | 24      | 48            |
-| Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | calc(100% - 96px)      | 24      | 48            |
-| Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | calc(100% - 96px)      | 24      | 48            |
-| Extra Extra Large | 1440px - 1679px  | `.sgds-col-2-xl-*` | 12      | calc(100% - 96px)      | 24      | 48            |
-| 3-XL              | 1680px and above | `.sgds-col-3-xl-*` | 12      | 1296px                 | 24      | auto          |
+| Medium            | 768px - 1023px   | `.sgds-col-md-*`   | 8       | auto            | 24      | 48            |
+| Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | auto            | 24      | 48            |
+| Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | auto            | 24      | 48            |
+| Extra Extra Large | 1440px - 1679px  | `.sgds-col-2-xl-*` | 12      | auto            | 24      | 48            |
+| 3-XL              | 1680px and above | `.sgds-col-3-xl-*` | 12      | 1296px          | 24      | auto          |

--- a/docs/Grid.md
+++ b/docs/Grid.md
@@ -47,6 +47,8 @@ The **SGDS Grid System** is a mobile-first, fully responsive layout system based
 
 ## Grid Breakpoints
 
+### Standard (`.sgds-container`)
+
 | Breakpoint        | Screen Size      | Class Prefix       | Columns | Container Width | Gutters | Outer Margins |
 | ----------------- | ---------------- | ------------------ | ------- | --------------- | ------- | ------------- |
 | Extra Small       | 511px and below  | `.sgds-col-*`      | 4       | auto            | 16      | 20            |
@@ -55,4 +57,17 @@ The **SGDS Grid System** is a mobile-first, fully responsive layout system based
 | Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | 888px           | 24      | auto          |
 | Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | 1168px          | 32      | auto          |
 | Extra Extra Large | 1440px and above | `.sgds-col-2-xl-*` | 12      | 1312px          | 32      | auto          |
-| 3-XL (sidebar only) | 1680px and above | `.sgds-col-3-xl-*` | 12      | 1296px          | 32      | auto          |
+
+### With Sticky Sidebar (`.sgds-container-sidebar`)
+
+Use for layouts where a sidebar exists alongside the main content area. The gutter is always 24px (`--sgds-gap-xl`) regardless of breakpoint.
+
+| Breakpoint        | Screen Size      | Class Prefix       | Columns | Container Width        | Gutters | Outer Margins |
+| ----------------- | ---------------- | ------------------ | ------- | ---------------------- | ------- | ------------- |
+| Extra Small       | 511px and below  | `.sgds-col-*`      | 4       | auto                   | 24      | 20            |
+| Small             | 512px - 767px    | `.sgds-col-sm-*`   | 8       | auto                   | 24      | 24            |
+| Medium            | 768px - 1023px   | `.sgds-col-md-*`   | 8       | calc(100% - 96px)      | 24      | 48            |
+| Large             | 1024px - 1279px  | `.sgds-col-lg-*`   | 12      | calc(100% - 96px)      | 24      | 48            |
+| Extra Large       | 1280px - 1439px  | `.sgds-col-xl-*`   | 12      | calc(100% - 96px)      | 24      | 48            |
+| Extra Extra Large | 1440px - 1679px  | `.sgds-col-2-xl-*` | 12      | calc(100% - 96px)      | 24      | 48            |
+| 3-XL              | 1680px and above | `.sgds-col-3-xl-*` | 12      | 1296px                 | 24      | auto          |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@ Install SGDS web components locally with the following command
 
 ```js
 
-npm install @govtechsg/sgds-web-component@3.22.1
+npm install @govtechsg/sgds-web-component@3.23.0
 
 ```
 
@@ -53,14 +53,14 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 
 ```js
 // Load global css file
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/themes/day.css' rel='stylesheet' type='text/css' />
-<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/css/sgds.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.23.0/themes/day.css' rel='stylesheet' type='text/css' />
+<link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.23.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1" async crossorigin="anonymous" integrity="sha384-mW5uJNL4Tu4KJJN/xR74d+08lRv9sJ/hUO26+AOB7XSpBqJ+ChvHVngDeyk+fHB7"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.23.0" async crossorigin="anonymous" integrity="sha384-2tlFut86o+vNS8140BJakqwFeUyOyKdm8FOiiX6Q8J7/JMYsffSnyZ1h4tqYg4rH"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.22.1/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.23.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
 
 ```
 

--- a/playground/layouts/layout-sidebar-aside-left.html
+++ b/playground/layouts/layout-sidebar-aside-left.html
@@ -109,14 +109,11 @@
     <!-- MAIN CONTENT -->
     <main class="sgds:flex sgds:flex-col sgds:w-full sgds:min-h-[calc(100vh-108px)]" id="main-content" tabindex="-1">
       <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-        <div class="sgds-grid" style="gap: var(--sgds-gap-layout-md); align-items: stretch;">
-
+        <div class="sgds-grid">
           <!-- ASIDE — 4 cols -->
           <aside class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-4"></aside>
-
           <!-- CONTENT — 8 cols -->
-          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-8 sgds-col-sm-8 sgds-col-lg-8"></div>
-
+          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-8"></div>
         </div>
       </div>
 

--- a/playground/layouts/layout-sidebar-aside-right.html
+++ b/playground/layouts/layout-sidebar-aside-right.html
@@ -109,14 +109,11 @@
     <!-- MAIN CONTENT -->
     <main class="sgds:flex sgds:flex-col sgds:w-full sgds:min-h-[calc(100vh-108px)]" id="main-content" tabindex="-1">
       <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-        <div class="sgds-grid" style="gap: var(--sgds-gap-layout-md); align-items: stretch;">
-
+        <div class="sgds-grid">
           <!-- CONTENT — 8 cols -->
-          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-8 sgds-col-sm-8 sgds-col-lg-8"></div>
-
+          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-8"></div>
           <!-- ASIDE — 4 cols -->
           <aside class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-4"></aside>
-
         </div>
       </div>
 

--- a/playground/layouts/layout-sidebar-split.html
+++ b/playground/layouts/layout-sidebar-split.html
@@ -109,13 +109,10 @@
     <!-- MAIN CONTENT -->
     <main class="sgds:flex sgds:flex-col sgds:w-full sgds:min-h-[calc(100vh-108px)]" id="main-content" tabindex="-1">
       <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-
-        <!-- SPLIT PANES -->
-        <div class="sgds:flex sgds:gap-layout-md">
-          <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
-          <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
+        <div class="sgds-grid">
+          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-6"></div>
+          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-6"></div>
         </div>
-
       </div>
 
       <!-- Footer -->

--- a/playground/layouts/layout-sidebar.html
+++ b/playground/layouts/layout-sidebar.html
@@ -107,7 +107,9 @@
     <!-- MAIN CONTENT -->
     <main class="sgds:flex sgds:flex-col sgds:w-full sgds:min-h-[calc(100vh-108px)]" id="main-content" tabindex="-1">
       <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-        <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
+        <div class="sgds-grid">
+          <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-12"></div>
+        </div>
       </div>
 
       <!-- Footer -->

--- a/skills/sgds-layouts/reference/with-sidebar.md
+++ b/skills/sgds-layouts/reference/with-sidebar.md
@@ -6,14 +6,15 @@ With Sidebar layouts are for dashboards, internal tools, admin portals, and tran
 
 | Breakpoint | `.sgds-container-sidebar` max-width |
 |---|---|
-| < 768px | `100%` |
-| >= 768px (md) | `calc(100% - 96px)` |
-| >= 1024px (lg) | `calc(100% - 96px)` |
-| >= 1280px (xl) | `calc(100% - 96px)` |
-| >= 1440px (2xl) | `calc(100% - 96px)` |
+| < 512px | `calc(100% - 40px)` |
+| >= 512px (sm) | `calc(100% - 48px)` |
+| >= 768px (md) | `auto` (48px margins) |
+| >= 1024px (lg) | `auto` (48px margins) |
+| >= 1280px (xl) | `auto` (48px margins) |
+| >= 1440px (2xl) | `auto` (48px margins) |
 | >= 1680px (3xl) | `1296px` |
 
-**Grid gutter:** `.sgds-grid` inside `.sgds-container-sidebar` always uses `var(--sgds-gap-xl)` (24px) regardless of breakpoint. No gap utility class is needed.
+**Grid gutter:** `.sgds-grid` inside `.sgds-container-sidebar` uses `var(--sgds-gap-md)` (16px) at XS/SM and `var(--sgds-gap-xl)` (24px) from MD (768px) onwards. No gap utility class is needed.
 
 ## Common Structure
 

--- a/skills/sgds-layouts/reference/with-sidebar.md
+++ b/skills/sgds-layouts/reference/with-sidebar.md
@@ -8,9 +8,12 @@ With Sidebar layouts are for dashboards, internal tools, admin portals, and tran
 |---|---|
 | < 768px | `100%` |
 | >= 768px (md) | `calc(100% - 96px)` |
-| >= 1024px (lg) | `840px` |
-| >= 1280px (xl) | `888px` |
-| >= 1440px (2xl) | `1024px` |
+| >= 1024px (lg) | `calc(100% - 96px)` |
+| >= 1280px (xl) | `calc(100% - 96px)` |
+| >= 1440px (2xl) | `calc(100% - 96px)` |
+| >= 1680px (3xl) | `1296px` |
+
+**Grid gutter:** `.sgds-grid` inside `.sgds-container-sidebar` always uses `var(--sgds-gap-xl)` (24px) regardless of breakpoint. No gap utility class is needed.
 
 ## Common Structure
 
@@ -28,7 +31,9 @@ All With Sidebar layouts share this viewport-contained structure:
     <sgds-sidebar>...</sgds-sidebar>
     <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
       <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-        <!-- Content goes here -->
+        <div class="sgds-grid">
+          <!-- Content goes here using sgds-col-* classes -->
+        </div>
       </div>
       <sgds-footer tone="neutral" layout="sidebar"></sgds-footer>
     </div>
@@ -47,7 +52,7 @@ All With Sidebar layouts share this viewport-contained structure:
 
 ## Default
 
-Basic sidebar layout with a single content area.
+Basic sidebar layout with a single full-width content area. Uses `.sgds-grid` with a 12-column span.
 
 ```
 +----------------------------------------------+
@@ -55,14 +60,16 @@ Basic sidebar layout with a single content area.
 +----------------------------------------------+
 | sgds-mainnav (fluid)                         |
 +----------+-----------------------------------+
-|          |                                   |
-| sgds-    |  .sgds-container-sidebar          |
-| sidebar  |  [  main content area  ]          |
+|          |  .sgds-container-sidebar           |
+| sgds-    |  .sgds-grid                        |
+| sidebar  |  [  main content col-12  ]         |
 |          |                                   |
 |          +-----------------------------------+
 |          | sgds-footer (neutral, sidebar)    |
 +----------+-----------------------------------+
 ```
+
+Grid classes: `sgds-col-4 sgds-col-sm-8 sgds-col-lg-12` (full width at all breakpoints)
 
 ### Raw Content Link
 
@@ -134,7 +141,7 @@ Grid classes: `sgds-col-8 sgds-col-sm-8 sgds-col-lg-8` (main) + `sgds-col-4 sgds
 
 ## Overlay
 
-Collapsible overlay sidebar with a breadcrumb bar and toggle button. The sidebar uses `variant="overlay"` and sits above the content rather than beside it.
+Collapsible overlay sidebar with a breadcrumb bar and toggle button. The sidebar uses `variant="overlay"` and sits above the content rather than beside it. Uses `.sgds-grid` with a 12-column span.
 
 ```
 +----------------------------------------------+
@@ -145,18 +152,21 @@ Collapsible overlay sidebar with a breadcrumb bar and toggle button. The sidebar
 | [toggle] breadcrumb bar (border-b)           |
 +----------------------------------------------+
 |  (overlay)  |                                |
-|  sgds-      |  .sgds-container               |
-|  sidebar    |  [  main content area  ]       |
+|  sgds-      |  .sgds-container-sidebar        |
+|  sidebar    |  .sgds-grid                     |
+|             |  [  main content col-12  ]      |
 |             |                                |
 |             +--------------------------------+
 |             | sgds-footer (neutral)          |
 +-------------+--------------------------------+
 ```
 
+Grid classes: `sgds-col-4 sgds-col-sm-8 sgds-col-lg-12` (full width at all breakpoints)
+
 **Key differences from other sidebar layouts:**
 - Sidebar uses `variant="overlay"` and `scrim` attribute
 - Breadcrumb bar includes an `<sgds-icon-button>` toggler with `data-sidebar-toggler="true"`
-- Content uses `.sgds-container` (not `.sgds-container-sidebar`) since the sidebar overlays
+- Content uses `.sgds-container-sidebar` with `.sgds-grid` for consistent grid gutter
 - Footer uses `tone="neutral"` without `layout="sidebar"`
 - Root wrapper includes `sgds:relative` for overlay positioning
 
@@ -170,7 +180,7 @@ Collapsible overlay sidebar with a breadcrumb bar and toggle button. The sidebar
 
 ## Split
 
-Sidebar layout with two equal content panels side by side.
+Sidebar layout with two equal content panels side by side. Uses `.sgds-grid` with a 6/6 column split.
 
 ```
 +----------------------------------------------+
@@ -179,16 +189,17 @@ Sidebar layout with two equal content panels side by side.
 | sgds-mainnav (fluid)                         |
 +----------+-----------------------------------+
 |          |  .sgds-container-sidebar           |
-| sgds-    |  +-------------+------------+     |
-| sidebar  |  |   panel 1   |  panel 2   |     |
-|          |  |   flex-1    |  flex-1    |     |
+| sgds-    |  .sgds-grid                        |
+| sidebar  |  +-------------+------------+     |
+|          |  |   panel 1   |  panel 2   |     |
+|          |  |   col-6     |  col-6     |     |
 |          |  +-------------+------------+     |
 |          +-----------------------------------+
 |          | sgds-footer (neutral, sidebar)    |
 +----------+-----------------------------------+
 ```
 
-Uses `sgds:flex sgds:gap-layout-md` with two `sgds:flex-1` children inside `.sgds-container-sidebar`.
+Grid classes: `sgds-col-4 sgds-col-sm-8 sgds-col-lg-6` (each panel stacks full-width on XS/SM, splits 6-6 on LG+)
 
 ### Raw Content Link
 

--- a/skills/sgds-utilities/reference/grid.md
+++ b/skills/sgds-utilities/reference/grid.md
@@ -35,13 +35,13 @@ The grid expands from 4 columns (mobile) → 8 columns (small/medium) → 12 col
 
 | Breakpoint | Min width | Class prefix | Columns | Gutter |
 |------------|-----------|--------------|---------|--------|
-| Extra Small (default) | — | `.sgds-col-*` | 4 | 16px |
-| Small | 512px | `.sgds-col-sm-*` | 8 | 16px |
-| Medium | 768px | `.sgds-col-md-*` | 8 | 24px |
-| Large | 1024px | `.sgds-col-lg-*` | 12 | 24px |
-| Extra Large | 1280px | `.sgds-col-xl-*` | 12 | 32px |
-| Extra Extra Large | 1440px | `.sgds-col-2-xl-*` | 12 | 32px |
-| 3-XL (sidebar only) | 1680px | `.sgds-col-3-xl-*` | 12 | 32px |
+| Extra Small (default) | — | `.sgds-col-*` | 4 | `var(--sgds-gap-layout-md)` |
+| Small | 512px | `.sgds-col-sm-*` | 8 | `var(--sgds-gap-layout-md)` |
+| Medium | 768px | `.sgds-col-md-*` | 8 | `var(--sgds-gap-layout-md)` |
+| Large | 1024px | `.sgds-col-lg-*` | 12 | `var(--sgds-gap-layout-md)` |
+| Extra Large | 1280px | `.sgds-col-xl-*` | 12 | `var(--sgds-gap-layout-md)` |
+| Extra Extra Large | 1440px | `.sgds-col-2-xl-*` | 12 | `var(--sgds-gap-layout-md)` |
+| 3-XL (sidebar only) | 1680px | `.sgds-col-3-xl-*` | 12 | `var(--sgds-gap-layout-md)` |
 
 Classes are mobile-first additive — define the XS span first, then override at larger breakpoints.
 
@@ -90,12 +90,16 @@ Use for every page that does **not** have a persistent sidebar.
 
 Use when content sits alongside a sticky sidebar (i.e. the Sidebar App Layout from the [Application Shell](../../sgds-blocks/reference/application-shell.md)). Narrower max-widths preserve readable line lengths.
 
+The gutter is 16px (`--sgds-gap-md`) at XS/SM and 24px (`--sgds-gap-xl`) from MD onwards.
+
 | Breakpoint | Max width |
 |------------|-----------|
-| MD (768px+) | `calc(100% - 96px)` — 48px margins |
-| LG (1024px+) | 840px |
-| XL (1280px+) | 888px |
-| 2-XL (1440px+) | 1024px |
+| XS (default) | `calc(100% - 40px)` — 20px margins |
+| SM (512px+) | `calc(100% - 48px)` — 24px margins |
+| MD (768px+) | auto — 48px margins |
+| LG (1024px+) | auto — 48px margins |
+| XL (1280px+) | auto — 48px margins |
+| 2-XL (1440px+) | auto — 48px margins |
 | 3-XL (1680px+) | 1296px |
 
 ### Sidebar Behaviour

--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -13,12 +13,12 @@
 }
 
 .sgds-container-sidebar .sgds-grid {
-  gap: var(--sgds-gap-xl);
+  gap: var(--sgds-gap-md);
 }
 
 .sgds-grid {
   display: grid;
-  gap: var(--sgds-gap-md);
+  gap: var(--sgds-gap-layout-md);
   grid-template-columns: repeat(4, 1fr);
 }
 
@@ -57,14 +57,12 @@
   .sgds-container {
     max-width: calc(100% - 56px); /* outer margin of 28px on each side */
   }
-    .sgds-container-sidebar {
+  .sgds-container-sidebar {
     max-width: calc(100% - 96px); /* outer margin of 48px on each side */
   }
-
-  .sgds-grid {
+  .sgds-container-sidebar .sgds-grid {
     gap: var(--sgds-gap-xl);
   }
-
   .sgds-col-md-1 { grid-column: span 1; }
   .sgds-col-md-2 { grid-column: span 2; }
   .sgds-col-md-3 { grid-column: span 3; }
@@ -115,10 +113,6 @@
 }
 
 @media (min-width: 1280px) {  /* sgds-breakpoint-xl */
-  .sgds-grid {
-    gap: var(--sgds-gap-2-xl);
-  }
-
   .sgds-container {
     max-width: var(--sgds-dimension-1168);
   }

--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -12,6 +12,10 @@
   max-width: calc(100% - 40px); /* outer margin of 20px on each side. Expects sidebar to be overlayed */
 }
 
+.sgds-container-sidebar .sgds-grid {
+  gap: var(--sgds-gap-xl);
+}
+
 .sgds-grid {
   display: grid;
   gap: var(--sgds-gap-md);

--- a/stories/layouts/WithSidebar/Sidebar.stories.js
+++ b/stories/layouts/WithSidebar/Sidebar.stories.js
@@ -92,7 +92,11 @@ const Template = () => html`
       ${sidebarNav}
       <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
         <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-          <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
+          <div class="sgds-grid">
+            <div
+              class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-12"
+            ></div>
+          </div>
         </div>
         <sgds-footer tone="neutral" layout="sidebar"></sgds-footer>
       </div>

--- a/stories/layouts/WithSidebar/SidebarAsideLeft.stories.js
+++ b/stories/layouts/WithSidebar/SidebarAsideLeft.stories.js
@@ -92,11 +92,11 @@ const Template = () => html`
       ${sidebarNav}
       <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
         <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-          <div class="sgds-grid sgds:gap-layout-md sgds:items-stretch">
+          <div class="sgds-grid">
             <aside
               class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-4"
             ></aside>
-            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-8 sgds-col-sm-8 sgds-col-lg-8"></div>
+            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-8"></div>
           </div>
         </div>
         <sgds-footer tone="neutral" layout="sidebar"></sgds-footer>

--- a/stories/layouts/WithSidebar/SidebarAsideRight.stories.js
+++ b/stories/layouts/WithSidebar/SidebarAsideRight.stories.js
@@ -92,8 +92,8 @@ const Template = () => html`
       ${sidebarNav}
       <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
         <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-          <div class="sgds-grid sgds:gap-layout-md sgds:items-stretch">
-            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-8 sgds-col-sm-8 sgds-col-lg-8"></div>
+          <div class="sgds-grid">
+            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-8"></div>
             <aside
               class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-4"
             ></aside>

--- a/stories/layouts/WithSidebar/SidebarOverlay.stories.js
+++ b/stories/layouts/WithSidebar/SidebarOverlay.stories.js
@@ -88,8 +88,12 @@ const Template = () => html`
     <div class="sgds:flex sgds:flex-row sgds:flex-1 sgds:overflow-hidden sgds:relative">
       ${sidebarNav}
       <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
-        <div class="sgds-container sgds:py-layout-md sgds:flex-1">
-          <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
+        <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
+          <div class="sgds-grid">
+            <div
+              class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-12"
+            ></div>
+          </div>
         </div>
         <sgds-footer tone="neutral"></sgds-footer>
       </div>

--- a/stories/layouts/WithSidebar/SidebarSplit.stories.js
+++ b/stories/layouts/WithSidebar/SidebarSplit.stories.js
@@ -92,9 +92,9 @@ const Template = () => html`
       ${sidebarNav}
       <div class="sgds:flex sgds:flex-col sgds:flex-1 sgds:overflow-y-auto">
         <div class="sgds-container-sidebar sgds:py-layout-md sgds:flex-1">
-          <div class="sgds:flex sgds:gap-layout-md">
-            <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
-            <div class="content-placeholder sgds:border sgds:border-muted sgds:flex-1"></div>
+          <div class="sgds-grid">
+            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-6"></div>
+            <div class="content-placeholder sgds:border sgds:border-muted sgds-col-4 sgds-col-sm-8 sgds-col-lg-6"></div>
           </div>
         </div>
         <sgds-footer tone="neutral" layout="sidebar"></sgds-footer>


### PR DESCRIPTION
## :open_book: Description

  Summary                                                                                              
                                                                                                         
  - Fix grid gutter in sgds-container-sidebar layouts to always use 24px (--sgds-gap-md) at mobile,    
  scaling to --sgds-gap-xl at tablet+ — previously it incorrectly inherited the general grid's           
  progressive gutter values (--sgds-gap-layout-md → --sgds-gap-2-xl)
  - Separate the general .sgds-grid gutter (uses layout gap tokens that scale with breakpoints) from the 
  sidebar-specific .sgds-container-sidebar .sgds-grid gutter (fixed 24px at mobile, 48px at tablet+)     
  - Update documentation, playground demos, Storybook stories, and skill references to use sgds-grid     
  gutter classes consistently    


Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
