### PR TITLE
chore(accordion-item): remove mouse focus state [skip-cd][run-chromatic]

### DIFF
--- a/src/components/Accordion/accordion-item.css
+++ b/src/components/Accordion/accordion-item.css
@@ -61,16 +61,10 @@
   background-color: var(--sgds-bg-translucent-subtle);
 }
 
-.accordion-btn:not(.disabled):focus,
 .accordion-btn:not(.disabled):focus-visible,
-.accordion-btn:not(:disabled):focus,
 .accordion-btn:not(:disabled):focus-visible {
   z-index: 3;
   background-color: var(--sgds-bg-translucent-subtle);
-}
-
-.accordion-btn:not(.disabled):focus-visible,
-.accordion-btn:not(:disabled):focus-visible {
   outline: var(--sgds-outline-focus);
   outline-offset: var(--sgds-outline-offset-focus);
 }
@@ -86,8 +80,8 @@ slot[name="badge"]::slotted(*) {
 }
 
 .accordion-header__trailing {
-  margin-left:auto;
-  display:flex;
+  margin-left: auto;
+  display: flex;
   gap: var(--sgds-gap-md);
 }
 


### PR DESCRIPTION
## :open_book: Description

remove the mouse click focus state of the accordion item

Enhancement #764 

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
