### PR TITLE
feat(QuantityToggle): custom validation support with noValidate [skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,7 +57,7 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.25.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.25.0" async crossorigin="anonymous" integrity="sha384-x5qlUVAYsIZ0q9x2kTVI3nCV02+87rJQKPhwO5ozY2doiALsB87lWqq96sTqHqXb"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.25.0" async crossorigin="anonymous" integrity="sha384-QREDaTjaMf9Z6P7a6861QJYZ8uqEpPe9Ej49SGDpVlhBbdYmmhAImQY0NDbYQGkm"></script>
 
 //or load a single component e.g. Masthead
 <script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.25.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>

--- a/playground/Form.html
+++ b/playground/Form.html
@@ -145,3 +145,45 @@
     <sgds-button type="reset" variant="ghost">Reset</sgds-button>
   </div>
 </form>
+
+<h2>Custom Validation (noValidate)</h2>
+<form id="custom-validation-form">
+  <sgds-quantity-toggle
+    noValidate
+    hasFeedback="both"
+    label="Quantity"
+    hintText="Custom validation: value must be a multiple of 5"
+    id="custom-qt"
+    step="1"
+  ></sgds-quantity-toggle>
+  <div class="d-flex gap-2">
+    <sgds-button type="submit">Submit</sgds-button>
+    <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+  </div>
+</form>
+<script>
+  const customQt = document.querySelector("#custom-qt");
+  const customForm = document.querySelector("#custom-validation-form");
+  customQt.addEventListener("sgds-change", e => {
+    if (e.target.value === 0) {
+      e.target.setInvalid(false);
+      return;
+    }
+    if (e.target.value % 5 !== 0) {
+      e.target.setInvalid(true);
+      e.target.invalidFeedback = "Value must be a multiple of 5";
+    } else {
+      e.target.setInvalid(false);
+    }
+  });
+  customForm.addEventListener("submit", e => {
+    e.preventDefault();
+    if (customQt.value === 0) {
+      customQt.setInvalid(true);
+      customQt.invalidFeedback = "Please enter a quantity";
+      return;
+    }
+    if (customQt.invalid) return;
+    alert("Submitted: " + customQt.value);
+  });
+</script>

--- a/playground/QuantityToggle.html
+++ b/playground/QuantityToggle.html
@@ -50,6 +50,48 @@
           <sgds-button type="submit">Submit</sgds-button>
         </form>
       </div>
+
+      <div>
+        <h2>Custom Validation (noValidate)</h2>
+        <form id="custom-validation-form">
+          <sgds-quantity-toggle
+            noValidate
+            hasFeedback="both"
+            label="Quantity (must be multiple of 5)"
+            id="custom-qt"
+            step="1"
+          ></sgds-quantity-toggle>
+          <br />
+          <sgds-button type="submit">Submit</sgds-button>
+          <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+        </form>
+        <script>
+          const customQt = document.querySelector("#custom-qt");
+          const customForm = document.querySelector("#custom-validation-form");
+          customQt.addEventListener("sgds-change", e => {
+            if (e.target.value === 0) {
+              e.target.setInvalid(false);
+              return;
+            }
+            if (e.target.value % 5 !== 0) {
+              e.target.setInvalid(true);
+              e.target.invalidFeedback = "Value must be a multiple of 5";
+            } else {
+              e.target.setInvalid(false);
+            }
+          });
+          customForm.addEventListener("submit", e => {
+            e.preventDefault();
+            if (customQt.value === 0) {
+              customQt.setInvalid(true);
+              customQt.invalidFeedback = "Please enter a quantity";
+              return;
+            }
+            if (customQt.invalid) return;
+            alert("Submitted: " + customQt.value);
+          });
+        </script>
+      </div>
     </div>
   </body>
 </html>

--- a/skills/sgds-components/reference/quantity-toggle.md
+++ b/skills/sgds-components/reference/quantity-toggle.md
@@ -28,12 +28,15 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - `disabled` disables the entire control — both buttons and the input.
 - `hasFeedback` controls validation UI: `"style"` (border colour only), `"text"` (message only), `"both"` (border + message). Pair with `invalidFeedback`.
 - `invalid` manually sets the invalid state without relying on browser constraint validation.
+- `noValidate` disables SGDS's built-in constraint validation — use with `setInvalid()` for fully custom validation logic.
 - `hintText` and the error message occupy the same space below the toggle — when the field is invalid, `hintText` is replaced by the error message. Once the error is resolved, `hintText` reappears.
 - Fires `sgds-change` after a button click or committed keyboard input, and `sgds-input` on each input event.
+- Fires `sgds-invalid` when `setInvalid(true)` is called, and `sgds-valid` when `setInvalid(false)` is called.
 
 ## Advanced Considerations
 
 - **`step` with `min`/`max`**: if `step` does not evenly divide the range between `min` and `max`, the last increment may overshoot `max` — the component clamps the value at `max`.
+- **Custom validation with `noValidate`**: set `noValidate` on the component (or `novalidate` on the `<form>`), listen to `sgds-change`, and call `setInvalid(true/false)` with a dynamic `invalidFeedback` message. This gives full control over when and why the component is marked invalid.
 - **Manual invalid state**: use `invalid` to programmatically reflect server-side validation errors or cross-field validation results without triggering browser constraint validation.
 - **`size`**: matches the size scale of `<sgds-input>` — use to align the toggle visually with adjacent form fields.
 - **`readonly` vs `disabled`**: `readonly` preserves the value in form submission and keeps the input visible but non-editable; `disabled` excludes the field from form submission entirely.
@@ -107,6 +110,45 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
     console.log("New quantity:", document.getElementById("qty").value);
   });
 </script>
+
+<!-- Custom validation with noValidate -->
+<form id="custom-form">
+  <sgds-quantity-toggle
+    noValidate
+    hasFeedback="both"
+    label="Quantity"
+    hintText="Value must be a multiple of 5"
+    id="custom-qt"
+  ></sgds-quantity-toggle>
+  <sgds-button type="submit">Submit</sgds-button>
+  <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+</form>
+<script>
+  const qt = document.getElementById("custom-qt");
+  const form = document.getElementById("custom-form");
+  qt.addEventListener("sgds-change", e => {
+    if (e.target.value === 0) {
+      e.target.setInvalid(false);
+      return;
+    }
+    if (e.target.value % 5 !== 0) {
+      e.target.setInvalid(true);
+      e.target.invalidFeedback = "Value must be a multiple of 5";
+    } else {
+      e.target.setInvalid(false);
+    }
+  });
+  form.addEventListener("submit", e => {
+    e.preventDefault();
+    if (qt.value === 0) {
+      qt.setInvalid(true);
+      qt.invalidFeedback = "Please enter a quantity";
+      return;
+    }
+    if (qt.invalid) return;
+    alert("Submitted: " + qt.value);
+  });
+</script>
 ```
 
 ## API Summary
@@ -126,6 +168,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `disabled` | boolean | `false` | Disables the control |
 | `readonly` | boolean | `false` | Makes the value read-only (hides +/− buttons is false — they are still shown but the input becomes non-editable) |
 | `invalid` | boolean | `false` | Manually sets the invalid state |
+| `noValidate` | boolean | `false` | Disables built-in constraint validation; use `setInvalid()` for custom logic |
 | `hasFeedback` | `style \| text \| both` | — | Controls validation UI feedback |
 | `invalidFeedback` | string | — | Error message when value is invalid |
 
@@ -135,6 +178,16 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 |---|---|
 | `sgds-change` | Value changes after a button click or keyboard input |
 | `sgds-input` | Value changes on each input event |
+| `sgds-invalid` | `setInvalid(true)` is called |
+| `sgds-valid` | `setInvalid(false)` is called |
+
+## Methods
+
+| Method | Description |
+|---|---|
+| `setInvalid(bool)` | Programmatically sets or clears the invalid state; emits `sgds-invalid` or `sgds-valid` |
+| `checkValidity()` | Returns validity without showing feedback |
+| `reportValidity()` | Returns validity and displays feedback |
 
 ---
 
@@ -142,4 +195,5 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 1. Button clicks increment/decrement by `step`; direct input allows custom values.
 2. When `min` is set, the minus (−) button is disabled at the minimum value; similarly for `max` and the plus (+) button.
 3. Read `element.value` (a number) after `sgds-change` to get the current count.
-4. There are no public methods on this component.
+4. For custom validation: set `noValidate`, listen to `sgds-change`, call `setInvalid(true/false)` and set `invalidFeedback` dynamically.
+5. Form reset always clears the invalid state regardless of `noValidate`.

--- a/skills/sgds-forms/SKILL.md
+++ b/skills/sgds-forms/SKILL.md
@@ -26,7 +26,7 @@ All form components must be placed inside a `<form>` element and given a `name` 
 
 **Read submitted field values?** → Use `new FormData(event.target)` in the submit handler
 
-**Disable SGDS validation per component?** → `noValidate` prop on `<sgds-input>`, `<sgds-textarea>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-datepicker>`, or `<sgds-file-upload>`
+**Disable SGDS validation per component?** → `noValidate` prop on `<sgds-input>`, `<sgds-textarea>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-datepicker>`, `<sgds-quantity-toggle>`, or `<sgds-file-upload>`
 
 **Disable SGDS validation for the whole form?** → `novalidate` on the `<form>` element
 
@@ -155,7 +155,7 @@ For 3rd-party validation libraries (e.g. Zod) or fully custom logic, disable SGD
 
 ### Option 1 — Disable per component with `noValidate`
 
-Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`**, **`<sgds-datepicker>`**, **`<sgds-file-upload>`**, **`<sgds-select>`**, and **`<sgds-radio-group>`, **`<sgds-checkbox>`**, and **`<sgds-checkbox-group>`**. Other components are WIP.
+Currently supported on **`<sgds-input>`**, **`<sgds-textarea>`**, **`<sgds-combo-box>`**, **`<sgds-datepicker>`**, **`<sgds-file-upload>`**, **`<sgds-select>`**, **`<sgds-quantity-toggle>`**, **`<sgds-radio-group>`**, **`<sgds-checkbox>`**, and **`<sgds-checkbox-group>`**.
 
 ```html
 <sgds-input
@@ -229,7 +229,7 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 | `<sgds-textarea>`                           | ✅ Implemented |
 | `<sgds-datepicker>`                         | ✅ Implemented |
 | `<sgds-checkbox>` / `<sgds-checkbox-group>` | ✅ Implemented |
-| `<sgds-quantity-toggle>`                    | WIP            |
+| `<sgds-quantity-toggle>`                    | ✅ Implemented |
 | `<sgds-radio-group>`                        | ✅ Implemented |
 | `<sgds-file-upload>`                        | ✅ Implemented |
 | `<sgds-select>`                             | ✅ Implemented |
@@ -245,7 +245,7 @@ Pair `setInvalid(true)` with setting the `invalidFeedback` property on the eleme
 4. Use `invalidFeedback` to override the browser's native constraint validation message with a custom string.
 5. Constraint validation and form submission blocking are built-in — do not add extra submit event listeners to replicate this behaviour.
 6. Use `new FormData(event.target)` in the submit handler to read values. For file uploads, read `selectedFiles` directly from the `<sgds-file-upload>` element.
-7. When using custom/3rd-party validation, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker, `sgds-change` for select/combo-box/radio-group/checkbox-group, `sgds-add-files`/`sgds-remove-file` for file-upload).
-8. `<sgds-input>`, `<sgds-textarea>`, `<sgds-datepicker>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-radio-group>`, `<sgds-checkbox>`, `<sgds-checkbox-group>`, and `<sgds-file-upload>` fully support custom validation via `noValidate` + `setInvalid`. Only `<sgds-quantity-toggle>` has this feature as WIP.
+7. When using custom/3rd-party validation, add `noValidate` on the component (or `novalidate` on the form), then call `element.setInvalid(true/false)` and set `element.invalidFeedback` inside the relevant event listener (`sgds-input` for inputs/textareas, `sgds-change-date` for datepicker, `sgds-change` for select/combo-box/radio-group/checkbox-group/quantity-toggle, `sgds-add-files`/`sgds-remove-file` for file-upload).
+8. All form components (`<sgds-input>`, `<sgds-textarea>`, `<sgds-datepicker>`, `<sgds-combo-box>`, `<sgds-select>`, `<sgds-quantity-toggle>`, `<sgds-radio-group>`, `<sgds-checkbox>`, `<sgds-checkbox-group>`, and `<sgds-file-upload>`) fully support custom validation via `noValidate` + `setInvalid`.
 9. The reset button (`type="reset"`) automatically clears all validity states and values — no extra reset logic is needed.
 10. Disabled components are excluded from constraint validation and will never block form submission.

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -20,6 +20,8 @@ import formControlStyle from "../../styles/form-text-control.css";
  *
  * @event sgds-change - Emitted when an alteration to the control's value is committed by the user.
  * @event sgds-input - Emitted when the control receives input and its value changes.
+ * @event sgds-invalid - Emitted when the control's invalid state is set to true.
+ * @event sgds-valid - Emitted when the control's invalid state is set to false.
  *
  */
 export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElement) implements SgdsFormControl {
@@ -57,6 +59,8 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
 
   /**Feedback text for error state when validated */
   @property({ type: String, reflect: true }) invalidFeedback: string;
+  /** Disables native and sgds validation for the quantity toggle. */
+  @property({ type: Boolean, reflect: true }) noValidate = false;
   /** Sets the quantity toggle as readonly  */
   @property({ type: Boolean, reflect: true }) readonly = false;
 
@@ -100,11 +104,20 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     }
     this.value = parseInt(sgdsInput.value);
     this._mixinSetFormValue();
+    if (this._mixinShouldSkipSgdsValidation()) return;
     this._mixinValidate(sgdsInput.input);
     this.invalid = !this._mixinReportValidity();
   }
   private async _handleInputChange() {
     const sgdsInput = await this._sgdsInput;
+    if (this._mixinShouldSkipSgdsValidation()) {
+      if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
+        sgdsInput.value = "0";
+      }
+      this.value = parseInt(sgdsInput.value);
+      this._mixinSetFormValue();
+      return;
+    }
     this.invalid = false;
     if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
       sgdsInput.value = "0";
@@ -161,6 +174,7 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     event.stopPropagation();
     this.value = parseInt(sgdsInput.value) + parseInt(sgdsInput.step.toString());
     this._validateOnClick(sgdsInput.input);
+    this.emit("sgds-change");
   }
   private async _onMinus(event: MouseEvent) {
     const sgdsInput = await this._sgdsInput;
@@ -171,8 +185,8 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     } else {
       this.value = parseInt(sgdsInput.value) - parseInt(sgdsInput.step.toString());
     }
-
     this._validateOnClick(sgdsInput.input);
+    this.emit("sgds-change");
   }
 
   /**
@@ -185,6 +199,7 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     const sgdsInput = await this._sgdsInput;
     await sgdsInput.updateComplete;
     this._mixinSetFormValue();
+    if (this._mixinShouldSkipSgdsValidation()) return;
     this._mixinValidate(input);
     this.invalid = !this._mixinReportValidity();
   }
@@ -260,6 +275,7 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
             @sgds-valid=${this._handleValid}
             @keydown=${this._handleKeyDown}
             ?disabled=${this.disabled}
+            ?noValidate=${this._mixinShouldSkipSgdsValidation()}
             id=${this._controlId}
             ?invalid=${this.invalid}
             hasFeedback=${ifDefined(this.hasFeedback !== "text" ? "style" : undefined)}

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -5,11 +5,12 @@ const ValidationTemplate = args =>
   html`
     <form>
       <sgds-quantity-toggle
+        class="sgds:mb-layout-sm"
         name="QT1"
         id="QT1"
         min="3"
         hasFeedback="both"
-        hintText="Hint text"
+        hintText="Minimum value is 3"
         label="Label"
         invalidFeedback=${ifDefined(args.invalidFeedback)}
       >
@@ -44,5 +45,56 @@ export const OverrideInvalidFeedback = {
   render: ValidationTemplate.bind({}),
   name: "Override default invalid feedback",
   args: { invalidFeedback: "Custom error message" },
+  parameters: {}
+};
+
+const NoValidateTemplate = () =>
+  html`
+    <form id="novalidate-qt-story-form">
+      <sgds-quantity-toggle
+        class="sgds:mb-layout-sm"
+        noValidate
+        hasFeedback="both"
+        label="Quantity"
+        hintText="Custom validation: value must be a multiple of 5"
+        id="novalidate-qt-story"
+      ></sgds-quantity-toggle>
+      <sgds-button type="submit">Submit</sgds-button>
+      <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+    </form>
+    <script>
+      const noValidateQt = document.querySelector("#novalidate-qt-story");
+      const noValidateQtForm = document.querySelector("#novalidate-qt-story-form");
+
+      noValidateQt.addEventListener("sgds-change", e => {
+        if (e.target.value === 0) {
+          e.target.setInvalid(false);
+          return;
+        }
+        if (e.target.value % 5 !== 0) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Custom feedback: value must be a multiple of 5";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      noValidateQtForm.addEventListener("submit", e => {
+        e.preventDefault();
+        if (noValidateQt.value === 0) {
+          noValidateQt.setInvalid(true);
+          noValidateQt.invalidFeedback = "Custom feedback: enter a quantity";
+          return;
+        }
+        if (noValidateQt.invalid) return;
+        alert("Submitted: " + noValidateQt.value);
+      });
+    </script>
+  `;
+
+export const NoValidate = {
+  render: NoValidateTemplate.bind({}),
+  name: "Custom Validation with noValidate",
+  args: {},
   parameters: {}
 };

--- a/stories/form-validation/customValidation.mdx
+++ b/stories/form-validation/customValidation.mdx
@@ -31,7 +31,7 @@ When `novalidate` is present on the closest parent `<form>`, all child form comp
 | Datepicker     | Implemented |
 | Checkbox       | Implemented |
 | CheckboxGroup  | Implemented |
-| QuantityToggle | WIP         |
+| QuantityToggle | Implemented |
 | RadioGroup     | Implemented |
 | FileUpload     | Implemented |
 | Select         | Implemented |

--- a/stories/form-validation/customValidation.stories.js
+++ b/stories/form-validation/customValidation.stories.js
@@ -1,125 +1,176 @@
 import { html } from "lit";
 
 export default {
-  title: "Form/Custom Validation"
+  title: "Form/Custom Validation",
+  parameters: { layout: "fullscreen" }
 };
-const handleInput = e => {};
 
 const DisableValidationByInputTemplate = args => {
   return html`
-    <form id="custom-validation-form" class="sgds:flex sgds:flex-col sgds:gap-layout-xs">
-      <sgds-input
-        noValidate
-        required
-        label="Keys"
-        hinttext="Keys cannot start with special characters like @, #, $"
-        name="input-keys"
-        hasFeedback="both"
-        placeholder="Placeholder"
-        id="custom-validation__input-novalidate"
-        @sgds-input=${handleInput}
-      >
-      </sgds-input>
-      <sgds-textarea
-        noValidate
-        required
-        label="Bio"
-        hinttext="Must be at least 10 characters long"
-        name="textarea-bio"
-        hasFeedback
-        placeholder="Enter bio"
-        id="custom-validation__textarea-novalidate"
-      >
-      </sgds-textarea>
-      <sgds-combo-box
-        noValidate
-        required
-        label="Fruit"
-        hinttext="Selection must start with 'A'"
-        name="combo-fruit"
-        hasFeedback
-        placeholder="Select a fruit"
-        id="custom-validation__combobox-novalidate"
-      >
-        <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
-        <sgds-combo-box-option value="apricot">Apricot</sgds-combo-box-option>
-        <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
-        <sgds-combo-box-option value="durian">Durian</sgds-combo-box-option>
-      </sgds-combo-box>
-      <sgds-select
-        noValidate
-        required
-        label="Gender"
-        hinttext="Please select a gender"
-        name="select-gender"
-        hasFeedback
-        placeholder="Select a gender"
-        id="custom-validation__select-novalidate"
-      >
-        <sgds-select-option value="male">Male</sgds-select-option>
-        <sgds-select-option value="female">Female</sgds-select-option>
-        <sgds-select-option value="other">Other</sgds-select-option>
-        <sgds-select-option value="prefer-not-to-say">Prefer not to say</sgds-select-option>
-      </sgds-select>
-      <sgds-file-upload
-        noValidate
-        required
-        label="Documents"
-        hinttext="Max 2 PDF files"
-        name="documents"
-        hasFeedback
-        multiple
-        accept=".pdf"
-        id="custom-validation__file-upload-novalidate"
-      >
-        Choose Files
-      </sgds-file-upload>
-      <sgds-datepicker
-        noValidate
-        required
-        label="Appointment Date"
-        hintText="Must be a future date"
-        name="appointment-date"
-        hasFeedback
-        id="custom-validation__datepicker-novalidate"
-      ></sgds-datepicker>
-      <sgds-radio-group
-        noValidate
-        required
-        label="Gender"
-        hintText="Please select a gender"
-        name="radio-gender"
-        hasFeedback
-        id="custom-validation__radio-novalidate"
-      >
-        <sgds-radio value="male">Male</sgds-radio>
-        <sgds-radio value="female">Female</sgds-radio>
-        <sgds-radio value="other">Other</sgds-radio>
-      </sgds-radio-group>
-      <sgds-checkbox-group
-        noValidate
-        required
-        label="Interests"
-        hintText="Select at least one interest"
-        name="checkbox-interests"
-        hasFeedback
-        id="custom-validation__checkbox-novalidate"
-      >
-        <sgds-checkbox value="sports">Sports</sgds-checkbox>
-        <sgds-checkbox value="music">Music</sgds-checkbox>
-        <sgds-checkbox value="reading">Reading</sgds-checkbox>
-      </sgds-checkbox-group>
-      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
-        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
-        <sgds-button type="submit">Submit</sgds-button>
+    <div class="sgds-container sgds:py-layout-md">
+      <div class="sgds-grid sgds:gap-layout-md">
+        <form
+          id="custom-validation-form"
+          class="sgds-col-4 sgds-col-sm-8 sgds-col-md-8 sgds-col-lg-center-8 sgds-col-xl-center-8 sgds-col-2-xl-center-8"
+        >
+          <div class="sgds:flex sgds:flex-col sgds:gap-layout-lg">
+            <div class="sgds:flex sgds:flex-col sgds:gap-layout-md">
+              <h5
+                class="sgds:text-subtitle-lg sgds:font-semibold sgds:leading-xs sgds:tracking-normal sgds:text-heading-default sgds:mb-0"
+              >
+                Custom Validation (Component noValidate)
+              </h5>
+              <div>
+                <sgds-input
+                  noValidate
+                  required
+                  label="Keys"
+                  hinttext="Keys cannot start with special characters like @, #, $"
+                  name="input-keys"
+                  hasFeedback="both"
+                  placeholder="Placeholder"
+                  id="custom-validation__input-novalidate"
+                >
+                </sgds-input>
+              </div>
+              <div>
+                <sgds-textarea
+                  noValidate
+                  required
+                  label="Bio"
+                  hinttext="Must be at least 10 characters long"
+                  name="textarea-bio"
+                  hasFeedback="both"
+                  placeholder="Enter bio"
+                  id="custom-validation__textarea-novalidate"
+                >
+                </sgds-textarea>
+              </div>
+              <div>
+                <sgds-combo-box
+                  noValidate
+                  required
+                  label="Fruit"
+                  hinttext="Selection must start with 'A'"
+                  name="combo-fruit"
+                  hasFeedback="both"
+                  placeholder="Select a fruit"
+                  id="custom-validation__combobox-novalidate"
+                >
+                  <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
+                  <sgds-combo-box-option value="apricot">Apricot</sgds-combo-box-option>
+                  <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
+                  <sgds-combo-box-option value="durian">Durian</sgds-combo-box-option>
+                </sgds-combo-box>
+              </div>
+              <div>
+                <sgds-select
+                  noValidate
+                  required
+                  label="Gender"
+                  hinttext="Please select a gender"
+                  name="select-gender"
+                  hasFeedback="both"
+                  placeholder="Select a gender"
+                  id="custom-validation__select-novalidate"
+                >
+                  <sgds-select-option value="male">Male</sgds-select-option>
+                  <sgds-select-option value="female">Female</sgds-select-option>
+                  <sgds-select-option value="other">Other</sgds-select-option>
+                  <sgds-select-option value="prefer-not-to-say">Prefer not to say</sgds-select-option>
+                </sgds-select>
+              </div>
+              <div>
+                <sgds-file-upload
+                  noValidate
+                  required
+                  label="Documents"
+                  hinttext="Max 2 PDF files"
+                  name="documents"
+                  hasFeedback="both"
+                  multiple
+                  accept=".pdf"
+                  id="custom-validation__file-upload-novalidate"
+                >
+                  Choose Files
+                </sgds-file-upload>
+              </div>
+              <div>
+                <sgds-datepicker
+                  noValidate
+                  required
+                  label="Appointment Date"
+                  hintText="Must be a future date"
+                  name="appointment-date"
+                  hasFeedback="both"
+                  id="custom-validation__datepicker-novalidate"
+                ></sgds-datepicker>
+              </div>
+              <div>
+                <sgds-radio-group
+                  noValidate
+                  required
+                  label="Gender"
+                  hintText="Please select a gender"
+                  name="radio-gender"
+                  hasFeedback="both"
+                  id="custom-validation__radio-novalidate"
+                >
+                  <sgds-radio value="male">Male</sgds-radio>
+                  <sgds-radio value="female">Female</sgds-radio>
+                  <sgds-radio value="other">Other</sgds-radio>
+                </sgds-radio-group>
+              </div>
+              <div>
+                <sgds-checkbox-group
+                  noValidate
+                  required
+                  label="Interests"
+                  hintText="Select at least one interest"
+                  name="checkbox-interests"
+                  hasFeedback="both"
+                  id="custom-validation__checkbox-novalidate"
+                >
+                  <sgds-checkbox value="sports">Sports</sgds-checkbox>
+                  <sgds-checkbox value="music">Music</sgds-checkbox>
+                  <sgds-checkbox value="reading">Reading</sgds-checkbox>
+                </sgds-checkbox-group>
+              </div>
+              <div>
+                <sgds-quantity-toggle
+                  noValidate
+                  min="3"
+                  max="50"
+                  label="Quantity"
+                  hintText="Value must be a multiple of 5 (min=3, max=50 ignored by noValidate)"
+                  name="quantity"
+                  hasFeedback="both"
+                  id="custom-validation__quantity-toggle-novalidate"
+                ></sgds-quantity-toggle>
+              </div>
+            </div>
+            <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">
+              <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+              <sgds-button type="submit">Submit</sgds-button>
+            </div>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
     <script>
       const formOne = document.getElementById("custom-validation-form");
       formOne.addEventListener("submit", e => {
         e.preventDefault();
+
+        // Validate quantity-toggle on submit
+        const qtSubmit = document.getElementById("custom-validation__quantity-toggle-novalidate");
+        if (qtSubmit.value !== 0 && qtSubmit.value % 5 !== 0) {
+          qtSubmit.setInvalid(true);
+          qtSubmit.invalidFeedback = "Value must be a multiple of 5";
+        }
+
         const components = formOne.querySelectorAll(
-          "sgds-input, sgds-textarea, sgds-combo-box, sgds-select, sgds-file-upload, sgds-datepicker"
+          "sgds-input, sgds-textarea, sgds-combo-box, sgds-select, sgds-file-upload, sgds-datepicker, sgds-quantity-toggle"
         );
         let hasInvalid = false;
         components.forEach(c => {
@@ -238,114 +289,183 @@ const DisableValidationByInputTemplate = args => {
           e.target.setInvalid(false);
         }
       });
+
+      const qtOne = document.getElementById("custom-validation__quantity-toggle-novalidate");
+      qtOne.addEventListener("sgds-change", e => {
+        if (e.target.value % 5 !== 0) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Value must be a multiple of 5";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
     </script>
   `;
 };
 const DisableValidationByFormTemplate = args => {
   return html`
-    <form id="custom-validation-form_novalidate" class="sgds:flex sgds:flex-col sgds:gap-layout-xs" novalidate>
-      <sgds-input
-        required
-        label="Keys"
-        hinttext="Keys cannot start with special characters like @, #, $"
-        name="input-keys"
-        hasFeedback="both"
-        placeholder="Placeholder"
-        id="custom-validation__input-two-novalidate"
-      >
-      </sgds-input>
-      <sgds-textarea
-        required
-        label="Notes"
-        hinttext="Custom validation: minimum 5 characters"
-        name="textarea-notes"
-        hasFeedback
-        placeholder="Enter notes"
-        id="custom-validation__textarea-two-novalidate"
-      >
-      </sgds-textarea>
-      <sgds-combo-box
-        required
-        label="Fruit"
-        hinttext="Selection must start with 'A'"
-        name="combo-fruit"
-        hasFeedback
-        placeholder="Select a fruit"
-        id="custom-validation__combobox-two-novalidate"
-      >
-        <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
-        <sgds-combo-box-option value="apricot">Apricot</sgds-combo-box-option>
-        <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
-        <sgds-combo-box-option value="durian">Durian</sgds-combo-box-option>
-      </sgds-combo-box>
-      <sgds-select
-        required
-        label="Gender"
-        hinttext="Please select a gender"
-        name="select-gender"
-        hasFeedback
-        placeholder="Select a gender"
-        id="custom-validation__select-two-novalidate"
-      >
-        <sgds-select-option value="male">Male</sgds-select-option>
-        <sgds-select-option value="female">Female</sgds-select-option>
-        <sgds-select-option value="other">Other</sgds-select-option>
-        <sgds-select-option value="prefer-not-to-say">Prefer not to say</sgds-select-option>
-      </sgds-select>
-      <sgds-file-upload
-        required
-        label="Documents"
-        hinttext="Max 2 PDF files"
-        name="documents"
-        hasFeedback
-        multiple
-        accept=".pdf"
-        id="custom-validation__file-upload-two-novalidate"
-      >
-        Choose Files
-      </sgds-file-upload>
-      <sgds-datepicker
-        required
-        label="Appointment Date"
-        hintText="Must be a future date"
-        name="appointment-date"
-        hasFeedback
-        id="custom-validation__datepicker-two-novalidate"
-      ></sgds-datepicker>
-      <sgds-radio-group
-        required
-        label="Gender"
-        hintText="Please select a gender"
-        name="radio-gender"
-        hasFeedback
-        id="custom-validation__radio-two-novalidate"
-      >
-        <sgds-radio value="male">Male</sgds-radio>
-        <sgds-radio value="female">Female</sgds-radio>
-        <sgds-radio value="other">Other</sgds-radio>
-      </sgds-radio-group>
-      <sgds-button type="submit">Submit</sgds-button>
-      <sgds-checkbox-group
-        required
-        label="Interests"
-        hintText="Select at least one interest"
-        name="checkbox-interests"
-        hasFeedback
-        id="custom-validation__checkbox-two-novalidate"
-      >
-        <sgds-checkbox value="sports">Sports</sgds-checkbox>
-        <sgds-checkbox value="music">Music</sgds-checkbox>
-        <sgds-checkbox value="reading">Reading</sgds-checkbox>
-      </sgds-checkbox-group>
-      <div class="sgds:flex sgds:justify-end sgds:gap-component-xs">
-        <sgds-button type="reset" variant="ghost">Reset</sgds-button>
-        <sgds-button type="submit">Submit</sgds-button>
+    <div class="sgds-container sgds:py-layout-md">
+      <div class="sgds-grid sgds:gap-layout-md">
+        <form
+          id="custom-validation-form_novalidate"
+          class="sgds-col-4 sgds-col-sm-8 sgds-col-md-8 sgds-col-lg-center-8 sgds-col-xl-center-8 sgds-col-2-xl-center-8"
+          novalidate
+        >
+          <div class="sgds:flex sgds:flex-col sgds:gap-layout-lg">
+            <div class="sgds:flex sgds:flex-col sgds:gap-layout-md">
+              <h5
+                class="sgds:text-subtitle-lg sgds:font-semibold sgds:leading-xs sgds:tracking-normal sgds:text-heading-default sgds:mb-0"
+              >
+                Custom Validation (Form novalidate)
+              </h5>
+              <div>
+                <sgds-input
+                  required
+                  label="Keys"
+                  hinttext="Keys cannot start with special characters like @, #, $"
+                  name="input-keys"
+                  hasFeedback="both"
+                  placeholder="Placeholder"
+                  id="custom-validation__input-two-novalidate"
+                >
+                </sgds-input>
+              </div>
+              <div>
+                <sgds-textarea
+                  required
+                  label="Notes"
+                  hinttext="Custom validation: minimum 5 characters"
+                  name="textarea-notes"
+                  hasFeedback="both"
+                  placeholder="Enter notes"
+                  id="custom-validation__textarea-two-novalidate"
+                >
+                </sgds-textarea>
+              </div>
+              <div>
+                <sgds-combo-box
+                  required
+                  label="Fruit"
+                  hinttext="Selection must start with 'A'"
+                  name="combo-fruit"
+                  hasFeedback="both"
+                  placeholder="Select a fruit"
+                  id="custom-validation__combobox-two-novalidate"
+                >
+                  <sgds-combo-box-option value="apple">Apple</sgds-combo-box-option>
+                  <sgds-combo-box-option value="apricot">Apricot</sgds-combo-box-option>
+                  <sgds-combo-box-option value="banana">Banana</sgds-combo-box-option>
+                  <sgds-combo-box-option value="durian">Durian</sgds-combo-box-option>
+                </sgds-combo-box>
+              </div>
+              <div>
+                <sgds-select
+                  required
+                  label="Gender"
+                  hinttext="Please select a gender"
+                  name="select-gender"
+                  hasFeedback="both"
+                  placeholder="Select a gender"
+                  id="custom-validation__select-two-novalidate"
+                >
+                  <sgds-select-option value="male">Male</sgds-select-option>
+                  <sgds-select-option value="female">Female</sgds-select-option>
+                  <sgds-select-option value="other">Other</sgds-select-option>
+                  <sgds-select-option value="prefer-not-to-say">Prefer not to say</sgds-select-option>
+                </sgds-select>
+              </div>
+              <div>
+                <sgds-file-upload
+                  required
+                  label="Documents"
+                  hinttext="Max 2 PDF files"
+                  name="documents"
+                  hasFeedback="both"
+                  multiple
+                  accept=".pdf"
+                  id="custom-validation__file-upload-two-novalidate"
+                >
+                  Choose Files
+                </sgds-file-upload>
+              </div>
+              <div>
+                <sgds-datepicker
+                  required
+                  label="Appointment Date"
+                  hintText="Must be a future date"
+                  name="appointment-date"
+                  hasFeedback="both"
+                  id="custom-validation__datepicker-two-novalidate"
+                ></sgds-datepicker>
+              </div>
+              <div>
+                <sgds-radio-group
+                  required
+                  label="Gender"
+                  hintText="Please select a gender"
+                  name="radio-gender"
+                  hasFeedback="both"
+                  id="custom-validation__radio-two-novalidate"
+                >
+                  <sgds-radio value="male">Male</sgds-radio>
+                  <sgds-radio value="female">Female</sgds-radio>
+                  <sgds-radio value="other">Other</sgds-radio>
+                </sgds-radio-group>
+              </div>
+              <div>
+                <sgds-checkbox-group
+                  required
+                  label="Interests"
+                  hintText="Select at least one interest"
+                  name="checkbox-interests"
+                  hasFeedback="both"
+                  id="custom-validation__checkbox-two-novalidate"
+                >
+                  <sgds-checkbox value="sports">Sports</sgds-checkbox>
+                  <sgds-checkbox value="music">Music</sgds-checkbox>
+                  <sgds-checkbox value="reading">Reading</sgds-checkbox>
+                </sgds-checkbox-group>
+              </div>
+              <div>
+                <sgds-quantity-toggle
+                  min="3"
+                  max="50"
+                  label="Quantity"
+                  hintText="Value must be a multiple of 5 (min=3, max=50 ignored by form novalidate)"
+                  name="quantity"
+                  hasFeedback="both"
+                  id="custom-validation__quantity-toggle-two-novalidate"
+                ></sgds-quantity-toggle>
+              </div>
+            </div>
+            <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">
+              <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+              <sgds-button type="submit">Submit</sgds-button>
+            </div>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
     <script>
       const formTwo = document.getElementById("custom-validation-form_novalidate");
       formTwo.addEventListener("submit", e => {
         e.preventDefault();
+
+        // Validate quantity-toggle on submit
+        const qtSubmitTwo = document.getElementById("custom-validation__quantity-toggle-two-novalidate");
+        if (qtSubmitTwo.value !== 0 && qtSubmitTwo.value % 5 !== 0) {
+          qtSubmitTwo.setInvalid(true);
+          qtSubmitTwo.invalidFeedback = "Value must be a multiple of 5";
+        }
+
+        const components = formTwo.querySelectorAll(
+          "sgds-input, sgds-textarea, sgds-combo-box, sgds-select, sgds-file-upload, sgds-datepicker, sgds-quantity-toggle"
+        );
+        let hasInvalid = false;
+        components.forEach(c => {
+          if (c.invalid) hasInvalid = true;
+        });
+        if (hasInvalid) return;
         alert(
           "Form submitted successfully despite empty required fields — constraint validation was disabled by the noValidate property."
         );
@@ -455,6 +575,16 @@ const DisableValidationByFormTemplate = args => {
         if (!e.target.value) {
           e.target.setInvalid(true);
           e.target.invalidFeedback = "Please select at least one interest";
+        } else {
+          e.target.setInvalid(false);
+        }
+      });
+
+      const qtTwo = document.getElementById("custom-validation__quantity-toggle-two-novalidate");
+      qtTwo.addEventListener("sgds-change", e => {
+        if (e.target.value % 5 !== 0) {
+          e.target.setInvalid(true);
+          e.target.invalidFeedback = "Value must be a multiple of 5";
         } else {
           e.target.setInvalid(false);
         }

--- a/stories/form-validation/validation.stories.js
+++ b/stories/form-validation/validation.stories.js
@@ -1,98 +1,134 @@
 import { html } from "lit";
 
 export default {
-  title: "Form/Validation"
+  title: "Form/Validation",
+  parameters: { layout: "fullscreen" }
 };
 
 const ConstraintValidationTemplate = args => {
   return html`
-    <form id="validation-form_constraint-validation" class="d-flex-column">
-      <sgds-input
-        label="First Name"
-        hinttext="type Sarah"
-        name="firstName"
-        required
-        hasFeedback="both"
-        placeholder="Placeholder"
-        pattern="Sarah"
-      >
-      </sgds-input>
-      <sgds-datepicker required hasFeedback name="appointmentDate" label="Appointment date"></sgds-datepicker>
-      <sgds-select
-        required
-        hasFeedback
-        name="favouriteAnimal"
-        menuList='[
-      { "label": "Aligator", "value": "1" },
-      { "label": "Bear", "value": "2" },
-      { "label": "Cat", "value": "3" },
-      { "label": "Dog", "value": "4" },
-      { "label": "Elephant", "value": "5" },
-      { "label": "Frog", "value": "6" },
-      { "label": "Goose", "value": "7" },
-      { "label": "Hen", "value": "8" }
-    ]'
-      ></sgds-select>
-      <sgds-combo-box
-        required
-        hasFeedback
-        name="countryOfBirth"
-        label="Country of birth"
-        menuList='[
-      { "label": "Singapore", "value": "1" },
-      { "label": "Thailand", "value": "2" },
-      { "label": "Malaysia", "value": "3" },
-      { "label": "Philippines", "value": "4" },
-      { "label": "Japan", "value": "5" },
-      { "label": "Laos", "value": "6" },
-      { "label": "Vietnam", "value": "7" },
-      { "label": "China", "value": "8" }
-    ]'
-        placeholder="Choose a country"
-      ></sgds-combo-box>
-      <sgds-quantity-toggle
-        label="Number of dependents"
-        name="dependentCount"
-        min="1"
-        max="10"
-        hinttext="Input number 1 to 10 only"
-        hasFeedback="both"
-      ></sgds-quantity-toggle>
-      <sgds-checkbox-group
-        hasFeedback
-        hintText="Check at least one option"
-        required
-        label="Food preference"
-        name="food"
-      >
-        <sgds-checkbox value="vegetarian">vegetarian</sgds-checkbox>
-        <sgds-checkbox value="halal">halal</sgds-checkbox>
-        <sgds-checkbox value="na">no preference</sgds-checkbox>
-      </sgds-checkbox-group>
-
-      <sgds-radio-group hasFeedback name="gender" required label="Gender">
-        <sgds-radio value="female">Female</sgds-radio>
-        <sgds-radio value="male">Male</sgds-radio>
-      </sgds-radio-group>
-
-      <sgds-textarea
-        name="comments"
-        minlength="3"
-        required
-        hasFeedback
-        resize="auto"
-        label="Comments"
-        hintText="Required to fill with minimum length of 3"
-      ></sgds-textarea>
-      <sgds-file-upload required label="Supporting documents" multiple name="documents" hasFeedback
-        >File upload</sgds-file-upload
-      >
-      <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
-      <div class="d-flex-row">
-        <sgds-button type="submit" id="submit">Submit</sgds-button>
-        <sgds-button type="reset" id="reset" variant="ghost">Reset</sgds-button>
+    <div class="sgds-container sgds:py-layout-md">
+      <div class="sgds-grid sgds:gap-layout-md">
+        <form
+          id="validation-form_constraint-validation"
+          class="sgds-col-4 sgds-col-sm-8 sgds-col-md-8 sgds-col-lg-center-8 sgds-col-xl-center-8 sgds-col-2-xl-center-8"
+        >
+          <div class="sgds:flex sgds:flex-col sgds:gap-layout-lg">
+            <div class="sgds:flex sgds:flex-col sgds:gap-layout-md">
+              <h5
+                class="sgds:text-subtitle-lg sgds:font-semibold sgds:leading-xs sgds:tracking-normal sgds:text-heading-default sgds:mb-0"
+              >
+                Constraint Validation
+              </h5>
+              <div>
+                <sgds-input
+                  label="First Name"
+                  hinttext="type Sarah"
+                  name="firstName"
+                  required
+                  hasFeedback="both"
+                  placeholder="Placeholder"
+                  pattern="Sarah"
+                >
+                </sgds-input>
+              </div>
+              <div>
+                <sgds-datepicker required hasFeedback="both" name="appointmentDate" label="Appointment date"></sgds-datepicker>
+              </div>
+              <div>
+                <sgds-select
+                  required
+                  hasFeedback="both"
+                  name="favouriteAnimal"
+                  label="Favourite animal"
+                  menuList='[
+                    { "label": "Aligator", "value": "1" },
+                    { "label": "Bear", "value": "2" },
+                    { "label": "Cat", "value": "3" },
+                    { "label": "Dog", "value": "4" },
+                    { "label": "Elephant", "value": "5" },
+                    { "label": "Frog", "value": "6" },
+                    { "label": "Goose", "value": "7" },
+                    { "label": "Hen", "value": "8" }
+                  ]'
+                ></sgds-select>
+              </div>
+              <div>
+                <sgds-combo-box
+                  required
+                  hasFeedback="both"
+                  name="countryOfBirth"
+                  label="Country of birth"
+                  menuList='[
+                    { "label": "Singapore", "value": "1" },
+                    { "label": "Thailand", "value": "2" },
+                    { "label": "Malaysia", "value": "3" },
+                    { "label": "Philippines", "value": "4" },
+                    { "label": "Japan", "value": "5" },
+                    { "label": "Laos", "value": "6" },
+                    { "label": "Vietnam", "value": "7" },
+                    { "label": "China", "value": "8" }
+                  ]'
+                  placeholder="Choose a country"
+                ></sgds-combo-box>
+              </div>
+              <div>
+                <sgds-quantity-toggle
+                  label="Number of dependents"
+                  name="dependentCount"
+                  min="1"
+                  max="10"
+                  hinttext="Input number 1 to 10 only"
+                  hasFeedback="both"
+                ></sgds-quantity-toggle>
+              </div>
+              <div>
+                <sgds-checkbox-group
+                  hasFeedback="both"
+                  hintText="Check at least one option"
+                  required
+                  label="Food preference"
+                  name="food"
+                >
+                  <sgds-checkbox value="vegetarian">vegetarian</sgds-checkbox>
+                  <sgds-checkbox value="halal">halal</sgds-checkbox>
+                  <sgds-checkbox value="na">no preference</sgds-checkbox>
+                </sgds-checkbox-group>
+              </div>
+              <div>
+                <sgds-radio-group hasFeedback="both" name="gender" required label="Gender">
+                  <sgds-radio value="female">Female</sgds-radio>
+                  <sgds-radio value="male">Male</sgds-radio>
+                </sgds-radio-group>
+              </div>
+              <div>
+                <sgds-textarea
+                  name="comments"
+                  minlength="3"
+                  required
+                  hasFeedback="both"
+                  resize="auto"
+                  label="Comments"
+                  hintText="Required to fill with minimum length of 3"
+                ></sgds-textarea>
+              </div>
+              <div>
+                <sgds-file-upload required label="Supporting documents" multiple name="documents" hasFeedback="both"
+                  >File upload</sgds-file-upload
+                >
+              </div>
+              <div>
+                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
+              </div>
+            </div>
+            <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">
+              <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+              <sgds-button type="submit">Submit</sgds-button>
+            </div>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
   `;
 };
 
@@ -106,100 +142,134 @@ export const ConstraintValidation = {
 
 const FormDataTemplate = args => {
   return html`
-    <form id="validation-form_getting-data" class="d-flex-column">
-      <sgds-input
-        label="First Name"
-        hinttext="type Sarah"
-        name="firstName"
-        required
-        hasFeedback="both"
-        placeholder="Placeholder"
-        pattern="Sarah"
-      >
-      </sgds-input>
-      <sgds-quantity-toggle
-        label="Number of dependents"
-        name="dependentCount"
-        min="1"
-        max="10"
-        hinttext="Input number 1 to 10 only"
-        hasFeedback="both"
-      ></sgds-quantity-toggle>
-      <sgds-datepicker required hasFeedback name="appointmentDate" label="Appointment date"></sgds-datepicker>
-      <sgds-select
-        required
-        hasFeedback
-        name="favouriteAnimal"
-        menuList='[
-      { "label": "Aligator", "value": "1" },
-      { "label": "Bear", "value": "2" },
-      { "label": "Cat", "value": "3" },
-      { "label": "Dog", "value": "4" },
-      { "label": "Elephant", "value": "5" },
-      { "label": "Frog", "value": "6" },
-      { "label": "Goose", "value": "7" },
-      { "label": "Hen", "value": "8" }
-    ]'
-      ></sgds-select>
-      <sgds-combo-box
-        required
-        hasFeedback
-        name="countryOfBirth"
-        label="Country of birth"
-        menuList='[
-      { "label": "Singapore", "value": "1" },
-      { "label": "Thailand", "value": "2" },
-      { "label": "Malaysia", "value": "3" },
-      { "label": "Philippines", "value": "4" },
-      { "label": "Japan", "value": "5" },
-      { "label": "Laos", "value": "6" },
-      { "label": "Vietnam", "value": "7" },
-      { "label": "China", "value": "8" }
-    ]'
-        placeholder="Choose a country"
-      ></sgds-combo-box>
-      <sgds-checkbox-group
-        hasFeedback
-        hintText="Check at least one option"
-        required
-        label="Food preference"
-        name="food"
-      >
-        <sgds-checkbox value="vegetarian">vegetarian</sgds-checkbox>
-        <sgds-checkbox value="halal">halal</sgds-checkbox>
-        <sgds-checkbox value="na">no preference</sgds-checkbox>
-      </sgds-checkbox-group>
-
-      <sgds-radio-group hasFeedback name="gender" required label="Gender">
-        <sgds-radio value="female">Female</sgds-radio>
-        <sgds-radio value="male">Male</sgds-radio>
-      </sgds-radio-group>
-
-      <sgds-textarea
-        name="comments"
-        minlength="3"
-        required
-        hasFeedback
-        resize="auto"
-        label="Comments"
-        hintText="Required to fill with minimum length of 3"
-      ></sgds-textarea>
-      <sgds-file-upload
-        id="file-upload-form-data"
-        required
-        label="Supporting documents"
-        multiple
-        name="documents"
-        hasFeedback
-        >File upload</sgds-file-upload
-      >
-      <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
-
-      <div class="d-flex-row">
-        <sgds-button type="submit" id="submit">Submit</sgds-button>
-        <sgds-button type="reset" id="reset" variant="ghost">Reset</sgds-button>
+    <div class="sgds-container sgds:py-layout-md">
+      <div class="sgds-grid sgds:gap-layout-md">
+        <form
+          id="validation-form_getting-data"
+          class="sgds-col-4 sgds-col-sm-8 sgds-col-md-8 sgds-col-lg-center-8 sgds-col-xl-center-8 sgds-col-2-xl-center-8"
+        >
+          <div class="sgds:flex sgds:flex-col sgds:gap-layout-lg">
+            <div class="sgds:flex sgds:flex-col sgds:gap-layout-md">
+              <h5
+                class="sgds:text-subtitle-lg sgds:font-semibold sgds:leading-xs sgds:tracking-normal sgds:text-heading-default sgds:mb-0"
+              >
+                Get Values Through FormData
+              </h5>
+              <div>
+                <sgds-input
+                  label="First Name"
+                  hinttext="type Sarah"
+                  name="firstName"
+                  required
+                  hasFeedback="both"
+                  placeholder="Placeholder"
+                  pattern="Sarah"
+                >
+                </sgds-input>
+              </div>
+              <div>
+                <sgds-quantity-toggle
+                  label="Number of dependents"
+                  name="dependentCount"
+                  min="1"
+                  max="10"
+                  hinttext="Input number 1 to 10 only"
+                  hasFeedback="both"
+                ></sgds-quantity-toggle>
+              </div>
+              <div>
+                <sgds-datepicker required hasFeedback="both" name="appointmentDate" label="Appointment date"></sgds-datepicker>
+              </div>
+              <div>
+                <sgds-select
+                  required
+                  hasFeedback="both"
+                  name="favouriteAnimal"
+                  label="Favourite animal"
+                  menuList='[
+                    { "label": "Aligator", "value": "1" },
+                    { "label": "Bear", "value": "2" },
+                    { "label": "Cat", "value": "3" },
+                    { "label": "Dog", "value": "4" },
+                    { "label": "Elephant", "value": "5" },
+                    { "label": "Frog", "value": "6" },
+                    { "label": "Goose", "value": "7" },
+                    { "label": "Hen", "value": "8" }
+                  ]'
+                ></sgds-select>
+              </div>
+              <div>
+                <sgds-combo-box
+                  required
+                  hasFeedback="both"
+                  name="countryOfBirth"
+                  label="Country of birth"
+                  menuList='[
+                    { "label": "Singapore", "value": "1" },
+                    { "label": "Thailand", "value": "2" },
+                    { "label": "Malaysia", "value": "3" },
+                    { "label": "Philippines", "value": "4" },
+                    { "label": "Japan", "value": "5" },
+                    { "label": "Laos", "value": "6" },
+                    { "label": "Vietnam", "value": "7" },
+                    { "label": "China", "value": "8" }
+                  ]'
+                  placeholder="Choose a country"
+                ></sgds-combo-box>
+              </div>
+              <div>
+                <sgds-checkbox-group
+                  hasFeedback="both"
+                  hintText="Check at least one option"
+                  required
+                  label="Food preference"
+                  name="food"
+                >
+                  <sgds-checkbox value="vegetarian">vegetarian</sgds-checkbox>
+                  <sgds-checkbox value="halal">halal</sgds-checkbox>
+                  <sgds-checkbox value="na">no preference</sgds-checkbox>
+                </sgds-checkbox-group>
+              </div>
+              <div>
+                <sgds-radio-group hasFeedback="both" name="gender" required label="Gender">
+                  <sgds-radio value="female">Female</sgds-radio>
+                  <sgds-radio value="male">Male</sgds-radio>
+                </sgds-radio-group>
+              </div>
+              <div>
+                <sgds-textarea
+                  name="comments"
+                  minlength="3"
+                  required
+                  hasFeedback="both"
+                  resize="auto"
+                  label="Comments"
+                  hintText="Required to fill with minimum length of 3"
+                ></sgds-textarea>
+              </div>
+              <div>
+                <sgds-file-upload
+                  id="file-upload-form-data"
+                  required
+                  label="Supporting documents"
+                  multiple
+                  name="documents"
+                  hasFeedback="both"
+                  >File upload</sgds-file-upload
+                >
+              </div>
+              <div>
+                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
+              </div>
+            </div>
+            <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">
+              <sgds-button type="reset" variant="ghost">Reset</sgds-button>
+              <sgds-button type="submit">Submit</sgds-button>
+            </div>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
 
     <script>
       const form = document.querySelector("#validation-form_getting-data");

--- a/stories/form-validation/validation.stories.js
+++ b/stories/form-validation/validation.stories.js
@@ -33,7 +33,12 @@ const ConstraintValidationTemplate = args => {
                 </sgds-input>
               </div>
               <div>
-                <sgds-datepicker required hasFeedback="both" name="appointmentDate" label="Appointment date"></sgds-datepicker>
+                <sgds-datepicker
+                  required
+                  hasFeedback="both"
+                  name="appointmentDate"
+                  label="Appointment date"
+                ></sgds-datepicker>
               </div>
               <div>
                 <sgds-select
@@ -118,7 +123,9 @@ const ConstraintValidationTemplate = args => {
                 >
               </div>
               <div>
-                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
+                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both"
+                  >I consent to ...</sgds-checkbox
+                >
               </div>
             </div>
             <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">
@@ -178,7 +185,12 @@ const FormDataTemplate = args => {
                 ></sgds-quantity-toggle>
               </div>
               <div>
-                <sgds-datepicker required hasFeedback="both" name="appointmentDate" label="Appointment date"></sgds-datepicker>
+                <sgds-datepicker
+                  required
+                  hasFeedback="both"
+                  name="appointmentDate"
+                  label="Appointment date"
+                ></sgds-datepicker>
               </div>
               <div>
                 <sgds-select
@@ -259,7 +271,9 @@ const FormDataTemplate = args => {
                 >
               </div>
               <div>
-                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both">I consent to ...</sgds-checkbox>
+                <sgds-checkbox name="consentA" value="consentA" required hasFeedback="both"
+                  >I consent to ...</sgds-checkbox
+                >
               </div>
             </div>
             <div class="sgds:flex sgds:gap-layout-sm sgds:items-center sgds:justify-end">

--- a/test/quantitytoggle.test.ts
+++ b/test/quantitytoggle.test.ts
@@ -444,9 +444,7 @@ describe("reset clears invalid state when noValidate is true", () => {
 
 describe("setInvalid emits sgds-invalid and sgds-valid events", () => {
   it("setInvalid(true) emits sgds-invalid event", async () => {
-    const el = await fixture<SgdsQuantityToggle>(html`
-      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
-    `);
+    const el = await fixture<SgdsQuantityToggle>(html` <sgds-quantity-toggle noValidate></sgds-quantity-toggle> `);
     const handler = sinon.spy();
     el.addEventListener("sgds-invalid", handler);
 
@@ -456,9 +454,7 @@ describe("setInvalid emits sgds-invalid and sgds-valid events", () => {
   });
 
   it("setInvalid(false) emits sgds-valid event", async () => {
-    const el = await fixture<SgdsQuantityToggle>(html`
-      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
-    `);
+    const el = await fixture<SgdsQuantityToggle>(html` <sgds-quantity-toggle noValidate></sgds-quantity-toggle> `);
     const handler = sinon.spy();
     el.addEventListener("sgds-valid", handler);
 
@@ -468,9 +464,7 @@ describe("setInvalid emits sgds-invalid and sgds-valid events", () => {
   });
 
   it("setInvalid(true) followed by setInvalid(false) emits both events in order", async () => {
-    const el = await fixture<SgdsQuantityToggle>(html`
-      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
-    `);
+    const el = await fixture<SgdsQuantityToggle>(html` <sgds-quantity-toggle noValidate></sgds-quantity-toggle> `);
     const invalidHandler = sinon.spy();
     const validHandler = sinon.spy();
     el.addEventListener("sgds-invalid", invalidHandler);

--- a/test/quantitytoggle.test.ts
+++ b/test/quantitytoggle.test.ts
@@ -307,3 +307,203 @@ describe("in form context", () => {
     expect(el.invalid).to.be.false;
   });
 });
+
+describe("noValidate disables native and sgds validation behaviours", () => {
+  it("form submission proceeds with noValidate even when min constraint is violated", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-quantity-toggle noValidate name="qty" min="3" value="1"></sgds-quantity-toggle>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitHandler);
+
+    const button = form.querySelector("sgds-button");
+    button?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("clicking +/- buttons does not show invalid state when noValidate is set", async () => {
+    const el = await fixture<SgdsQuantityToggle>(
+      html`<sgds-quantity-toggle noValidate hasFeedback="both" min="3" value="0"></sgds-quantity-toggle>`
+    );
+    const plusBtn = el.shadowRoot?.querySelectorAll("sgds-icon-button")[1] as SgdsIconButton;
+    plusBtn?.click();
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+    expect(el.shadowRoot?.querySelector(".invalid-feedback")).to.be.null;
+  });
+
+  it("direct input change does not trigger validation when noValidate is set", async () => {
+    const el = await fixture<SgdsQuantityToggle>(
+      html`<sgds-quantity-toggle noValidate hasFeedback="both" min="5"></sgds-quantity-toggle>`
+    );
+    const input = el.shadowRoot?.querySelector<SgdsInput>("sgds-input");
+    input?.focus();
+    await sendKeys({ press: "2" });
+    input?.blur();
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+    expect(el.shadowRoot?.querySelector(".invalid-feedback")).to.be.null;
+  });
+});
+
+describe("with noValidate, setInvalid(true) still works for programmatic control", () => {
+  it("setInvalid(true) sets invalid state", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`
+      <sgds-quantity-toggle noValidate hasFeedback="both"></sgds-quantity-toggle>
+    `);
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+  });
+
+  it("setInvalid(false) clears invalid state", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`
+      <sgds-quantity-toggle noValidate hasFeedback="both"></sgds-quantity-toggle>
+    `);
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(el.invalid).to.be.true;
+
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(el.invalid).to.be.false;
+  });
+});
+
+describe("form novalidate for sgds-quantity-toggle", () => {
+  it("when form has novalidate, form submission proceeds even when min constraint is violated", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-quantity-toggle name="qty" min="3" value="1"></sgds-quantity-toggle>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+    expect(form.reportValidity()).to.equal(true);
+    form.addEventListener("submit", submitHandler);
+    const button = form.querySelector("sgds-button");
+    button?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+
+  it("when form has novalidate, quantity-toggle does not show invalid state on touch", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-quantity-toggle hasFeedback="both" min="3" value="1"></sgds-quantity-toggle>
+      </form>
+    `);
+    const el = form.querySelector<SgdsQuantityToggle>("sgds-quantity-toggle");
+    const input = el?.shadowRoot?.querySelector<SgdsInput>("sgds-input");
+    input?.focus();
+    input?.blur();
+    await el?.updateComplete;
+    expect(el?.invalid).to.be.false;
+  });
+});
+
+describe("reset clears invalid state when noValidate is true", () => {
+  it("reset clears programmatic invalid state when component has noValidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-quantity-toggle noValidate name="qty"></sgds-quantity-toggle>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const el = form.querySelector<SgdsQuantityToggle>("sgds-quantity-toggle");
+    el?.setInvalid(true);
+    await el?.updateComplete;
+    expect(el?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector("sgds-button")?.click());
+    await waitUntil(() => el?.invalid === false);
+    expect(el?.invalid).to.be.false;
+  });
+
+  it("reset clears programmatic invalid state when form has novalidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form novalidate>
+        <sgds-quantity-toggle name="qty"></sgds-quantity-toggle>
+        <sgds-button type="reset">Reset</sgds-button>
+      </form>
+    `);
+    const el = form.querySelector<SgdsQuantityToggle>("sgds-quantity-toggle");
+    el?.setInvalid(true);
+    await el?.updateComplete;
+    expect(el?.invalid).to.be.true;
+
+    setTimeout(() => form.querySelector("sgds-button")?.click());
+    await waitUntil(() => el?.invalid === false);
+    expect(el?.invalid).to.be.false;
+  });
+});
+
+describe("setInvalid emits sgds-invalid and sgds-valid events", () => {
+  it("setInvalid(true) emits sgds-invalid event", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`
+      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
+    `);
+    const handler = sinon.spy();
+    el.addEventListener("sgds-invalid", handler);
+
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("setInvalid(false) emits sgds-valid event", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`
+      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
+    `);
+    const handler = sinon.spy();
+    el.addEventListener("sgds-valid", handler);
+
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it("setInvalid(true) followed by setInvalid(false) emits both events in order", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`
+      <sgds-quantity-toggle noValidate></sgds-quantity-toggle>
+    `);
+    const invalidHandler = sinon.spy();
+    const validHandler = sinon.spy();
+    el.addEventListener("sgds-invalid", invalidHandler);
+    el.addEventListener("sgds-valid", validHandler);
+
+    el.setInvalid(true);
+    await el.updateComplete;
+    expect(invalidHandler).to.have.been.calledOnce;
+    expect(validHandler).not.to.have.been.called;
+
+    el.setInvalid(false);
+    await el.updateComplete;
+    expect(validHandler).to.have.been.calledOnce;
+  });
+});
+
+describe("should still populate FormData when noValidate is enabled", () => {
+  it("FormData contains the quantity-toggle value with noValidate", async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <sgds-quantity-toggle noValidate name="qty" value="7"></sgds-quantity-toggle>
+        <sgds-button type="submit">Submit</sgds-button>
+      </form>
+    `);
+    const submitHandler = sinon.spy((event: SubmitEvent) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      expect(formData.get("qty")).to.equal("7");
+    });
+
+    form.addEventListener("submit", submitHandler);
+    form.querySelector("sgds-button")?.click();
+    await waitUntil(() => submitHandler.calledOnce);
+    expect(submitHandler).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
## :open_book: Description                                                                                                   
                                                                                                                             
  Implements `noValidate` and `setInvalid()` custom validation support for `<sgds-quantity-toggle>` — the last remaining form  
  component that was missing this feature. When `noValidate` is set (on the component or on the parent `<form>`), built-in 
  constraint validation (`min`, `max`) is bypassed, allowing developers to implement fully custom validation logic via         
  `setInvalid(bool)` and dynamic `invalidFeedback`.                                                                          

  Also dispatches `sgds-change` event on +/- button clicks so custom validation listeners fire consistently for both keyboard  
  and button interactions.
                                                                                                                               
  Fixes #416                                                                                                                 

  ## :pencil2: Type of change                                                                                                  
   
  - [x] New feature (non-breaking change which adds functionality)                                                             
  - [x] This change requires a documentation update                                                                          
                                                                                                                               
  ## :test_tube: How Has This Been Tested?
                                                                                                                               
  - [x] 37 unit tests pass (Chromium + Firefox) covering: noValidate disables validation, setInvalid programmatic control,     
  form-level novalidate, reset clears invalid state, sgds-invalid/sgds-valid event emission, FormData population with
  noValidate                                                                                                                   
  - [x] Storybook stories verified: "Custom Validation with noValidate" on QuantityToggle page and Form/Custom Validation page
  (both component-level and form-level novalidate)                                                                             
  - [x] Playground demos tested: QuantityToggle.html and Form.html custom validation sections
                                                                                                                               
  ## :white_check_mark: Checklist:                                                                                           
                                                                                                                               
  - [x] My code follows the SGDS style guidelines and naming conventions                                                       
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas                                                     
  - [x] I have made corresponding changes to the documentation                                                               
  - [x] My changes generate no new warnings                                                                                    
  - [x] I have added tests that prove my fix is effective or that my feature works                                           
  - [x] Any dependent changes have been merged and published in downstream modules  