### PR TITLE
fix(Sidebar): sidebar select event not emitting for react component [skip-cd]

### DIFF
--- a/src/components/Sidebar/sgds-sidebar.ts
+++ b/src/components/Sidebar/sgds-sidebar.ts
@@ -21,6 +21,8 @@ import { XL_BREAKPOINT, MD_BREAKPOINT } from "../../utils/breakpoints";
 import type { ISgdsSidebarSelectEventDetail } from "./types";
 export type { ISgdsSidebarSelectEventDetail };
 
+type SidebarVariant = "persistent" | "overlay" | "collapsible";
+
 /**
  * @summary Sidebar is a collapsible navigation component that displays menu items and groups.
  * Users can expand and collapse the sidebar to save screen space while navigating through organized menu items.
@@ -46,8 +48,6 @@ export type { ISgdsSidebarSelectEventDetail };
  * @eventDetail {ISgdsSidebarSelectEventDetail} sgds-select
  *
  */
-
-type SidebarVariant = "persistent" | "overlay" | "collapsible";
 export class SgdsSidebar extends SgdsElement {
   static styles = [...SgdsElement.styles, sidebarStyle];
 

--- a/src/components/Sidebar/sgds-sidebar.ts
+++ b/src/components/Sidebar/sgds-sidebar.ts
@@ -18,6 +18,8 @@ import { SidebarElement } from "./sidebar-element";
 import SgdsSidebarGroup from "./sgds-sidebar-group";
 import SgdsIconButton from "../IconButton/sgds-icon-button";
 import { XL_BREAKPOINT, MD_BREAKPOINT } from "../../utils/breakpoints";
+import type { ISgdsSidebarSelectEventDetail } from "./types";
+export type { ISgdsSidebarSelectEventDetail };
 
 /**
  * @summary Sidebar is a collapsible navigation component that displays menu items and groups.
@@ -40,8 +42,8 @@ import { XL_BREAKPOINT, MD_BREAKPOINT } from "../../utils/breakpoints";
  * @slot upper - Insert brand/logo content in sidebar header
  * @slot lower - Insert content in sidebar footer
  *
- * @fires sgds-select - Emitted when a sidebar item or group is selected.
- *   Event detail: { activeItem: string } - name of the selected item
+ * @event sgds-select - Emitted when a sidebar item or group is selected.
+ * @eventDetail {ISgdsSidebarSelectEventDetail} sgds-select
  *
  */
 
@@ -402,7 +404,7 @@ export class SgdsSidebar extends SgdsElement {
       }
 
       // Emit sgds-select event when an item is selected
-      this.emit("sgds-select", { detail: { activeItem: element.name } });
+      this.emit<ISgdsSidebarSelectEventDetail>("sgds-select", { detail: { activeItem: element.name } });
     }
   }
 

--- a/src/components/Sidebar/types.ts
+++ b/src/components/Sidebar/types.ts
@@ -1,0 +1,3 @@
+export interface ISgdsSidebarSelectEventDetail {
+  activeItem: string;
+}


### PR DESCRIPTION
## :open_book: Description

wrong jsdocs for sgds-select event in SgdsSidebar --> cause custom elements not to pick up the event --> causing React wrapped components to not pick up the onSgdsSelect

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
