### PR TITLE
feat(dropdown): add `fullWidth` attribute

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,10 +57,10 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0" async crossorigin="anonymous" integrity="sha384-8kwZdXaOj5V0innUnF8SJcEWA5lE1t0qF4Iv2F6CY8eNInKsBvh7ya+PqQzoQmfa"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0" async crossorigin="anonymous" integrity="sha384-C8TQzTRVJwkQgy0+V9M6/gUSaCi2fC1kGHVAyVmrDhxS278X94NMQCJjlm74MJLQ"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-o5UUyzK8p18cKx7nH8BF8rAG4VLU64zZxwEdi0UnGvkL7NYK49qC44TWnyLhEvvn"></script>
 
 ```
 

--- a/skills/sgds-components/reference/dropdown.md
+++ b/skills/sgds-components/reference/dropdown.md
@@ -25,6 +25,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 - The menu is hidden by default; clicking the `toggler` slot element opens and closes it.
 - `drop` controls the direction the menu opens: `down` (default), `up`, `left`, or `right`.
 - `menuAlignRight` right-aligns the menu panel with the toggler.
+- `fullWidth` makes the toggler and menu span the full width of the parent container; the menu width matches the toggler width. Also passes `fullWidth` to the toggler slot element.
 - `noFlip` prevents the menu from auto-repositioning when it would overflow the viewport edge.
 - `close` controls when the menu auto-closes: `default` (closes on outside click or item click), `outside` (closes only on outside click), `inside` (closes only on item click).
 - `disabled` on `<sgds-dropdown>` disables the toggler and prevents the menu from opening.
@@ -71,6 +72,8 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 
 **Menu opens upward?** → `drop="up"`
 
+**Full-width dropdown spanning its container?** → Add `fullWidth`
+
 **Right-align menu with toggler?** → Add `menuAlignRight`
 
 **Prevent menu from flipping when near viewport edge?** → Add `noFlip`
@@ -113,6 +116,15 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
   });
 </script>
 
+<!-- Full-width dropdown -->
+<sgds-dropdown fullWidth>
+  <sgds-button slot="toggler" ariaLabel="Select option">
+    Select option <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+  </sgds-button>
+  <sgds-dropdown-item ariaLabel="Option A">Option A</sgds-dropdown-item>
+  <sgds-dropdown-item ariaLabel="Option B">Option B</sgds-dropdown-item>
+</sgds-dropdown>
+
 <!-- Dropdown opens upward -->
 <sgds-dropdown drop="up">
   <sgds-button slot="toggler" ariaLabel="Menu above">Menu above <sgds-icon name="chevron-up" slot="rightIcon"></sgds-icon></sgds-button>
@@ -133,6 +145,7 @@ No CSS styling modifications — custom properties and CSS parts are not exposed
 | `menuIsOpen` | boolean | `false` | Opens the menu on first render |
 | `disabled` | boolean | `false` | Disables the toggler and prevents menu from opening |
 | `close` | `default \| outside \| inside` | `default` | When the menu auto-closes: default (outside click or item click), outside (only outside click), inside (only item click) |
+| `fullWidth` | boolean | `false` | Makes the toggler and menu span the full width of the parent; menu width matches the toggler |
 
 ### `<sgds-dropdown-item>`
 

--- a/src/components/Dropdown/dropdown.css
+++ b/src/components/Dropdown/dropdown.css
@@ -4,10 +4,6 @@
   height: inherit;
 }
 
-.dropdown-menu {
-  max-width: var(--sgds-dimension-320);
-}
-
 .toggler-container {
   flex: 1;
   pointer-events: none;
@@ -15,4 +11,8 @@
 
 .toggler-container ::slotted(*) {
   pointer-events: auto;
+}
+
+:host([fullWidth]) .toggler-container ::slotted(*){
+  width: 100%;
 }

--- a/src/components/Dropdown/sgds-dropdown.ts
+++ b/src/components/Dropdown/sgds-dropdown.ts
@@ -1,8 +1,9 @@
-import { html, PropertyValueMap } from "lit";
+import { html, PropertyValueMap, PropertyValues } from "lit";
 import { property, queryAssignedElements } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
 import { DropdownListElement } from "../../base/dropdown-list-element";
 import { watch } from "../../utils/watch";
+import { size } from "@floating-ui/dom";
 import dropdownMenuStyle from "./dropdown-menu.css";
 import dropdownStyle from "./dropdown.css";
 
@@ -37,6 +38,10 @@ export class SgdsDropdown extends DropdownListElement {
   /** Controls the close behaviour of dropdown menu. By default menu auto-closes when SgdsDropdownItem or area outside dropdown is clicked */
   @property({ type: String, reflect: true, state: false })
   close: "outside" | "default" | "inside" = "default";
+
+  /** When set, the dropdown toggler and menu will be in full width. Also passes the `fullWidth` property to the element in the `toggler` slot */
+  @property({ type: Boolean, reflect: true, state: false })
+  fullWidth = false;
 
   @queryAssignedElements({ slot: "toggler", flatten: true })
   private _toggler: Array<HTMLElement>;
@@ -81,6 +86,7 @@ export class SgdsDropdown extends DropdownListElement {
 
   async firstUpdated(changedProperties: PropertyValueMap<this>) {
     super.firstUpdated(changedProperties);
+    this._updateFloatingOpts();
     if (this.menuIsOpen) {
       await this.updateFloatingPosition();
     }
@@ -94,7 +100,31 @@ export class SgdsDropdown extends DropdownListElement {
     if (button) {
       button.setAttribute("aria-haspopup", "menu");
       button.setAttribute("aria-expanded", String(this.menuIsOpen));
+      button.toggleAttribute("fullWidth", this["fullWidth"]);
     }
+  }
+
+  private _updateFloatingOpts() {
+    this.floatingOpts = {
+      middleware: this.fullWidth
+        ? [
+            size({
+              apply({ rects, elements }) {
+                elements.floating.style.width = `${rects.reference.width}px`;
+              }
+            })
+          ]
+        : []
+    };
+  }
+
+  @watch("fullWidth")
+  _handleFullWidthChage() {
+    const button = this._toggler[0];
+    if (button) {
+      button.toggleAttribute("fullWidth", this["fullWidth"]);
+    }
+    this._updateFloatingOpts();
   }
 
   @watch("menuIsOpen")

--- a/stories/component-templates/Dropdown/additional.mdx
+++ b/stories/component-templates/Dropdown/additional.mdx
@@ -6,6 +6,14 @@ The close behaviour of `sgds-dropdown` can be modified using the `close` attribu
   <Story of={DropdownStories.SgdsSelectClose} />
 </Canvas>
 
+## Full Width
+
+`sgds-dropdown` can be set to fill the full width of its container by setting the `fullWidth` attribute to `true`. Will also pass `fullWidth` attribute to button in `toggler` slot.
+
+<Canvas of={DropdownStories.SgdsSelectFullWidth}>
+  <Story of={DropdownStories.SgdsSelectFullWidth} />
+</Canvas>
+
 ## sgds-select event
 
 The `sgds-select` event is emitted on `sgds-dropdown` whenever a non-disabled item is clicked. Use `event.detail.item` to access the selected `SgdsDropdownItem` element.
@@ -16,7 +24,7 @@ Disabled items do not emit `sgds-select`.
   <Story of={DropdownStories.SgdsSelectEvent} />
 </Canvas>
 
-## SGDS Dropdown Item Customisation
+## Dropdown Item Customisation
 
 Using SGDS utility classes, the layout of `SgdsDropdownItem` can be customised as needed.
 

--- a/stories/component-templates/Dropdown/additional.stories.js
+++ b/stories/component-templates/Dropdown/additional.stories.js
@@ -36,7 +36,30 @@ const SgdsSelectCloseTemplate = args => {
 
 export const SgdsSelectClose = {
   render: SgdsSelectCloseTemplate.bind({}),
-  name: "sgds-select close",
+  name: "Close",
+  args: {},
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  }
+};
+
+const SgdsSelectFullWidthTemplate = args => {
+  return html`
+    <sgds-dropdown fullWidth>
+      <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Full Width">
+        Dropdown
+        <sgds-icon name="chevron-down" slot="rightIcon"></sgds-icon>
+      </sgds-button>
+      <sgds-dropdown-item ariaLabel="Item #1">Item #1</sgds-dropdown-item>
+      <sgds-dropdown-item ariaLabel="Item #2">Item #2</sgds-dropdown-item>
+      <sgds-dropdown-item ariaLabel="Item #3">Item #3</sgds-dropdown-item>
+    </sgds-dropdown>
+  `;
+};
+
+export const SgdsSelectFullWidth = {
+  render: SgdsSelectFullWidthTemplate.bind({}),
+  name: "Full Width",
   args: {},
   parameters: {
     chromatic: { disableSnapshot: true }
@@ -143,7 +166,7 @@ const SgdsSelectDropdownItemTemplate = args => {
 
 export const SgdsSelectDropdownItem = {
   render: SgdsSelectDropdownItemTemplate.bind({}),
-  name: "sgds-dropdown-item customisation",
+  name: "Dropdown Item Customisation",
   args: {},
   parameters: {
     chromatic: { disableSnapshot: true }

--- a/stories/component-templates/Dropdown/basic.js
+++ b/stories/component-templates/Dropdown/basic.js
@@ -12,7 +12,8 @@ export const Template = ({
   close,
   menuIsOpen,
   disabled,
-  target
+  target,
+  fullWidth
 }) => {
   return html`
     <sgds-dropdown
@@ -23,6 +24,7 @@ export const Template = ({
       close=${ifDefined(close)}
       ?menuIsOpen=${menuIsOpen}
       ?disabled=${disabled}
+      ?fullWidth=${ifDefined(fullWidth)}
     >
       <sgds-button slot="toggler" variant="primary" tone="brand" ariaLabel="Dropdown">
         Dropdown

--- a/test/dropdown.test.ts
+++ b/test/dropdown.test.ts
@@ -1,6 +1,6 @@
 import "./sgds-web-component";
 import { SgdsDropdown, SgdsDropdownItem } from "../src/components";
-import { fixture, assert, expect, waitUntil, oneEvent, nextFrame } from "@open-wc/testing";
+import { fixture, assert, expect, waitUntil, oneEvent, nextFrame, elementUpdated } from "@open-wc/testing";
 import sinon from "sinon";
 import { html } from "lit";
 import { sendKeys, sendMouse } from "@web/test-runner-commands";
@@ -688,6 +688,64 @@ describe("sgds-dropdown", () => {
   //     expect(el.menuIsOpen).to.be.false;
   //   });
   // });
+
+  it("fullWidth attribute is forwarded to toggler", async () => {
+    const dropdown = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown fullWidth>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>slot 1</sgds-dropdown-item>
+        <sgds-dropdown-item>slot 2</sgds-dropdown-item>
+      </sgds-dropdown> `
+    );
+
+    const button = dropdown.querySelector("sgds-button");
+
+    expect(button?.hasAttribute("fullWidth")).to.be.true;
+
+    dropdown["fullWidth"] = false;
+    await elementUpdated(dropdown);
+
+    expect(button?.hasAttribute("fullWidth")).to.be.false;
+  });
+
+  it("fullWidth attribute stretches sgds-button toggler to width of sgds-dropdown", async () => {
+    const dropdown = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>slot 1</sgds-dropdown-item>
+        <sgds-dropdown-item>slot 2</sgds-dropdown-item>
+      </sgds-dropdown> `
+    );
+
+    const button = dropdown.querySelector("sgds-button")?.shadowRoot?.querySelector(".btn") as HTMLElement;
+    const dropdownWidth = getComputedStyle(dropdown).width;
+    expect(getComputedStyle(button).width).not.to.equal(dropdownWidth);
+
+    dropdown["fullWidth"] = true;
+    await elementUpdated(dropdown);
+
+    expect(getComputedStyle(button).width).to.equal(dropdownWidth);
+  });
+
+  it("fullWidth stretches the width of dropdown menu", async () => {
+    const dropdown = await fixture<SgdsDropdown>(
+      html`<sgds-dropdown>
+        <sgds-button slot="toggler">Dropdown</sgds-button>
+        <sgds-dropdown-item>slot 1</sgds-dropdown-item>
+        <sgds-dropdown-item>slot 2</sgds-dropdown-item>
+      </sgds-dropdown> `
+    );
+
+    const dropdownMenu = dropdown.shadowRoot?.querySelector(".dropdown-menu") as HTMLElement;
+    const dropdownWidth = getComputedStyle(dropdown).width;
+
+    expect(getComputedStyle(dropdownMenu).width).not.to.equal(dropdownWidth);
+
+    dropdown["fullWidth"] = true;
+    await elementUpdated(dropdown);
+
+    expect(getComputedStyle(dropdownMenu).width).to.equal(dropdownWidth);
+  });
 });
 
 describe("sgds-dropdown-item", () => {


### PR DESCRIPTION
## :open_book: Description

Implements `fullWidth` for `Dropdown`.

Test cases, storybook and skills updated accordingly.

Fixes #801 

## :pencil2: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :test_tube: How Has This Been Tested?

Red-green testing done to ensure
- `fullWidth` attribute is passed to slotted `toggler`
- `toggler` width matches container width when `fullWidth` is applied
- Dropdown menu only applies resizing functionality conditionally when `fullWidth` is applied

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
