### PR TITLE
fix(storybook): copy button now copies only the active tab's code in …

### DIFF
--- a/.storybook/addons/react-source/docs-tabs-inject.ts
+++ b/.storybook/addons/react-source/docs-tabs-inject.ts
@@ -1,11 +1,45 @@
 /**
  * Injects HTML/React tabs into Storybook's docs mode source blocks.
  * Targets `pre.prismjs` elements inside the Canvas source containers.
+ *
+ * Intercepts the native Storybook copy button so it copies only the
+ * active tab's code (same behavior as the canvas mode panel).
  */
 import { htmlToReact } from "./htmlToReact";
 
 const PROCESSED_ATTR = "data-react-tabs";
-const SEPARATOR = "\n\n// ─── React ───────────────────────────────────────\n\n";
+
+// Store active tab code per container so the clipboard interceptor can read it
+const containerCodeMap = new WeakMap<Element, () => string>();
+
+// Intercept clipboard writes from native Storybook copy buttons.
+// When a copy happens inside a processed container, override with the active tab's code.
+document.addEventListener(
+  "click",
+  e => {
+    const btn = (e.target as HTMLElement).closest("button");
+    if (!btn || btn.classList.contains("react-source-tab")) return;
+    if (btn.textContent?.trim() !== "Copy") return;
+
+    // Check if this button is inside one of our processed containers
+    const container = btn.closest("[data-react-tabs-container]");
+    if (!container) return;
+
+    const getCode = containerCodeMap.get(container);
+    if (!getCode) return;
+
+    // Prevent Storybook's handler and write our own clipboard content
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(getCode()).then(() => {
+      btn.textContent = "Copied";
+      setTimeout(() => {
+        btn.textContent = "Copy";
+      }, 1500);
+    });
+  },
+  true // capture phase to fire before Storybook's handler
+);
 
 function injectTabs(pre: HTMLElement) {
   if (pre.hasAttribute(PROCESSED_ATTR)) return;
@@ -15,23 +49,28 @@ function injectTabs(pre: HTMLElement) {
   const codeDiv = pre.querySelector("div[class*='language-']") as HTMLElement;
   if (!codeDiv) return;
 
-  const fullText = pre.textContent || "";
+  const htmlCode = (pre.textContent || "").trim();
 
-  // Check if this contains our separator (meaning transform already ran)
-  if (!fullText.includes("// ─── React")) return;
+  // Only inject tabs for SGDS components (skip script-containing snippets)
+  if (!htmlCode.includes("sgds-") || htmlCode.includes("<script")) return;
 
-  // Split into HTML and React parts
-  const sepIndex = fullText.indexOf(SEPARATOR);
-  if (sepIndex < 0) return;
-
-  const htmlCode = fullText.substring(0, sepIndex);
   const reactCode = htmlToReact(htmlCode);
+  if (!reactCode) return;
 
   // Find the outermost source container (parent of the scroll area wrapper)
   // Structure: div.css-* > div[dir="ltr"] > ... > pre.prismjs
   const scrollWrapper = pre.closest("[data-radix-scroll-area-viewport]")?.parentElement;
   const sourceContainer = scrollWrapper?.parentElement;
   if (!sourceContainer) return;
+
+  // Mark the container for the clipboard interceptor
+  sourceContainer.setAttribute("data-react-tabs-container", "true");
+
+  // State
+  let activeTab = "react";
+
+  // Register code getter for clipboard interceptor
+  containerCodeMap.set(sourceContainer, () => (activeTab === "react" ? reactCode : htmlCode));
 
   // Create tab bar
   const tabBar = document.createElement("div");
@@ -41,7 +80,7 @@ function injectTabs(pre: HTMLElement) {
     <button class="react-source-tab" data-tab="html">Others (Vue, Angular, HTML)</button>
   `;
   tabBar.style.cssText =
-    "display:flex;gap:0;padding:0 12px;border-bottom:1px solid rgba(255,255,255,0.1);background:inherit;";
+    "display:flex;gap:0;padding:0 12px;border-bottom:1px solid rgba(255,255,255,0.1);background:inherit;align-items:center;";
 
   // Style the tab buttons
   tabBar.querySelectorAll(".react-source-tab").forEach(btn => {
@@ -57,9 +96,6 @@ function injectTabs(pre: HTMLElement) {
 
   // Insert tab bar before the scroll area
   sourceContainer.insertBefore(tabBar, sourceContainer.firstChild);
-
-  // State
-  let activeTab = "react";
 
   // Initially show React code
   codeDiv.innerHTML = highlightReact(reactCode);

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,7 +9,6 @@ import "./utility.css";
 import "./gt-themes.css";
 import "./global.css";
 import sgdsTheme from "./sgdsTheme";
-import { htmlToReact } from "./addons/react-source/htmlToReact";
 import "./addons/react-source/docs-tabs-inject";
 
 export const setCustomElementsManifestWithOptions = (
@@ -46,14 +45,7 @@ export const parameters = {
       title: "Table of Contents",
       disable: false
     },
-    source: {
-      transform: (code: string) => {
-        if (!code.includes("sgds-")) return code;
-        if (code.includes("<script")) return code;
-        const reactCode = htmlToReact(code);
-        return `${code}\n\n// ─── React ───────────────────────────────────────\n\n${reactCode}`;
-      }
-    }
+    source: {}
   },
   viewport: {
     viewports: {


### PR DESCRIPTION
…docs mode

Previously, the docs mode copy button copied both HTML and React code concatenated together. Now it intercepts the native copy button click and writes only the active tab's content to the clipboard.

## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
