### PR TITLE
fix(QuantityToggle): input event emission lagging in value [skip-cd]

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,10 +57,10 @@ This method registers all SGDS elements up front in the Custom Elements Registry
 <link href='https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/css/sgds.css' rel='stylesheet' type='text/css' />
 
 // it is recommended to load a particular version when using cdn e.g. https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@1.0.2
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0" async crossorigin="anonymous" integrity="sha384-8kwZdXaOj5V0innUnF8SJcEWA5lE1t0qF4Iv2F6CY8eNInKsBvh7ya+PqQzoQmfa"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0" async crossorigin="anonymous" integrity="sha384-vBeyaV/27u+M8nzxwUKvGtzet0vWpAbb3dS5gzUBSBnOe4almA/I0fIXWJBjpYnK"></script>
 
 //or load a single component e.g. Masthead
-<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-vvllpLfJY3jG+vowUWZOJHnvtDTTdaSUOYGbiozHEq4+HESmYu0i/b2r616QoDly"></script>
+<script src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0/components/Masthead/index.umd.min.js" async crossorigin="anonymous" integrity="sha384-o5UUyzK8p18cKx7nH8BF8rAG4VLU64zZxwEdi0UnGvkL7NYK49qC44TWnyLhEvvn"></script>
 
 ```
 

--- a/playground/QuantityToggle.html
+++ b/playground/QuantityToggle.html
@@ -19,7 +19,7 @@
     <div class="container">
       <div>
         <h2>Default</h2>
-        <sgds-quantity-toggle label="Quantity"></sgds-quantity-toggle>
+        <sgds-quantity-toggle label="Quantity" id="qt"></sgds-quantity-toggle>
       </div>
 
       <div>
@@ -90,6 +90,12 @@
             if (customQt.invalid) return;
             alert("Submitted: " + customQt.value);
           });
+
+      const el = document.getElementById('qt');
+
+      el.addEventListener('sgds-input', (e) => {
+        console.log('sgds-input fired, el.value =', el.value);
+      });
         </script>
       </div>
     </div>

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -97,33 +97,30 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     return this._mixinGetValidationMessage();
   }
 
-  private async _handleChange() {
+  private async _handleChange(e: Event) {
+    e.stopPropagation();
     const sgdsInput = await this._sgdsInput;
     if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
       sgdsInput.value = "0";
     }
     this.value = parseInt(sgdsInput.value);
     this._mixinSetFormValue();
+    this.emit("sgds-change");
     if (this._mixinShouldSkipSgdsValidation()) return;
     this._mixinValidate(sgdsInput.input);
     this.invalid = !this._mixinReportValidity();
   }
-  private async _handleInputChange() {
+  private async _handleInputChange(e: Event) {
+    e.stopPropagation();
     const sgdsInput = await this._sgdsInput;
-    if (this._mixinShouldSkipSgdsValidation()) {
-      if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
-        sgdsInput.value = "0";
-      }
-      this.value = parseInt(sgdsInput.value);
-      this._mixinSetFormValue();
-      return;
-    }
-    this.invalid = false;
     if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
       sgdsInput.value = "0";
     }
     this.value = parseInt(sgdsInput.value);
     this._mixinSetFormValue();
+    this.emit("sgds-input");
+    if (this._mixinShouldSkipSgdsValidation()) return;
+    this.invalid = false;
     this._mixinValidate(sgdsInput.input);
   }
 

--- a/src/components/QuantityToggle/sgds-quantity-toggle.ts
+++ b/src/components/QuantityToggle/sgds-quantity-toggle.ts
@@ -97,7 +97,7 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     return this._mixinGetValidationMessage();
   }
 
-  private async _handleChange(e: Event) {
+  private async _handleValueChange(e: Event, eventName: "sgds-change" | "sgds-input") {
     e.stopPropagation();
     const sgdsInput = await this._sgdsInput;
     if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
@@ -105,23 +105,15 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
     }
     this.value = parseInt(sgdsInput.value);
     this._mixinSetFormValue();
-    this.emit("sgds-change");
+    this.emit(eventName);
     if (this._mixinShouldSkipSgdsValidation()) return;
-    this._mixinValidate(sgdsInput.input);
-    this.invalid = !this._mixinReportValidity();
-  }
-  private async _handleInputChange(e: Event) {
-    e.stopPropagation();
-    const sgdsInput = await this._sgdsInput;
-    if (parseInt(sgdsInput.value) < this.step || sgdsInput.value === "") {
-      sgdsInput.value = "0";
+    if (eventName === "sgds-input") {
+      this.invalid = false;
     }
-    this.value = parseInt(sgdsInput.value);
-    this._mixinSetFormValue();
-    this.emit("sgds-input");
-    if (this._mixinShouldSkipSgdsValidation()) return;
-    this.invalid = false;
     this._mixinValidate(sgdsInput.input);
+    if (eventName === "sgds-change") {
+      this.invalid = !this._mixinReportValidity();
+    }
   }
 
   private async _mixinResetFormControl() {
@@ -266,8 +258,8 @@ export class SgdsQuantityToggle extends SgdsFormValidatorMixin(FormControlElemen
             min=${ifDefined(this.min)}
             max=${ifDefined(this.max)}
             .value=${live(this.value)}
-            @sgds-change=${this._handleChange}
-            @sgds-input=${this._handleInputChange}
+            @sgds-change=${(e: Event) => this._handleValueChange(e, "sgds-change")}
+            @sgds-input=${(e: Event) => this._handleValueChange(e, "sgds-input")}
             @sgds-invalid=${this._handleInvalid}
             @sgds-valid=${this._handleValid}
             @keydown=${this._handleKeyDown}

--- a/stories/component-templates/QuantityToggle/additional.mdx
+++ b/stories/component-templates/QuantityToggle/additional.mdx
@@ -42,3 +42,16 @@ use `invalidFeedback` prop.
 <Canvas of={QuantityToggleStories.OverrideInvalidFeedback}>
   <Story of={QuantityToggleStories.OverrideInvalidFeedback} />
 </Canvas>
+
+## Event Emission
+
+Listen to `sgds-input` and `sgds-change` events to react to value changes.
+
+- `sgds-input` fires on every keystroke as the user types
+- `sgds-change` fires when the value is committed (on blur, or when +/- buttons are clicked)
+
+When the event fires, `el.value` reflects the current value.
+
+<Canvas of={QuantityToggleStories.EventEmission}>
+  <Story of={QuantityToggleStories.EventEmission} />
+</Canvas>

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -98,3 +98,40 @@ export const NoValidate = {
   args: {},
   parameters: {}
 };
+
+const EventEmissionTemplate = () =>
+  html`
+    <sgds-quantity-toggle
+      label="Quantity"
+      hintText="Type a number or use +/- buttons, then check the output below"
+      id="event-demo-qt"
+    ></sgds-quantity-toggle>
+    <div class="sgds:mt-layout-xs">
+      <strong>Event log:</strong>
+      <pre id="event-demo-log" style="background: var(--sgds-color-gray-100); padding: 0.5rem; min-height: 80px; overflow-y: auto; max-height: 200px;"></pre>
+    </div>
+    <script>
+      const eventDemoQt = document.querySelector("#event-demo-qt");
+      const eventDemoLog = document.querySelector("#event-demo-log");
+
+      eventDemoQt.addEventListener("sgds-input", e => {
+        const line = document.createElement("div");
+        line.textContent = "[sgds-input] value = " + e.target.value;
+        eventDemoLog.prepend(line);
+      });
+
+      eventDemoQt.addEventListener("sgds-change", e => {
+        const line = document.createElement("div");
+        line.textContent = "[sgds-change] value = " + e.target.value;
+        line.style.color = "var(--sgds-color-primary)";
+        eventDemoLog.prepend(line);
+      });
+    </script>
+  `;
+
+export const EventEmission = {
+  render: EventEmissionTemplate.bind({}),
+  name: "Event Emission",
+  args: {},
+  parameters: {}
+};

--- a/stories/component-templates/QuantityToggle/additional.stories.js
+++ b/stories/component-templates/QuantityToggle/additional.stories.js
@@ -108,7 +108,10 @@ const EventEmissionTemplate = () =>
     ></sgds-quantity-toggle>
     <div class="sgds:mt-layout-xs">
       <strong>Event log:</strong>
-      <pre id="event-demo-log" style="background: var(--sgds-color-gray-100); padding: 0.5rem; min-height: 80px; overflow-y: auto; max-height: 200px;"></pre>
+      <pre
+        id="event-demo-log"
+        style="background: var(--sgds-color-gray-100); padding: 0.5rem; min-height: 80px; overflow-y: auto; max-height: 200px;"
+      ></pre>
     </div>
     <script>
       const eventDemoQt = document.querySelector("#event-demo-qt");

--- a/test/quantitytoggle.test.ts
+++ b/test/quantitytoggle.test.ts
@@ -97,6 +97,37 @@ describe("when value change", () => {
     expect(inputHandler).to.have.been.calledOnce;
   });
 
+  it("el.value is up-to-date when sgds-input event fires", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="0"></sgds-quantity-toggle>`);
+    const inputEl = el.shadowRoot?.querySelector("sgds-input") as SgdsInput;
+    inputEl.focus();
+
+    let valueAtEvent: number | undefined;
+    el.addEventListener("sgds-input", () => {
+      valueAtEvent = el.value;
+    });
+
+    await sendKeys({ press: "5" });
+    await waitUntil(() => valueAtEvent !== undefined);
+    expect(valueAtEvent).to.equal(5);
+  });
+
+  it("el.value is up-to-date when sgds-change event fires", async () => {
+    const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="0"></sgds-quantity-toggle>`);
+    const inputEl = el.shadowRoot?.querySelector("sgds-input") as SgdsInput;
+    inputEl.focus();
+
+    let valueAtEvent: number | undefined;
+    el.addEventListener("sgds-change", () => {
+      valueAtEvent = el.value;
+    });
+
+    await sendKeys({ press: "5" });
+    await sendKeys({ press: "Tab" });
+    await waitUntil(() => valueAtEvent !== undefined);
+    expect(valueAtEvent).to.equal(5);
+  });
+
   it("prevent from entering special characters", async () => {
     const el = await fixture<SgdsQuantityToggle>(html`<sgds-quantity-toggle value="15"></sgds-quantity-toggle>`);
     const inputEl = el.shadowRoot?.querySelector("sgds-input") as SgdsInput;


### PR DESCRIPTION
## :open_book: Description

When listening for the sgds-input event, the value obtained when the event is emitted is the previous one and not the current one. A minimal code to reproduce it is:
<!DOCTYPE html>
<html lang="en">
  <head>
    <script
      type="module"
      src="https://cdn.jsdelivr.net/npm/@govtechsg/sgds-web-component@3.26.0"
    ></script>
  </head>
  <body>
    <sgds-quantity-toggle id="qt"></sgds-quantity-toggle>

    <script>
      const el = document.getElementById('qt');

      el.addEventListener('sgds-input', (e) => {
        console.log('sgds-input fired, el.value =', el.value);
      });
    </script>
  </body>
</html> 

Steps to reproduce:

Value starts at 0, type in any other number

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [x] My code follows the SGDS style guidelines and naming conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
