### PR TITLE
fix(TextArea): set height to auto, so its not locked [run-chromatic][skip-cd]

### DIFF
--- a/playground/Textarea.html
+++ b/playground/Textarea.html
@@ -34,7 +34,7 @@
 
       <div>
         <h2>Rows</h2>
-        <sgds-textarea label="Description" rows="6" placeholder="A taller textarea..."></sgds-textarea>
+        <sgds-textarea label="Description" rows="16" placeholder="A taller textarea..."></sgds-textarea>
       </div>
 
       <div>

--- a/src/components/Textarea/textarea.css
+++ b/src/components/Textarea/textarea.css
@@ -13,6 +13,7 @@ textarea.form-control-group {
   padding: var(--sgds-form-padding-y) var(--sgds-form-padding-x);
   min-height: var(--sgds-dimension-136);
   overflow: auto;
+  height: auto;
 }
 
 .textarea-resize-none {


### PR DESCRIPTION
## :open_book: Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
- text area height locked due to form control group class

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
