### PR TITLE
fix(Select): guard against empty menuList when value is set before options slot [skip-cd]

### DIFF
--- a/src/base/select-element.ts
+++ b/src/base/select-element.ts
@@ -219,7 +219,7 @@ export class SelectElement
     });
     const options = await Promise.all(readyOptions);
     return options?.map((el: OptionElement) => ({
-      label: el.innerText,
+      label: el.textContent?.trim() ?? "",
       value: el.getAttribute("value"),
       disabled: el.disabled ?? undefined
     }));

--- a/src/components/Select/sgds-select.ts
+++ b/src/components/Select/sgds-select.ts
@@ -72,20 +72,26 @@ export class SgdsSelect extends SelectElement {
       })
     );
     this.menuList = await this._getMenuListFromOptions(assignedElements);
-    this._updateDisplayValue();
+    // If value was set before options slotted (e.g. React sets value prop
+    // before children mount), sync the display now that options are available.
+    if (this.value) {
+      this._updateDisplayValue();
+      this._setActiveToOption();
+    }
     this.input = await this._input;
     this._mixinValidate(this.input);
   }
   private _updateDisplayValue() {
     if (this.value && this.menuList.length > 0) {
       const initialSelectedItem = this.menuList.filter(({ value }) => value === this.value);
+      if (initialSelectedItem.length === 0) return;
       this.displayValue = initialSelectedItem[0].label;
 
       this._setActiveToOption();
     }
   }
   private _setActiveToOption() {
-    const activeIndex = this.menuList.findIndex(item => item.value.toString() === this.value);
+    const activeIndex = this.menuList.findIndex(item => item.value?.toString() === this.value);
     this.options.forEach((option, index) => {
       option.active = index === activeIndex;
     });
@@ -93,6 +99,10 @@ export class SgdsSelect extends SelectElement {
 
   @watch("value", { waitUntilFirstUpdate: true })
   async _handleValueChange() {
+    // Guard: if options haven't slotted yet, menuList is empty.
+    // _handleSlotChange will sync the display once options are available.
+    if (this.menuList.length === 0) return;
+
     this._setActiveToOption();
 
     // when value change, always emit a change event

--- a/test/select.test.ts
+++ b/test/select.test.ts
@@ -796,3 +796,60 @@ describe("sgds-select-option (default)", () => {
     expect(dropdownMenu?.textContent).to.contain("Loading...");
   });
 });
+
+describe("select >> value set before options slot (React timing)", () => {
+  it("should not emit sgds-change when value is set after first update but before children slot", async () => {
+    // Simulate React useLayoutEffect timing:
+    // Element mounts → first Lit update → React sets value → slotchange hasn't fired yet
+    const el = document.createElement("sgds-select") as SgdsSelect;
+    document.body.appendChild(el);
+    await el.updateComplete; // first update done, hasUpdated = true
+
+    const changeHandler = sinon.spy();
+    el.addEventListener("sgds-change", changeHandler);
+
+    // React sets value AFTER first update but BEFORE children are slotted
+    el.value = "option2";
+    await el.updateComplete;
+    await aTimeout(50);
+
+    // Guard prevents sgds-change from firing with empty menuList
+    expect(changeHandler).to.not.have.been.called;
+
+    // Now append children — slotchange syncs display
+    const opt1 = document.createElement("sgds-select-option");
+    opt1.setAttribute("value", "option1");
+    opt1.textContent = "Option 1";
+    const opt2 = document.createElement("sgds-select-option");
+    opt2.setAttribute("value", "option2");
+    opt2.textContent = "Option 2";
+    el.appendChild(opt1);
+    el.appendChild(opt2);
+
+    await el.updateComplete;
+    await aTimeout(50);
+
+    const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
+    expect(input.value).to.equal("Option 2");
+    expect(el.value).to.equal("option2");
+
+    el.remove();
+  });
+
+  it("should display correct label after programmatic value change", async () => {
+    const el = await fixture<SgdsSelect>(html`
+      <sgds-select>
+        <sgds-select-option value="all">All Roles</sgds-select-option>
+        <sgds-select-option value="admin">Admin</sgds-select-option>
+        <sgds-select-option value="editor">Editor</sgds-select-option>
+      </sgds-select>
+    `);
+    await el.updateComplete;
+
+    el.value = "admin";
+    await el.updateComplete;
+    const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
+    await waitUntil(() => input.value === "Admin");
+    expect(input.value).to.equal("Admin");
+  });
+});


### PR DESCRIPTION
 ## :open_book: Description

  Guards against empty `menuList` when `value` is set before the options slot fires in `<sgds-select>`.  
  This race condition occurs when React (or any framework) sets the `value` property after the element's
  first update but before `slotchange` fires, causing:                                                   
                                                                                                       
  - TypeError crash in `_setActiveToOption` (`null.toString()`)
  - Spurious `sgds-change` event on mount
  - `displayValue` reset to `""` (DC-3059 related)                                                       
  - Label corruption when dropdown is `display:none` (switched `innerText` → `textContent` in base class)
                                                                                                         
  Fixes DC-3059                                                                                          
                                                                                                       
  ## :pencil2: Type of change                                                                            
                                                                                                       
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## :test_tube: How Has This Been Tested?                                                               
  
  - [x] Unit tests added for setting value before options are slotted                                    
  - [x] Unit tests for value set after options are available                                           
  - [x] Unit tests for empty value remaining unset                                                       
                                                                                                         
  ## :white_check_mark: Checklist:
                                                                                                         
  - [x] My code follows the SGDS style guidelines and naming conventions                                 
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas                               
  - [x] My changes generate no new warnings                                                              
  - [x] I have added tests that prove my fix is effective or that my feature works