### PR TITLE
fix(*): cdn  exports to bundle in production build [skip-cd]

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,8 +50,8 @@ const createPlugins = (resolveOptions = {}) => [
   visualizer()
 ];
 
-const wcPlugins = createPlugins({ dedupe: external });
-const umdPlugins = createPlugins();
+const wcPlugins = createPlugins({ dedupe: external }); // ESM — Lit is external, condition doesn't matter
+const umdPlugins = createPlugins({ exportConditions: ["default"] }); // UMD — bundles Lit, use production
 
 const reactBuildPlugins = [
   resolve(),


### PR DESCRIPTION
 to remove Lit dev mode warnings

## :open_book: Description

Lit Dev warnings from CDN loaded components seen in production build app. 

CDN should be build in exportCOnditions default (i.e. production for Lit) 
ESM retains in development build 

Fixes # (issue)

## :pencil2: Type of change

```
Please delete options that are not relevant.
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## :test_tube: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :white_check_mark: Checklist:

- [ ] My code follows the SGDS style guidelines and naming conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
